### PR TITLE
base_power is always in natural units

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -454,19 +454,26 @@ Unitless system base power (MVA) — internal anchor for unit conversion.
 _get_base_power(sys::System) = sys.units_settings.base_value
 
 """
-Return the system's base power as a bare number in the requested units (e.g.
-`NU`, `MW`, `SU`). For the unit-bearing value see [`get_base_power_unitful`](@ref).
+Return the system's base power as a bare `Float64` in natural units (MVA).
+
+Like the component accessor, `base_power` is always natural units: an optional
+units argument must be `NU` or a power-dimensioned `Unitful` unit (e.g. `MW`,
+`MVA`). Per-unit bases (`SU`, `DU`) and non-power units error. For the
+unit-bearing value see [`get_base_power_unitful`](@ref).
 """
+get_base_power(sys::System) = _get_base_power(sys)
 get_base_power(sys::System, u) = IS._strip_units(get_base_power_unitful(sys, u))
 
 """
 Return the system's base power as a unit-bearing quantity. See
 [`get_base_power`](@ref) for a bare number.
 """
+get_base_power_unitful(sys::System) = _get_base_power(sys) * MVA
 get_base_power_unitful(sys::System, ::NaturalUnit) = _get_base_power(sys) * MVA
 get_base_power_unitful(sys::System, u::Unitful.Units) =
     Unitful.uconvert(u, _get_base_power(sys) * MVA)
-get_base_power_unitful(sys::System, ::SystemBaseUnit) = 1.0 * SU
+get_base_power_unitful(sys::System, u::AbstractRelativeUnit) =
+    _base_power_units_error(u)
 
 """
 Return the system's frequency.

--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -11,45 +11,64 @@ field: the device base equals the system base.
 """
 _get_base_power(c::Component) = _get_system_base_power(c)
 
+# `base_power` is always stored and reported in natural units (MVA). It is the
+# anchor that every other field's per-unitization is defined against, so
+# expressing it in a per-unit base (`SU`/`DU`) is circular. Unlike every other
+# field accessor, `get_base_power`/`set_base_power!` therefore need *no* units
+# argument; an explicit one is accepted only when it denotes natural units —
+# `NU`, or a power-dimensioned `Unitful` unit such as `MW`/`MVA`.
+
 """
-Unit-aware `base_power` accessor returning a bare number. Unlike most field
-accessors, storage is in MVA (natural units), not device-base per-unit — so
-conversion is bespoke. For the unit-bearing value see [`get_base_power_unitful`](@ref).
+Get a component's `base_power` as a bare `Float64` in natural units (MVA).
+
+`get_base_power(c)` returns the stored MVA value. An optional units argument is
+accepted but must denote natural units: `NU`, or a power-dimensioned `Unitful`
+unit (e.g. `MW`, `MVA`). Per-unit bases (`SU`, `DU`) and non-power units error —
+`base_power` is only meaningful in absolute power. See
+[`get_base_power_unitful`](@ref) for the unit-bearing value.
 """
+get_base_power(c::Component) = _get_base_power(c)
 get_base_power(c::Component, u) = IS._strip_units(get_base_power_unitful(c, u))
 
 """
-Unit-aware `base_power` accessor returning a unit-bearing quantity. See
-[`get_base_power`](@ref) for a bare number.
+`base_power` as a unit-bearing quantity (MVA). See [`get_base_power`](@ref).
 """
+get_base_power_unitful(c::Component) = _get_base_power(c) * MVA
 get_base_power_unitful(c::Component, ::NaturalUnit) = _get_base_power(c) * MVA
+# Any power-dimensioned Unitful unit: `uconvert` does the scaling and throws a
+# `Unitful.DimensionError` for non-power units, so wrong units error for free.
 get_base_power_unitful(c::Component, u::Unitful.Units) =
     Unitful.uconvert(u, _get_base_power(c) * MVA)
-get_base_power_unitful(c::Component, ::SystemBaseUnit) =
-    (_get_base_power(c) / _get_system_base_power(c)) * SU
-get_base_power_unitful(c::Component, ::DeviceBaseUnit) = 1.0 * DU
+# Relative per-unit markers (`SU`, `DU`) are not natural units.
+get_base_power_unitful(::Component, u::AbstractRelativeUnit) =
+    _base_power_units_error(u)
 
 """
-Set `base_power` (stored as a bare MVA `Float64`).
+Set a component's `base_power` (stored as a bare MVA `Float64`).
 
-Accepts:
-- `Float64` — interpreted as MVA.
-- `Unitful.Quantity` of power — converted to MW.
-- [`RelativeQuantity`](@ref) in `SU` (system base) — multiplied by the system base.
-
-Setting in device base (`DU`) is rejected: device base is, by definition,
-`1.0 pu` of itself, so the value carries no information.
+Accepts a bare `Float64` (interpreted as MVA) or a power-dimensioned
+`Unitful.Quantity` (e.g. `80.0 * MW`, `90.0 * MVA`). Per-unit inputs (`SU`, `DU`)
+and non-power units error: `base_power` is only meaningful in absolute power.
 """
 set_base_power!(c::Component, val::Float64) = (c.base_power = val)
