### PR TITLE
Allow multiple CTs and CTs with different HRSGs in a CombinedCycleBlock

### DIFF
--- a/src/plant_attribute.jl
+++ b/src/plant_attribute.jl
@@ -780,30 +780,41 @@ function add_supplemental_attribute!(
     hrsg_number::Int,
 )
     uuid = IS.get_uuid(component)
-    if haskey(attribute.ct_hrsg_map, uuid) || haskey(attribute.ca_hrsg_map, uuid)
+    if haskey(attribute.ct_hrsg_map, uuid) && hrsg_number in attribute.ct_hrsg_map[uuid] ||
+       haskey(attribute.ca_hrsg_map, uuid) && hrsg_number in attribute.ca_hrsg_map[uuid]
         throw(
             IS.ArgumentError(
-                "Generator $(get_name(component)) is already part of block $(get_name(attribute))",
+                "Generator $(get_name(component)) is already part of block $(get_name(attribute)) with $(hrsg_number)",
             ),
         )
     end
     prime_mover = get_prime_mover_type(component)
     if prime_mover == PrimeMovers.CT
-        IS.add_supplemental_attribute!(sys.data, component, attribute)
         if haskey(attribute.hrsg_ct_map, hrsg_number)
             push!(attribute.hrsg_ct_map[hrsg_number], uuid)
         else
             attribute.hrsg_ct_map[hrsg_number] = [uuid]
         end
-        attribute.ct_hrsg_map[uuid] = [hrsg_number]
+        if haskey(attribute.ct_hrsg_map, uuid)
+            # We assume that IS has already has the association
+            push!(attribute.ct_hrsg_map[uuid], hrsg_number)
+        else
+            IS.add_supplemental_attribute!(sys.data, component, attribute)
+            attribute.ct_hrsg_map[uuid] = [hrsg_number]
+        end
     elseif prime_mover == PrimeMovers.CA
-        IS.add_supplemental_attribute!(sys.data, component, attribute)
         if haskey(attribute.hrsg_ca_map, hrsg_number)
             push!(attribute.hrsg_ca_map[hrsg_number], uuid)
         else
             attribute.hrsg_ca_map[hrsg_number] = [uuid]
         end
