### PR TITLE
Normalize VSC converter DCSET setpoints to per-unit in PSS/E parser

### DIFF
--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -1856,6 +1856,22 @@ function _psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["pf"] = flow_setpoint / baseMVA
             sub_data["if"] = 1000.0 * (flow_setpoint / base_voltage)
 
+            # DCSET is raw PSS/E units (kV for a dc-voltage-controlling converter, MW for a
+            # dc-power-controlling converter), not per-unit. Normalize each converter's own
+            # setpoint by its own quantity's base now that r/pf/if (which need the raw kV/MW
+            # values) have been computed, so downstream per-unit consumers aren't handed a
+            # setpoint off by ~base_voltage or ~baseMVA.
+            sub_data["dc_setpoint_from"] = if from_is_dc_voltage
+                1.0
+            else
+                sub_data["dc_setpoint_from"] / baseMVA
+            end
+            sub_data["dc_setpoint_to"] = if to_is_dc_voltage
+                1.0
+            else
+                sub_data["dc_setpoint_to"] / baseMVA
+            end
+
             sub_data["ext"] = Dict{String, Any}(
                 "REMOT_FROM" => from_bus["REMOT"],
                 "REMOT_TO" => to_bus["REMOT"],

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -168,7 +168,8 @@ end
     @info "Testing VSC Parser"
     vsc = only(get_components(TwoTerminalVSCLine, sys4))
     @test get_active_power_flow(vsc) == -0.2
-    @test get_dc_setpoint_to(vsc) == -20.0
+    @test get_dc_setpoint_from(vsc) == 1.0
+    @test get_dc_setpoint_to(vsc) == -0.2
 
     @info "Testing Load Zone Formatter"
     PSB.clear_serialized_systems("psse_Benchmark_4ger_33_2015_sys")


### PR DESCRIPTION
## Summary
- PSS/E's VSC `DCSET` field is raw physical units — kV for the DC-voltage-controlling converter, MW for the DC-power-controlling one — not per-unit.
- `dc_setpoint_from`/`dc_setpoint_to` were stored straight off the raw PTI data while every other converter quantity in this parser (`MINQ`/`MAXQ`, `SMAX`, etc.) is already normalized to system per-unit.
- Downstream consumers (e.g. PowerFlows.jl's joint AC/DC VSC solver) treat these setpoints as per-unit targets, so an unconverted raw value (off by a factor of ~`base_voltage` or ~`baseMVA`) drove the DC-network residual toward an unreachable state and caused solver divergence on any VSC-containing case.
- Fix normalizes each converter's own setpoint to `1.0` pu (voltage-controlling terminal, which by construction defines its own DC base) or `raw / baseMVA` (power-controlling terminal), applied *after* `r`/`pf`/`if` are computed from the raw values so those calculations are unaffected.

## Test plan
- [x] Updated `test/test_parse_psse.jl`'s existing VSC assertions, which had been asserting the raw (buggy) value (`get_dc_setpoint_to(vsc) == -20.0`) right next to the already-correctly-normalized `get_active_power_flow(vsc) == -0.2` for the same underlying MW quantity — now asserts `get_dc_setpoint_from(vsc) == 1.0` and `get_dc_setpoint_to(vsc) == -0.2`.
- [x] Ran `test/test_outages.jl` under `TestEnv` to confirm the local environment/dependency graph is otherwise clean (unrelated to this change; documented a stale local serialized-system cache issue separately).
- [x] Full `test/runtests.jl` run pending (not executed in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)