### PR TITLE
Add docstrings for exported types and methods

### DIFF
--- a/src/contingencies.jl
+++ b/src/contingencies.jl
@@ -1,1 +1,2 @@
+"""Supertype for contingency supplemental attributes that model component failures or outages"""
 abstract type Contingency <: SupplementalAttribute end

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -453,6 +453,13 @@ Notes
 - Intended for use in scheduling, dispatch, and state-tracking of pumped‑storage units.
 " PumpHydroStatus
 
+"""
+Denotes the type of dynamic equation governing a state variable in dynamic simulations.
+
+Used by [`PowerSimulationsDynamics.jl`](https://nrel-sienna.github.io/PowerSimulationsDynamics.jl/stable/)
+to classify states as `Differential` (governed by ``\\dot{x} = f(x)``), `Algebraic`
+(governed by ``0 = g(x)``), or `Hybrid` (either, depending on parameters).
+"""
 IS.@scoped_enum(StateTypes, Differential = 1, Algebraic = 2, Hybrid = 3,)
 
 IS.@scoped_enum(

--- a/src/models/RoundRotorExponential.jl
+++ b/src/models/RoundRotorExponential.jl
@@ -98,7 +98,9 @@ function RoundRotorExponential(::Nothing)
     )
 end
 
+"""Get the [`RoundRotorMachine`](@ref) of a [`RoundRotorExponential`](@ref)."""
 get_base_machine(value::RoundRotorExponential) = value.base_machine
+"""Get the exponential saturation coefficients of a [`RoundRotorExponential`](@ref)."""
 get_saturation_coeffs(value::RoundRotorExponential) = value.saturation_coeffs
 set_base_machine!(value::RoundRotorExponential, val::RoundRotorMachine) =
     value.base_machine = val

--- a/src/models/RoundRotorQuadratic.jl
+++ b/src/models/RoundRotorQuadratic.jl
@@ -97,7 +97,9 @@ function RoundRotorQuadratic(::Nothing)
     )
 end
 
+"""Get the [`RoundRotorMachine`](@ref) of a [`RoundRotorQuadratic`](@ref)."""
 get_base_machine(value::RoundRotorQuadratic) = value.base_machine
+"""Get the quadratic saturation coefficients of a [`RoundRotorQuadratic`](@ref)."""
 get_saturation_coeffs(value::RoundRotorQuadratic) = value.saturation_coeffs
 set_base_machine!(value::RoundRotorQuadratic, val::RoundRotorMachine) =
     value.base_machine = val

--- a/src/models/SalientPoleExponential.jl
+++ b/src/models/SalientPoleExponential.jl
@@ -54,7 +54,9 @@ function SalientPoleExponential(::Nothing)
     )
 end
 
+"""Get the [`SalientPoleMachine`](@ref) of a [`SalientPoleExponential`](@ref)."""
 get_base_machine(value::SalientPoleExponential) = value.base_machine
+"""Get the exponential saturation coefficients of a [`SalientPoleExponential`](@ref)."""
 get_saturation_coeffs(value::SalientPoleExponential) = value.saturation_coeffs
 
 set_base_machine!(value::SalientPoleExponential, val::SalientPoleMachine) =

--- a/src/models/SalientPoleQuadratic.jl
+++ b/src/models/SalientPoleQuadratic.jl
@@ -54,7 +54,9 @@ function SalientPoleQuadratic(::Nothing)
     )
 end
 
+"""Get the [`SalientPoleMachine`](@ref) of a [`SalientPoleQuadratic`](@ref)."""
 get_base_machine(value::SalientPoleQuadratic) = value.base_machine
+"""Get the quadratic saturation coefficients of a [`SalientPoleQuadratic`](@ref)."""
 get_saturation_coeffs(value::SalientPoleQuadratic) = value.saturation_coeffs
 set_base_machine!(value::SalientPoleQuadratic, val::SalientPoleMachine) =
     value.base_machine = val

--- a/src/models/dynamic_generator.jl
+++ b/src/models/dynamic_generator.jl
@@ -134,15 +134,22 @@ get_name(device::DynamicGenerator) = device.name
 get_states(device::DynamicGenerator) = device.states
 get_n_states(device::DynamicGenerator) = device.n_states
 get_ω_ref(device::DynamicGenerator) = device.ω_ref
+"""Get the [`Machine`](@ref) of a [`DynamicGenerator`](@ref)."""
 get_machine(device::DynamicGenerator) = device.machine
