### PR TITLE
Change HydroReservoir.head_to_volume_factor from ValueCurve to FunctionData

### DIFF
--- a/docs/src/how_to/create_hydro_datasets.md
+++ b/docs/src/how_to/create_hydro_datasets.md
@@ -74,7 +74,7 @@ reservoir = HydroReservoir(;
     outflow = 50.0,  # m³/h
     level_targets = 0.7,
     intake_elevation = 600.0,  # meters above sea level
-    head_to_volume_factor = LinearCurve(1.0),
+    head_to_volume_factor = LinearFunctionData(1.0),
 )
 add_component!(sys, reservoir)
 
@@ -189,7 +189,7 @@ head_reservoir = HydroReservoir(;
     outflow = 100.0,
     level_targets = 0.5,
     intake_elevation = 800.0,
-    head_to_volume_factor = LinearCurve(1.0),
+    head_to_volume_factor = LinearFunctionData(1.0),
 )
 add_component!(sys, head_reservoir)
 
@@ -204,7 +204,7 @@ tail_reservoir = HydroReservoir(;
     outflow = 100.0,
     level_targets = 0.5,
     intake_elevation = 200.0,
-    head_to_volume_factor = LinearCurve(1.0),
+    head_to_volume_factor = LinearFunctionData(1.0),
 )
 add_component!(sys, tail_reservoir)
 
@@ -246,7 +246,7 @@ Key fields for [`HydroReservoir`](@ref):
   - `spillage_limits::Union{Nothing, MinMax}`: Water spillage limits
   - `level_targets::Union{Nothing, Float64}`: Target level at simulation end as fraction of max
   - `intake_elevation::Float64`: Height of intake in meters above sea level
-  - `head_to_volume_factor::ValueCurve`: Head to volume relationship
+  - `head_to_volume_factor::FunctionData`: Head to volume relationship
   - `upstream_turbines::Vector{HydroUnit}`: Turbines feeding into this reservoir (tail reservoir)
   - `downstream_turbines::Vector{HydroUnit}`: Turbines fed by this reservoir (head reservoir)
   - `upstream_reservoirs::Vector{Device}`: Reservoirs feeding spillage into this reservoir

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -6135,8 +6135,8 @@
                 {
                     "name": "head_to_volume_factor",
                     "comment": "Head to volume relationship for the reservoir.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "ValueCurve"
+                    "null_value": "LinearFunctionData(0.0)",
+                    "data_type": "FunctionData"
                 },
                 {
                     "name": "upstream_turbines",

--- a/src/models/generated/HydroReservoir.jl
+++ b/src/models/generated/HydroReservoir.jl
@@ -15,7 +15,7 @@ This file is auto-generated. Do not edit.
         outflow::Float64
         level_targets::Union{Nothing, Float64}
         intake_elevation::Float64
-        head_to_volume_factor::ValueCurve
+        head_to_volume_factor::FunctionData
         upstream_turbines::Vector{HydroUnit}
         downstream_turbines::Vector{HydroUnit}
         upstream_reservoirs::Vector{Device}
@@ -38,7 +38,7 @@ See [How to Define Hydro Generators with Reservoirs](@ref hydro_resv) for suppor
 - `outflow::Float64`: Amount of water naturally going out of the reservoir in m^3/h or MW (if `level_data_type` is [`ReservoirDataType`](@ref hydroreservoir_list)`.ENERGY`).
 - `level_targets::Union{Nothing, Float64}`: Reservoir level targets at the end of a simulation as a fraction of the `storage_level_limits.max`.
 - `intake_elevation::Float64`: Height of the intake of the reservoir, towards the downstream turbines, in meters above the sea level.
-- `head_to_volume_factor::ValueCurve`: Head to volume relationship for the reservoir.
+- `head_to_volume_factor::FunctionData`: Head to volume relationship for the reservoir.
 - `upstream_turbines::Vector{HydroUnit}`: (default: `Device[]`) Vector of [HydroUnit](@ref)(s) that are immediately upstream of this reservoir. This reservoir is the tail reservoir for these units, and their flow goes into this reservoir.
 - `downstream_turbines::Vector{HydroUnit}`: (default: `Device[]`) Vector of [HydroUnit](@ref)(s) that are immediately downstream of this reservoir. This reservoir is the head reservoir for these units, and its feed flow into these units.
 - `upstream_reservoirs::Vector{Device}`: (default: `Device[]`) Vector of [Device](@ref)(s) reservoirs that are immediately upstream of this reservoir. This reservoir receives the spillage flow from upstream_reservoirs.
@@ -67,7 +67,7 @@ mutable struct HydroReservoir <: Device
     "Height of the intake of the reservoir, towards the downstream turbines, in meters above the sea level."
     intake_elevation::Float64
     "Head to volume relationship for the reservoir."
-    head_to_volume_factor::ValueCurve
+    head_to_volume_factor::FunctionData
     "Vector of [HydroUnit](@ref)(s) that are immediately upstream of this reservoir. This reservoir is the tail reservoir for these units, and their flow goes into this reservoir."
     upstream_turbines::Vector{HydroUnit}
     "Vector of [HydroUnit](@ref)(s) that are immediately downstream of this reservoir. This reservoir is the head reservoir for these units, and its feed flow into these units."
@@ -104,7 +104,7 @@ function HydroReservoir(::Nothing)
         outflow=0.0,
         level_targets=nothing,
         intake_elevation=0.0,
-        head_to_volume_factor=LinearCurve(0.0),
+        head_to_volume_factor=LinearFunctionData(0.0),
         upstream_turbines=Device[],
         downstream_turbines=Device[],
         upstream_reservoirs=Device[],

--- a/src/models/supplemental_setters.jl
+++ b/src/models/supplemental_setters.jl
@@ -15,7 +15,7 @@ function set_downstream_turbine!(reservoir::HydroReservoir, turbine::HydroUnit)
 end
 
 function set_head_to_volume_factor!(reservoir::HydroReservoir, val::Float64)
-    return set_head_to_volume_factor!(reservoir, LinearCurve(val))
+    return set_head_to_volume_factor!(reservoir, LinearFunctionData(val))
 end
 
 function _raise_if_attached_to_system(hybrid::HybridSystem)

--- a/test/test_hydro_reservoir.jl
+++ b/test/test_hydro_reservoir.jl
@@ -29,7 +29,7 @@ end
         outflow = 0.0,
         level_targets = 0.0,
         intake_elevation = 0.0,
-        head_to_volume_factor = LinearCurve(0.0),
+        head_to_volume_factor = LinearFunctionData(0.0),
     )
     @test get_storage_level_limits(reservoir) == (min = 0.0, max = 1.0)
     @test get_initial_level(reservoir) == 1.0
