### PR TITLE
fix: update parsing logics for v35 wecc case

### DIFF
--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1981,7 +1981,15 @@ function _psse2pm_switch_breaker!(pm_data::Dict, pti_data::Dict, import_all::Boo
     pm_data["breaker"] = []
     pm_data["switch"] = []
     mapping = Dict('@' => ("breaker", 1), '*' => ("switch", 0))
-    mapping_v35 = Dict(2 => "breaker", 3 => "switch")
+    # PSS(R)E v35 STYPE values:
+    # 1 - Generic connector, 2 - Circuit breaker, 3 - Disconnect switch.
+    # Generic connectors are stored in the "switch" list and distinguished via
+    # discrete_branch_type = OTHER (2).
+    mapping_v35 = Dict(
+        1 => ("switch", 2),
+        2 => ("breaker", 1),
+        3 => ("switch", 0),
+    )
 
     # Always check for legacy entries in PSSe 35 for switches and breakers set as @ or *
     if haskey(pti_data, "SWITCHES_AS_BRANCHES")
@@ -2012,9 +2020,15 @@ function _psse2pm_switch_breaker!(pm_data::Dict, pti_data::Dict, import_all::Boo
     if haskey(pti_data, "SWITCHING DEVICE")
         if pm_data["source_version"] == "35"
             for switching_device in pti_data["SWITCHING DEVICE"]
-                device_type = get(mapping_v35, switching_device["STYPE"], "other")
-                discrete_branch_type =
-                    device_type == "breaker" ? 1 : (device_type == "switch" ? 0 : 2)
+                stype = get(switching_device, "STYPE", nothing)
+                type_mapping = get(mapping_v35, stype, nothing)
+
+                if isnothing(type_mapping)
+                    @warn "Unsupported SWITCHING DEVICE STYPE=$(stype). Skipping entry."
+                    continue
+                end
+
+                device_type, discrete_branch_type = type_mapping
 
                 sub_data = _build_switch_breaker_sub_data(
                     pm_data,
@@ -2025,7 +2039,7 @@ function _psse2pm_switch_breaker!(pm_data::Dict, pti_data::Dict, import_all::Boo
                 )
 
                 if import_all
-                    _import_remaining_keys!(sub_data, branch)
+                    _import_remaining_keys!(sub_data, switching_device)
                 end
 
                 branch_isolated_bus_modifications!(pm_data, sub_data)

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1699,7 +1699,11 @@ function read_branch!(
         bus_f = bus_number_to_bus[d["f_bus"]]
         bus_t = bus_number_to_bus[d["t_bus"]]
         name = if isnothing(_get_name)
-            _get_pm_branch_name_with_counter!(d, bus_f, bus_t, branch_pair_counts)
+            if source_type == "pti"
+                _get_pm_branch_name_with_counter!(d, bus_f, bus_t, branch_pair_counts)
+            else
+                _get_pm_branch_name(d, bus_f, bus_t)
+            end
         else
             _get_name(d, bus_f, bus_t)
         end

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -157,6 +157,31 @@ function _get_pm_branch_name(device_dict, bus_f::ACBus, bus_t::ACBus)
     return "$(get_name(bus_f))-$(get_name(bus_t))-i_$index"
 end
 
+function _is_psse_branch_source_id(device_dict::Dict)
+    if !haskey(device_dict, "source_id") || isempty(device_dict["source_id"])
+        return false
+    end
+
+    source_type = device_dict["source_id"][1]
+    return source_type in ("branch", "switch", "breaker", "transformer")
+end
+
+function _get_pm_branch_name_with_counter!(
+    device_dict::Dict,
+    bus_f::ACBus,
+    bus_t::ACBus,
+    branch_pair_counts::Dict{Tuple{String, String}, Int},
+)
+    if _is_psse_branch_source_id(device_dict)
+        pair_key = (get_name(bus_f), get_name(bus_t))
+        branch_pair_counts[pair_key] = get(branch_pair_counts, pair_key, 0) + 1
+        index = branch_pair_counts[pair_key]
+        return "$(pair_key[1])-$(pair_key[2])-i_$(index)"
+    end
+
+    return _get_pm_branch_name(device_dict, bus_f, bus_t)
+end
+
 """
 Internal 3WT name retrieval from pm2ps_dict
 """
@@ -1665,14 +1690,19 @@ function read_branch!(
         return
     end
 
-    _get_name = get(kwargs, :branch_name_formatter, _get_pm_branch_name)
+    _get_name = get(kwargs, :branch_name_formatter, nothing)
     ict_instances = _impedance_correction_table_lookup(data)
+    branch_pair_counts = Dict{Tuple{String, String}, Int}()
 
     source_type = data["source_type"]
     for d in values(data["branch"])
         bus_f = bus_number_to_bus[d["f_bus"]]
         bus_t = bus_number_to_bus[d["t_bus"]]
-        name = _get_name(d, bus_f, bus_t)
+        name = if isnothing(_get_name)
+            _get_pm_branch_name_with_counter!(d, bus_f, bus_t, branch_pair_counts)
+        else
+            _get_name(d, bus_f, bus_t)
+        end
         value = make_branch(name, d, bus_f, bus_t, source_type; kwargs...)
 
         if !isnothing(value)

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -275,6 +275,26 @@ end
     @test get_branch_status(other) == DiscreteControlledBranchStatus.CLOSED
 end
 
+@testset "PSSE default branch name counter" begin
+    sys = build_system(PSSEParsingTestSystems, "pti_case24_sys")
+    buses = collect(get_components(ACBus, sys))
+    bus_f = buses[1]
+    bus_t = buses[2]
+
+    branch_pair_counts = Dict{Tuple{String, String}, Int}()
+    d1 = Dict{String, Any}("source_id" => Any["transformer", 1, 2, 0, " 1", 0])
+    d2 = Dict{String, Any}("source_id" => Any["transformer", 1, 2, 0, "1 ", 0])
+
+    n1 =
+        PowerSystems._get_pm_branch_name_with_counter!(d1, bus_f, bus_t, branch_pair_counts)
+    n2 =
+        PowerSystems._get_pm_branch_name_with_counter!(d2, bus_f, bus_t, branch_pair_counts)
+
+    @test n1 != n2
+    @test endswith(n1, "-i_1")
+    @test endswith(n2, "-i_2")
+end
+
 @testset "PSSE LCC Parsing" begin
     sys = build_system(PSSEParsingTestSystems, "pti_two_terminal_hvdc_test_sys")
 


### PR DESCRIPTION
- Fix issue with switching STYPE field parsing to use existing device mapping.
- In this WECC psse case, there are branch type elements with similar IDs:

> 1234, 4321, '1 '
> 1232, 4321, ' 1'

messing with the parsing logic. The fix adds a function counter to address this particular cases with _1, _2, etc.. suffixes.