+"""Get the [`Shaft`](@ref) of a [`DynamicGenerator`](@ref)."""
 get_shaft(device::DynamicGenerator) = device.shaft
+"""Get the [`AVR`](@ref) of a [`DynamicGenerator`](@ref)."""
 get_avr(device::DynamicGenerator) = device.avr
+"""Get the [`TurbineGov`](@ref) (prime mover) of a [`DynamicGenerator`](@ref)."""
 get_prime_mover(device::DynamicGenerator) = device.prime_mover
+"""Get the [`PSS`](@ref) of a [`DynamicGenerator`](@ref)."""
 get_pss(device::DynamicGenerator) = device.pss
 get_base_power(device::DynamicGenerator) = device.base_power
 get_ext(device::DynamicGenerator) = device.ext
 get_internal(device::DynamicGenerator) = device.internal
+"""Get the voltage set-point from the [`AVR`](@ref) of a [`DynamicGenerator`](@ref)."""
 get_V_ref(value::DynamicGenerator) = get_V_ref(get_avr(value))
+"""Get the power set-point from the [`TurbineGov`](@ref) of a [`DynamicGenerator`](@ref)."""
 get_P_ref(value::DynamicGenerator) = get_P_ref(get_prime_mover(value))
 
 set_base_power!(value::DynamicGenerator, val) = value.base_power = val

--- a/src/models/dynamic_generator_components.jl
+++ b/src/models/dynamic_generator_components.jl
@@ -1,8 +1,14 @@
+"""Supertype for components that make up a [`DynamicGenerator`](@ref)"""
 abstract type DynamicGeneratorComponent <: DynamicComponent end
+"""Supertype for Automatic Voltage Regulator (AVR) models that define excitation system dynamics"""
 abstract type AVR <: DynamicGeneratorComponent end
+"""Supertype for machine models that define stator electro-magnetic dynamics"""
 abstract type Machine <: DynamicGeneratorComponent end
+"""Supertype for Power System Stabilizer (PSS) models that provide stabilization signals to the [`AVR`](@ref)"""
 abstract type PSS <: DynamicGeneratorComponent end
+"""Supertype for shaft models that define rotor electro-mechanical dynamics"""
 abstract type Shaft <: DynamicGeneratorComponent end
+"""Supertype for prime mover and turbine governor models that define thermo-mechanical dynamics"""
 abstract type TurbineGov <: DynamicGeneratorComponent end
 
 """

--- a/src/models/dynamic_inverter.jl
+++ b/src/models/dynamic_inverter.jl
@@ -1,3 +1,4 @@
+"""Supertype for inverter dynamic components (deprecated alias for [`DynamicInverterComponent`](@ref))"""
 abstract type InverterComponent <: DynamicComponent end
 
 """
@@ -232,17 +233,25 @@ get_ω_ref(device::DynamicInverter) = device.ω_ref
 get_ext(device::DynamicInverter) = device.ext
 get_states(device::DynamicInverter) = device.states
 get_n_states(device::DynamicInverter) = device.n_states
+"""Get the [`Converter`](@ref) of a [`DynamicInverter`](@ref)."""
 get_converter(device::DynamicInverter) = device.converter
+"""Get the [`OuterControl`](@ref) of a [`DynamicInverter`](@ref)."""
 get_outer_control(device::DynamicInverter) = device.outer_control
+"""Get the [`InnerControl`](@ref) of a [`DynamicInverter`](@ref)."""
 get_inner_control(device::DynamicInverter) = device.inner_control
+"""Get the [`DCSource`](@ref) of a [`DynamicInverter`](@ref)."""
 get_dc_source(device::DynamicInverter) = device.dc_source
+"""Get the [`FrequencyEstimator`](@ref) of a [`DynamicInverter`](@ref)."""
 get_freq_estimator(device::DynamicInverter) = device.freq_estimator
+"""Get the [`Filter`](@ref) of a [`DynamicInverter`](@ref)."""
 get_filter(device::DynamicInverter) = device.filter
 get_limiter(device::DynamicInverter) = device.limiter
 get_base_power(device::DynamicInverter) = device.base_power
 get_internal(device::DynamicInverter) = device.internal
+"""Get the active power set-point from the [`OuterControl`](@ref) of a [`DynamicInverter`](@ref)."""
 get_P_ref(value::DynamicInverter) =
     get_P_ref(get_active_power_control(get_outer_control(value)))