-        attribute.ca_hrsg_map[uuid] = [hrsg_number]
+        if haskey(attribute.ca_hrsg_map, uuid)
+            # We assume that IS has already has the association
+            push!(attribute.ca_hrsg_map[uuid], hrsg_number)
+        else
+            IS.add_supplemental_attribute!(sys.data, component, attribute)
+            attribute.ca_hrsg_map[uuid] = [hrsg_number]
+        end
     else
         throw(
             IS.ArgumentError(
@@ -883,14 +894,13 @@ function add_supplemental_attribute!(
 )
     uuid = IS.get_uuid(component)
     # Check if already in any exclusion group
-    for (_, uuids) in attribute.operation_exclusion_map
-        if uuid in uuids
-            throw(
-                IS.ArgumentError(
-                    "Generator $(get_name(component)) is already part of plant $(get_name(attribute))",
-                ),
-            )
-        end
+    if haskey(attribute.inverse_operation_exclusion_map, uuid)
+        throw(
+            IS.ArgumentError(
+                "Generator $(get_name(component)) is already part of plant $(get_name(attribute)) \
+                under exclusion group $(attribute.inverse_operation_exclusion_map[uuid])",
+            ),
+        )
     end
     prime_mover = get_prime_mover_type(component)
     if prime_mover != PrimeMovers.CC
@@ -928,25 +938,19 @@ function remove_supplemental_attribute!(
     attribute::CombinedCycleFractional,
 )
     uuid = IS.get_uuid(component)
-    found = false
-    for (group, _) in attribute.operation_exclusion_map
-        if uuid in attribute.operation_exclusion_map[group]
-            filter!(x -> x != uuid, attribute.operation_exclusion_map[group])
-            if isempty(attribute.operation_exclusion_map[group])
-                delete!(attribute.operation_exclusion_map, group)
-            end
-            found = true
-            break
-        end
-    end
-    if !found
+    if !haskey(attribute.inverse_operation_exclusion_map, uuid)
         throw(
             IS.ArgumentError(
                 "Generator $(get_name(component)) is not part of plant $(get_name(attribute))",
             ),
         )
     end
+    group = attribute.inverse_operation_exclusion_map[uuid]
     delete!(attribute.inverse_operation_exclusion_map, uuid)
+    filter!(x -> x != uuid, attribute.operation_exclusion_map[group])
+    if isempty(attribute.operation_exclusion_map[group])
+        delete!(attribute.operation_exclusion_map, group)
+    end
     IS.remove_supplemental_attribute!(sys.data, component, attribute)
     return
 end

--- a/test/test_plant_attributes.jl
+++ b/test/test_plant_attributes.jl
@@ -1,13 +1,3 @@
-using Test
-using PowerSystems
-using InfrastructureSystems
-import InfrastructureSystems as IS
-import JSON3
-import PowerSystemCaseBuilder as PSB
-const PSY = PowerSystems
-
-include("common.jl")
-
 @testset "Test plant attributes" begin
     @testset "ThermalPowerPlant construction and basic accessors" begin
         plant = ThermalPowerPlant(name = "Coal Plant A")
@@ -852,19 +842,20 @@ include("common.jl")
         add_supplemental_attribute!(sys, ct_gen, cc_block; hrsg_number = 1)
         add_supplemental_attribute!(sys, ca_gen, cc_block; hrsg_number = 1)
 
-        # Adding the same CT again should throw
+        # Adding the same CT to the same hrsg should throw
         @test_throws IS.ArgumentError add_supplemental_attribute!(
             sys, ct_gen, cc_block; hrsg_number = 1,
         )
-        @test_throws IS.ArgumentError add_supplemental_attribute!(
+        # Adding to a different hrsg should not throw
+        add_supplemental_attribute!(
             sys, ct_gen, cc_block; hrsg_number = 2,
         )
-
         # Adding the same CA again should throw
         @test_throws IS.ArgumentError add_supplemental_attribute!(
             sys, ca_gen, cc_block; hrsg_number = 1,
         )
-        @test_throws IS.ArgumentError add_supplemental_attribute!(
+        # Adding to a different hrsg should not throw
+        add_supplemental_attribute!(
             sys, ca_gen, cc_block; hrsg_number = 2,
         )
 
@@ -873,12 +864,12 @@ include("common.jl")
         hrsg_ca_map = get_hrsg_ca_map(cc_block)
         ct_hrsg_map = get_ct_hrsg_map(cc_block)
         ca_hrsg_map = get_ca_hrsg_map(cc_block)
-        @test length(hrsg_ct_map) == 1
+        @test length(hrsg_ct_map) == 2
         @test length(hrsg_ct_map[1]) == 1
-        @test length(hrsg_ca_map) == 1
+        @test length(hrsg_ca_map) == 2
         @test length(hrsg_ca_map[1]) == 1
-        @test ct_hrsg_map[IS.get_uuid(ct_gen)] == [1]
-        @test ca_hrsg_map[IS.get_uuid(ca_gen)] == [1]
+        @test ct_hrsg_map[IS.get_uuid(ct_gen)] == [1, 2]
+        @test ca_hrsg_map[IS.get_uuid(ca_gen)] == [1, 2]
     end
 
     @testset "Multiple plants per generator" begin


### PR DESCRIPTION
Calling `add_supplemental_attribute!` with different hsrg_numbers and the same CT or CA and CominedCycleBlock will add multiple numbers. Previously, this was prevented with an error message.

Fixes #1673 

I also cleaned up a test warning caused by extr4a imports at the top, and simplified some of the logic for removing from the combined cycle plant attributes.