### PR TITLE
parse tap transformers from psse

### DIFF
--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1235,10 +1235,9 @@ function get_branch_type_psse(
     end
 
     _add_vector_control_group(d, "shift", "group_number")
-    is_tap_controllable, is_alpha_controllable = _determine_control_modes(d, "COD1", "tap")
+    is_alpha_controllable = _determine_control_mode(d, "COD1", "tap")
     if d["group_number"] == WindingGroupNumber.UNDEFINED || is_alpha_controllable
         return PhaseShiftingTransformer
-        # parse TapTransformer from PSSE regardless of is_tap_controllable to avoid parsing mixed transformer types in parallel
     else 
         return TapTransformer
     end
@@ -1778,50 +1777,38 @@ function read_3w_transformer!(
     end
 end
 
-function _determine_control_modes(d::Dict, control_flag::String, tap_key::String)
+function _determine_control_mode(d::Dict, control_flag::String, tap_key::String)
     control_code = get(d, control_flag, -99)
-    tap = d[tap_key]
 
-    is_tap_controllable = false
     is_alpha_controllable = false
 
     # There is no control
     if control_code == 0
-        is_tap_controllable = false
         is_alpha_controllable = false
         # Reactive Power Control
     elseif control_code ∈ [1, -1]
-        is_tap_controllable = true
         is_alpha_controllable = false
         # Voltage Control
     elseif control_code ∈ [2, -2]
-        is_tap_controllable = true
         is_alpha_controllable = false
         # Active Power Control
     elseif control_code ∈ [3, -3]
-        is_tap_controllable = true
         is_alpha_controllable = true
         # DC Line Control
     elseif control_code ∈ [4, -4]
-        is_tap_controllable = true
         is_alpha_controllable = true
         # Asymmetric Active Power Control
     elseif control_code ∈ [5, -5]
-        is_tap_controllable = true
         is_alpha_controllable = true
     elseif control_code == -99
-        @warn "Can't determine control objective for the transformer from the $(control_flag) field for $d \
-              Will attempt to infer control objective from shift and tap fields."
+        @warn "Can't determine control objective for the transformer from the $(control_flag) field for $d. Will attempt to infer control objective from non-zero shift field."
         if d["shift"] != 0.0
             is_alpha_controllable = true
         end 
-        if (tap != 0.0) && (tap != 1.0)
-            is_tap_controllable = true
-        end
     else
         error(d)
     end
-    return is_tap_controllable, is_alpha_controllable
+    return is_alpha_controllable
 end
 
 function get_three_winding_transformer_type(d::Dict)
@@ -1829,12 +1816,12 @@ function get_three_winding_transformer_type(d::Dict)
     _add_vector_control_group(d, "secondary_phase_shift_angle", "secondary_group_number")
     _add_vector_control_group(d, "tertiary_phase_shift_angle", "tertiary_group_number")
     # NOTE: with current three winding transformer type hierarchy, tap controllable and not controllable three winding transformers are Transformer3W
-    _, primary_is_alpha_controllable =
-        _determine_control_modes(d, "COD1", "primary_turns_ratio")
-    _, secondary_is_alpha_controllable =
-        _determine_control_modes(d, "COD2", "secondary_turns_ratio")
-    _, tertiary_is_alpha_controllable =
-        _determine_control_modes(d, "COD3", "tertiary_turns_ratio")
+    primary_is_alpha_controllable =
+        _determine_control_mode(d, "COD1", "primary_turns_ratio")
+    secondary_is_alpha_controllable =
+        _determine_control_mode(d, "COD2", "secondary_turns_ratio")
+    tertiary_is_alpha_controllable =
+        _determine_control_mode(d, "COD3", "tertiary_turns_ratio")
     if d["primary_group_number"] == WindingGroupNumber.UNDEFINED ||
        d["secondary_group_number"] == WindingGroupNumber.UNDEFINED ||
        d["tertiary_group_number"] == WindingGroupNumber.UNDEFINED ||

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1238,11 +1238,9 @@ function get_branch_type_psse(
     is_tap_controllable, is_alpha_controllable = _determine_control_modes(d, "COD1", "tap")
     if d["group_number"] == WindingGroupNumber.UNDEFINED || is_alpha_controllable
         return PhaseShiftingTransformer
-    elseif (is_tap_controllable || (tap != 1.0)) &&
-           d["group_number"] != WindingGroupNumber.UNDEFINED
+    # parse TapTransformer from PSSE regardless of is_tap_controllable to avoid parsing mixed transformer types in parallel
+    elseif d["group_number"] != WindingGroupNumber.UNDEFINED
         return TapTransformer
-    elseif !is_tap_controllable && d["group_number"] != WindingGroupNumber.UNDEFINED
-        return Transformer2W
     else
         error("Couldn't infer the branch type for branch $d")
     end
@@ -1820,7 +1818,7 @@ function _determine_control_modes(d::Dict, control_flag::String, tap_key::String
         elseif (tap != 0.0) || (tap != 1.0)
             is_tap_controllable = true
         else
-            @warn "Can't determine control objective for the other fields. Will return a Transformer2W"
+            @warn "Can't determine control objective for the other fields. Will return a TapTransformer"
         end
     else
         error(d)

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1238,11 +1238,9 @@ function get_branch_type_psse(
     is_tap_controllable, is_alpha_controllable = _determine_control_modes(d, "COD1", "tap")
     if d["group_number"] == WindingGroupNumber.UNDEFINED || is_alpha_controllable
         return PhaseShiftingTransformer
-    # parse TapTransformer from PSSE regardless of is_tap_controllable to avoid parsing mixed transformer types in parallel
-    elseif d["group_number"] != WindingGroupNumber.UNDEFINED
+        # parse TapTransformer from PSSE regardless of is_tap_controllable to avoid parsing mixed transformer types in parallel
+    else 
         return TapTransformer
-    else
-        error("Couldn't infer the branch type for branch $d")
     end
 end
 
@@ -1812,13 +1810,13 @@ function _determine_control_modes(d::Dict, control_flag::String, tap_key::String
         is_tap_controllable = true
         is_alpha_controllable = true
     elseif control_code == -99
-        @warn "Can't determine control objective for the transformer from the $(control_flag) field for $d"
+        @warn "Can't determine control objective for the transformer from the $(control_flag) field for $d \
+              Will attempt to infer control objective from shift and tap fields."
         if d["shift"] != 0.0
             is_alpha_controllable = true
-        elseif (tap != 0.0) || (tap != 1.0)
+        end 
+        if (tap != 0.0) && (tap != 1.0)
             is_tap_controllable = true
-        else
-            @warn "Can't determine control objective for the other fields. Will return a TapTransformer"
         end
     else
         error(d)

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -73,6 +73,7 @@ end
     @info "Testing Three-Winding Transformer Parsing"
 
     @test isnothing(get_component(Transformer3W, sys3, "1"))
+    @test isempty(get_components(Transformer2W, sys3))
     @test haskey(
         get_ext(get_component(TapTransformer, sys3, "DALLAS 1 3-DALLAS 1 0-i_1")),
         "psse_name",
@@ -313,6 +314,7 @@ end
     file_dir = joinpath(base_dir, "test_data", "modified_14bus_system.raw")
     sys = System(file_dir)
 
+    @test isempty(get_components(Transformer2W, sys)) 
     tr2w_1 = get_component(TapTransformer, sys, "BUS 110-BUS 109-i_1")
     suppl_attr_tr2w_1 = only(get_supplemental_attributes(tr2w_1))
     @test get_table_number(suppl_attr_tr2w_1) == 3

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -314,7 +314,7 @@ end
     file_dir = joinpath(base_dir, "test_data", "modified_14bus_system.raw")
     sys = System(file_dir)
 
-    @test isempty(get_components(Transformer2W, sys)) 
+    @test isempty(get_components(Transformer2W, sys))
     tr2w_1 = get_component(TapTransformer, sys, "BUS 110-BUS 109-i_1")
     suppl_attr_tr2w_1 = only(get_supplemental_attributes(tr2w_1))
     @test get_table_number(suppl_attr_tr2w_1) == 3

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -74,7 +74,7 @@ end
 
     @test isnothing(get_component(Transformer3W, sys3, "1"))
     @test haskey(
-        get_ext(get_component(Transformer2W, sys3, "DALLAS 1 3-DALLAS 1 0-i_1")),
+        get_ext(get_component(TapTransformer, sys3, "DALLAS 1 3-DALLAS 1 0-i_1")),
         "psse_name",
     )
     @test get_available(
@@ -313,7 +313,7 @@ end
     file_dir = joinpath(base_dir, "test_data", "modified_14bus_system.raw")
     sys = System(file_dir)
 
-    tr2w_1 = get_component(Transformer2W, sys, "BUS 110-BUS 109-i_1")
+    tr2w_1 = get_component(TapTransformer, sys, "BUS 110-BUS 109-i_1")
     suppl_attr_tr2w_1 = only(get_supplemental_attributes(tr2w_1))
     @test get_table_number(suppl_attr_tr2w_1) == 3
     @test get_points(get_impedance_correction_curve(suppl_attr_tr2w_1))[1] ==
@@ -324,7 +324,7 @@ end
     @test get_transformer_control_mode(suppl_attr_tr2w_1) ==
           ImpedanceCorrectionTransformerControlMode.PHASE_SHIFT_ANGLE
 
-    tr2w_2 = get_component(Transformer2W, sys, "BUS 109-BUS 104-i_1")
+    tr2w_2 = get_component(TapTransformer, sys, "BUS 109-BUS 104-i_1")
     suppl_attr_tr2w_2 = only(get_supplemental_attributes(tr2w_2))
     @test get_table_number(suppl_attr_tr2w_2) == 4
     @test get_points(get_impedance_correction_curve(suppl_attr_tr2w_2))[1] ==
@@ -335,7 +335,7 @@ end
     @test get_transformer_control_mode(suppl_attr_tr2w_2) ==
           ImpedanceCorrectionTransformerControlMode.TAP_RATIO
 
-    tr2w_3 = get_component(Transformer2W, sys, "BUS 106-BUS 105-i_1")
+    tr2w_3 = get_component(TapTransformer, sys, "BUS 106-BUS 105-i_1")
     suppl_attr_tr2w_3 = only(get_supplemental_attributes(tr2w_3))
     @test get_table_number(suppl_attr_tr2w_3) == 7
     @test get_points(get_impedance_correction_curve(suppl_attr_tr2w_3))[1] ==


### PR DESCRIPTION
Parse all transformers from PSSE as tap transformer by default, to avoid parsing mixed transformer types in parallel. 