+"""Get the voltage set-point from the [`OuterControl`](@ref) of a [`DynamicInverter`](@ref)."""
 get_V_ref(value::DynamicInverter) =
     get_V_ref(get_reactive_power_control(get_outer_control(value)))
 

--- a/src/models/dynamic_inverter_components.jl
+++ b/src/models/dynamic_inverter_components.jl
@@ -1,9 +1,16 @@
+"""Supertype for components that compose a [`DynamicInverter`](@ref)"""
 abstract type DynamicInverterComponent <: DynamicComponent end
+"""Supertype for converter models that define pulse width modulation (PWM) or space vector modulation (SVM) dynamics"""
 abstract type Converter <: DynamicInverterComponent end
+"""Supertype for DC source models that define dynamics of the DC side of the converter"""
 abstract type DCSource <: DynamicInverterComponent end
+"""Supertype for filter models that connect the converter output to the grid"""
 abstract type Filter <: DynamicInverterComponent end
+"""Supertype for frequency estimator models (typically PLLs) that estimate grid frequency from voltage measurements"""
 abstract type FrequencyEstimator <: DynamicInverterComponent end
+"""Supertype for inner control loop models that define virtual impedance, voltage control, and current control dynamics"""
 abstract type InnerControl <: DynamicInverterComponent end
+"""Supertype for output current limiter models that constrain inverter output current"""
 abstract type OutputCurrentLimiter <: DynamicInverterComponent end
 
 abstract type ActivePowerControl <: DeviceParameter end

--- a/src/models/reserves.jl
+++ b/src/models/reserves.jl
@@ -34,6 +34,7 @@ reserves, respectively.
 A [`Reserve`](@ref) can be specified as a `ReserveSymmetric` when it is defined.
 """
 abstract type ReserveSymmetric <: ReserveDirection end
+"""Supertype for all reserve products, including spinning and non-spinning reserves"""
 abstract type AbstractReserve <: Service end
 
 """
@@ -41,4 +42,5 @@ A reserve product to be able to respond to unexpected disturbances,
 such as the sudden loss of a transmission line or generator.
 """
 abstract type Reserve{T <: ReserveDirection} <: AbstractReserve end
+"""Supertype for non-spinning reserve products that can be brought online within a specified time"""
 abstract type ReserveNonSpinning <: AbstractReserve end

--- a/src/outages.jl
+++ b/src/outages.jl
@@ -1,5 +1,7 @@
+"""Supertype for outage attributes that model periods when components are unavailable"""
 abstract type Outage <: Contingency end
 
+"""Supertype for unplanned/forced outage attributes caused by equipment failures"""
 abstract type UnplannedOutage <: Outage end
 
 supports_time_series(::Outage) = true

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -11,6 +11,11 @@ const INPUT_CATEGORY_NAMES = [
     ("storage", InputCategory.STORAGE),
 ]
 
+"""
+Container for tabular power system data parsed from CSV files.
+
+See the constructor `PowerSystemTableData(data, directory, ...)` for details on usage.
+"""
 struct PowerSystemTableData
     base_power::Float64
     category_to_df::Dict{InputCategory, DataFrames.DataFrame}


### PR DESCRIPTION
Add docstrings for previously undocumented exported types and methods:

Types:
- StateTypes enum (definitions.jl)
- AbstractReserve, ReserveNonSpinning (reserves.jl)
- DynamicGeneratorComponent, AVR, Machine, PSS, Shaft, TurbineGov
- DynamicInverterComponent, Converter, DCSource, Filter, FrequencyEstimator, InnerControl, OutputCurrentLimiter
- InverterComponent (dynamic_inverter.jl)
- Contingency, Outage, UnplannedOutage
- PowerSystemTableData

Methods:
- DynamicGenerator: get_machine, get_shaft, get_avr, get_prime_mover, get_pss, get_V_ref, get_P_ref
- DynamicInverter: get_converter, get_outer_control, get_inner_control, get_dc_source, get_freq_estimator, get_filter, get_P_ref, get_V_ref
- Machine models: get_base_machine, get_saturation_coeffs for SalientPole* and RoundRotor* types

Completely written by claude, but with the exception of a couple ref's, it looks pretty good. Leaving as a draft because I'm unable to build the docs and confirm this works, due to pre-existing errors.