+# `ustrip(MVA, val)` converts power units and throws for non-power units.
 set_base_power!(c::Component, val::Unitful.Quantity) =
     (c.base_power = Unitful.ustrip(MVA, val))
-set_base_power!(c::Component, val::RelativeQuantity{<:Any, SystemBaseUnit}) =
-    (c.base_power = IS.ustrip(val) * _get_system_base_power(c))
-set_base_power!(::Component, ::RelativeQuantity{<:Any, DeviceBaseUnit}) =
-    error(
-        "Setting base_power in device base (DU) is ambiguous: device base is " *
-        "1.0 pu of itself by construction. Pass MVA, MW, or SU instead.",
+set_base_power!(::Component, val::RelativeQuantity) =
+    _base_power_units_error(val.unit)
+
+"""
+Reject any attempt to read/write `base_power` in non-natural units.
+"""
+function _base_power_units_error(u)
+    throw(
+        ArgumentError(
+            "base_power is always in natural units (MVA). Pass no units, `NU`, " *
+            "or a power-dimensioned Unitful unit such as `MW` or `MVA`; got `$u`. " *
+            "Per-unit bases (`SU`, `DU`) are not valid for base_power.",
+        ),
     )
+end
 
 IS.display_units_arg(::typeof(get_base_power), ::Type{<:Component}) = NU
 IS.display_units_arg(::typeof(get_base_power_unitful), ::Type{<:Component}) = NU

--- a/test/test_base_power.jl
+++ b/test/test_base_power.jl
@@ -42,11 +42,12 @@ end
     system_base = PSY._get_base_power(sys)
     @test device_base != system_base
 
-    # 1-arg form is gone — public getter requires explicit units.
-    @test_throws MethodError get_base_power(gen)
+    # base_power is always natural units: the 1-arg form returns the stored MVA.
+    @test get_base_power(gen) isa Float64
+    @test get_base_power(gen) ≈ device_base
 
     # Bare-number getter returns Float64 in the requested unit; companion
-    # `_unitful` keeps the Unitful/RelativeQuantity wrapper.
+    # `_unitful` keeps the Unitful wrapper.
     @test get_base_power(gen, NU) isa Float64
     @test get_base_power(gen, NU) ≈ device_base
     bp_nu = get_base_power_unitful(gen, NU)
@@ -54,6 +55,8 @@ end
     @test Unitful.ustrip(bp_nu) ≈ device_base
     # Not double-wrapped: no `device_base * MVA * MVA`.
     @test Unitful.unit(bp_nu) == Unitful.unit(1.0 * MVA)
+    # 1-arg unitful form mirrors `(c, NU)`.
+    @test get_base_power_unitful(gen) ≈ bp_nu
 
     @test get_base_power(gen, MW) isa Float64
     @test get_base_power(gen, MW) ≈ device_base
@@ -61,30 +64,29 @@ end
     @test bp_mw isa Unitful.Quantity
     @test Unitful.ustrip(MW, bp_mw) ≈ device_base
 
-    @test get_base_power(gen, SU) isa Float64
-    @test get_base_power(gen, SU) ≈ device_base / system_base
-    bp_su = get_base_power_unitful(gen, SU)
-    @test bp_su isa RelativeQuantity
-    @test ustrip(bp_su) ≈ device_base / system_base
+    @test get_base_power(gen, MVA) ≈ device_base
 
-    # DU is self-referential: base_power in device-base pu is always 1.
-    @test get_base_power(gen, DU) == 1.0
-    bp_du = get_base_power_unitful(gen, DU)
-    @test bp_du isa RelativeQuantity
-    @test ustrip(bp_du) == 1.0
+    # Per-unit bases are circular for base_power and are rejected.
+    @test_throws ArgumentError get_base_power(gen, SU)
+    @test_throws ArgumentError get_base_power_unitful(gen, SU)
+    @test_throws ArgumentError get_base_power(gen, DU)
+    @test_throws ArgumentError get_base_power_unitful(gen, DU)
+    # Non-power units fail dimensionally.
+    @test_throws Unitful.DimensionError get_base_power(gen, kV)
 
-    # Components with no base_power field fall back to system base, so DU == SU == 1.
+    # Components with no base_power field fall back to the system base.
     bus = first(get_components(ACBus, sys))
-    @test get_base_power(bus, SU) ≈ 1.0
+    @test get_base_power(bus) ≈ system_base
     @test get_base_power(bus, NU) ≈ system_base
     @test get_base_power_unitful(bus, NU) isa Unitful.Quantity
+    @test_throws ArgumentError get_base_power(bus, SU)
 
     # System-level getter mirrors the component version.
-    @test_throws MethodError get_base_power(sys)
+    @test get_base_power(sys) ≈ system_base
     @test get_base_power(sys, NU) ≈ system_base
     @test get_base_power_unitful(sys, NU) isa Unitful.Quantity
-    @test get_base_power(sys, SU) == 1.0
-    @test get_base_power_unitful(sys, SU) isa RelativeQuantity
+    @test_throws ArgumentError get_base_power(sys, SU)
+    @test_throws ArgumentError get_base_power_unitful(sys, SU)
 end
 
 # Used to build via `PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")` and pull
@@ -131,10 +133,10 @@ end
     sys, gen = _sys_with_thermal(; system_base = 100.0, device_base = 250.0)
     system_base = PSY._get_base_power(sys)
 
-    # Bare Float64 — stored as MVA.
+    # Bare Float64 — interpreted and stored as MVA.
     set_base_power!(gen, 75.0)
     @test PSY._get_base_power(gen) ≈ 75.0
-    @test get_base_power(gen, MVA) ≈ 75.0
+    @test get_base_power(gen) ≈ 75.0
 
     # Unitful.Quantity in MW (MVA and MW share dimensions; storage is MVA).
     set_base_power!(gen, 80.0 * MW)
@@ -144,17 +146,11 @@ end
     set_base_power!(gen, 90.0 * MVA)
     @test PSY._get_base_power(gen) ≈ 90.0
 
-    # System-base per-unit: multiplied by the system base.
-    set_base_power!(gen, 0.5 * SU)
-    @test PSY._get_base_power(gen) ≈ 0.5 * system_base
-
-    # Round-trip through the getter.
-    set_base_power!(gen, 1.25 * SU)
-    @test get_base_power(gen, SU) ≈ 1.25
-
-    # Device base is rejected: 1.0 DU carries no information.
-    @test_throws ErrorException set_base_power!(gen, 1.0 * DU)
-    @test_throws ErrorException set_base_power!(gen, 0.5 * DU)
+    # Per-unit bases are circular for base_power and are rejected.
+    @test_throws ArgumentError set_base_power!(gen, 0.5 * SU)
+    @test_throws ArgumentError set_base_power!(gen, 1.25 * SU)
+    @test_throws ArgumentError set_base_power!(gen, 1.0 * DU)
+    @test_throws ArgumentError set_base_power!(gen, 0.5 * DU)
 
     # Dimensionally wrong inputs fail at conversion time.
     @test_throws Unitful.DimensionError set_base_power!(gen, 1.0 * kV)


### PR DESCRIPTION
## Summary

Per the convention that `base_power` is the anchor every other field's per-unitization is defined against, `get_base_power`/`set_base_power!` now treat `base_power` as **always** being in natural units (MVA), rather than going through the per-unit-aware machinery like other fields.

Behavior:

1. `get_base_power(comp)` and `set_base_power!(comp, 0.5)` need **no** units argument — they read/write the stored MVA value directly.
2. `get_base_power(comp, NU)` and `set_base_power!(comp, 0.5 * MW)` (or `* MVA`) also work. Any power-dimensioned `Unitful` unit is accepted (conversion via `uconvert`/`ustrip`).
3. Anything other than natural units **errors**:
   - Per-unit bases `SU`/`DU` → `ArgumentError` (expressing a base in terms of itself or the system base is circular).
   - Non-power Unitful units (e.g. `kV`) → `Unitful.DimensionError`, for free, from Unitful.

The system-level accessor (`get_base_power(sys, ...)`) is updated to mirror the component one.

## Changes

- `src/models/components.jl` — component `base_power` accessors + `_base_power_units_error` helper
- `src/base.jl` — system `base_power` accessors
- `test/test_base_power.jl` — updated to assert the new contract

## Notes

- This covers the `base_power` field only. `Transformer3W`'s `base_power_12/23/13` are generated `:mva`-conversion fields that still flow through the generic machinery and continue to accept `SU`/`DU`. Extending the natural-units-only rule to those is a follow-up (it touches the struct-generation path), so it's deliberately out of scope here.
- No changes in InfrastructureSystems.jl — this is entirely a PSY-side dispatch concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)