@@ -37,7 +37,7 @@ end
     @test get_inflow(reservoir) == 0.0
     @test get_outflow(reservoir) == 0.0
     @test get_intake_elevation(reservoir) == 0.0
-    @test get_head_to_volume_factor(reservoir) == LinearCurve(0.0)
+    @test get_head_to_volume_factor(reservoir) == LinearFunctionData(0.0)
     set_intake_elevation!(reservoir, 10.0)
     @test get_intake_elevation(reservoir) == 10.0
 end


### PR DESCRIPTION
## Summary
- Change `HydroReservoir.head_to_volume_factor` from `ValueCurve` to `FunctionData` (default `LinearFunctionData(0.0)`), per the resolution in #1556: an "average/incremental head rate" isn't a real cost-curve-shaped concept, so this shouldn't be modeled as a `ValueCurve`.
- Regenerated `src/models/generated/HydroReservoir.jl` from the updated descriptor.
- Updated the hand-written `set_head_to_volume_factor!(reservoir, ::Float64)` convenience setter, tests, and docs to construct `LinearFunctionData` instead of `LinearCurve`.

This addresses item 1 of #1556 ("`HydroReservoir.head_to_volume_factor::ValueCurve`: change to `FunctionData`"); items 2–3 (`EmissionsData.emission_rate` and loss curves) are unchanged, per that same comment.

Note: this is a breaking change for downstream packages (e.g. HydroPowerSimulations.jl, PowerSystemCaseBuilder.jl) that construct `HydroReservoir` with `head_to_volume_factor = LinearCurve(...)` — they'll need a follow-up update to `LinearFunctionData(...)`. `get_proportional_term` continues to work unchanged since it has a direct method on `LinearFunctionData` as well as on `ValueCurve`.

## Test plan
- [x] `julia --project=test test/runtests.jl test_hydro_reservoir` — 41/41 passing
- [x] `julia --project=test -e 'using PowerSystems'` compiles cleanly
- [x] Formatter run (`scripts/formatter/formatter_code.jl`) — no additional changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)