### PR TITLE
Show explicit unit suffixes for converted fields; rating fields display in device base

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/show-components-units-override"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "0289b7180303d166daf25fbeb7bacecf1a40b466"}
 
 [compat]
 DataStructures = "^0.19"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/show-components-units-override"}
 
 [compat]
 DataStructures = "^0.19"

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -466,6 +466,7 @@ export get_components
 export get_num_components
 export get_associated_components
 export show_components
+export show_component
 export get_subcomponents
 export get_components_by_name
 export get_available

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -499,7 +499,8 @@
                     "comment": "Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to",
                     "data_type": "Float64",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "angle_limits",
@@ -714,7 +715,8 @@
                     "comment": "Thermal rating (MVA). Flow on the branch must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to",
                     "data_type": "Float64",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "discrete_branch_type",
@@ -839,7 +841,8 @@
                     "data_type": "Float64",
                     "comment": "Thermal rating (MVA). Flow through the transformer must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "angle_limits",
@@ -1010,7 +1013,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "base_power",
@@ -1201,7 +1205,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "base_power",
@@ -1409,7 +1414,8 @@
                     },
                     "validation_action": "error",
                    "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "base_power",
@@ -1675,7 +1681,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "null_value": "0.0",
@@ -1897,7 +1904,8 @@
                     "comment": "Rating (in MVA) for primary winding.",
                     "default": "0.0",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "null_value": "0.0",
@@ -1906,7 +1914,8 @@
                     "comment": "Rating (in MVA) for secondary winding.",
                     "default": "0.0",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "null_value": "0.0",
@@ -1915,7 +1924,8 @@
                     "comment": "Rating (in MVA) for tertiary winding.",
                     "default": "0.0",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "primary_group_number",
@@ -2161,7 +2171,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "null_value": "0.0",
@@ -2416,7 +2427,8 @@
                     "comment": "Rating (in MVA) for primary winding.",
                     "default": "0.0",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "null_value": "0.0",
@@ -2425,7 +2437,8 @@
                     "comment": "Rating (in MVA) for secondary winding.",
                     "default": "0.0",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "null_value": "0.0",
@@ -2434,7 +2447,8 @@
                     "comment": "Rating (in MVA) for tertiary winding.",
                     "default": "0.0",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "phase_angle_limits",
@@ -2624,7 +2638,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "active_power_limits_from",
@@ -4069,7 +4084,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "max_active_power",
@@ -5145,7 +5161,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "active_power_limits",
@@ -5483,7 +5500,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "prime_mover_type",
@@ -5655,7 +5673,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "active_power_limits",
@@ -5869,7 +5888,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "active_power_limits",
@@ -6240,7 +6260,8 @@
                         "min": 0,
                         "max": null
                     },
-                    "validation_action": "error"
+                    "validation_action": "error",
+                    "display_units": "DU"
                 },
                 {
                     "name": "prime_mover_type",
@@ -6368,7 +6389,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "prime_mover_type",
@@ -6492,7 +6514,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "active_power_limits",
@@ -6663,7 +6686,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "reactive_power_limits",
@@ -6792,7 +6816,8 @@
                     },
                     "validation_action": "error",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "prime_mover_type",
@@ -7016,7 +7041,8 @@
                     "null_value": "0.0",
                     "data_type": "Float64",
                     "needs_conversion": true,
-                    "conversion_unit": ":mva"
+                    "conversion_unit": ":mva",
+                    "display_units": "DU"
                 },
                 {
                     "name": "active_power",

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -496,7 +496,7 @@
                 {
                     "null_value": "0.0",
                     "name": "rating",
-                    "comment": "Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to",
+                    "comment": "Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base",
                     "data_type": "Float64",
                     "needs_conversion": true,
                     "conversion_unit": ":mva",
@@ -712,7 +712,7 @@
                 {
                     "null_value": "0.0",
                     "name": "rating",
-                    "comment": "Thermal rating (MVA). Flow on the branch must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to",
+                    "comment": "Thermal rating (MVA). Flow on the branch must be between -`rating` and `rating`. When defining a branch before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base",
                     "data_type": "Float64",
                     "needs_conversion": true,
                     "conversion_unit": ":mva",
@@ -839,7 +839,7 @@
                     "null_value": "0.0",
                     "name": "rating",
                     "data_type": "Float64",
-                    "comment": "Thermal rating (MVA). Flow through the transformer must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to",
+                    "comment": "Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base",
                     "needs_conversion": true,
                     "conversion_unit": ":mva",
                     "display_units": "DU"

--- a/src/models/generated/DiscreteControlledACBranch.jl
+++ b/src/models/generated/DiscreteControlledACBranch.jl
@@ -122,8 +122,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_x_unitful), ::Type{Discrete
 get_rating(value::DiscreteControlledACBranch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`DiscreteControlledACBranch`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::DiscreteControlledACBranch, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.DU
 """Get [`DiscreteControlledACBranch`](@ref) `discrete_branch_type`."""
 get_discrete_branch_type(value::DiscreteControlledACBranch) = value.discrete_branch_type
 """Get [`DiscreteControlledACBranch`](@ref) `branch_status`."""

--- a/src/models/generated/DiscreteControlledACBranch.jl
+++ b/src/models/generated/DiscreteControlledACBranch.jl
@@ -30,7 +30,7 @@ Used to represent switches and breakers connecting AC Buses
 - `arc::Arc`: An [`Arc`](@ref) defining this line `from` a bus `to` another bus
 - `r::Float64`: Resistance in pu ([`SYSTEM_BASE`](@ref per_unit)), validation range: `(0, 4)`
 - `x::Float64`: Reactance in pu ([`SYSTEM_BASE`](@ref per_unit)), validation range: `(0, 4)`
-- `rating::Float64`: Thermal rating (MVA). Flow on the branch must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to
+- `rating::Float64`: Thermal rating (MVA). Flow on the branch must be between -`rating` and `rating`. When defining a branch before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base
 - `discrete_branch_type::DiscreteControlledBranchType`: (default: `DiscreteControlledBranchType.OTHER`) Type of discrete control
 - `branch_status::DiscreteControlledBranchStatus`: (default: `DiscreteControlledBranchStatus.CLOSED`) Open or Close status
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
@@ -51,7 +51,7 @@ mutable struct DiscreteControlledACBranch <: ACTransmission
     r::Float64
     "Reactance in pu ([`SYSTEM_BASE`](@ref per_unit))"
     x::Float64
-    "Thermal rating (MVA). Flow on the branch must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to"
+    "Thermal rating (MVA). Flow on the branch must be between -`rating` and `rating`. When defining a branch before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base"
     rating::Float64
     "Type of discrete control"
     discrete_branch_type::DiscreteControlledBranchType

--- a/src/models/generated/EnergyReservoirStorage.jl
+++ b/src/models/generated/EnergyReservoirStorage.jl
@@ -174,8 +174,8 @@ get_initial_storage_capacity_level(value::EnergyReservoirStorage) = value.initia
 get_rating(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`EnergyReservoirStorage`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.DU
 """Get [`EnergyReservoirStorage`](@ref) `active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_unitful`](@ref)."""
 get_active_power(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mva), units))
 """Get [`EnergyReservoirStorage`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""

--- a/src/models/generated/HydroDispatch.jl
+++ b/src/models/generated/HydroDispatch.jl
@@ -147,8 +147,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::
 get_rating(value::HydroDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`HydroDispatch`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::HydroDispatch, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroDispatch}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroDispatch}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroDispatch}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroDispatch}) = InfrastructureSystems.DU
 """Get [`HydroDispatch`](@ref) `prime_mover_type`."""
 get_prime_mover_type(value::HydroDispatch) = value.prime_mover_type
 """Get [`HydroDispatch`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""

--- a/src/models/generated/HydroPumpTurbine.jl
+++ b/src/models/generated/HydroPumpTurbine.jl
@@ -195,8 +195,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::
 get_rating(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`HydroPumpTurbine`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroPumpTurbine}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.DU
 """Get [`HydroPumpTurbine`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mva), units))
 """Get [`HydroPumpTurbine`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""

--- a/src/models/generated/HydroTurbine.jl
+++ b/src/models/generated/HydroTurbine.jl
@@ -165,8 +165,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::
 get_rating(value::HydroTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`HydroTurbine`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::HydroTurbine, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroTurbine}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroTurbine}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroTurbine}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroTurbine}) = InfrastructureSystems.DU
 """Get [`HydroTurbine`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::HydroTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mva), units))
 """Get [`HydroTurbine`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""

--- a/src/models/generated/InterconnectingConverter.jl
+++ b/src/models/generated/InterconnectingConverter.jl
@@ -151,8 +151,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Ty
 get_rating(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`InterconnectingConverter`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{InterconnectingConverter}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.DU
 """Get [`InterconnectingConverter`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mva), units))
 """Get [`InterconnectingConverter`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""

--- a/src/models/generated/Line.jl
+++ b/src/models/generated/Line.jl
@@ -35,7 +35,7 @@ An AC transmission line
 - `r::Float64`: Resistance in pu ([`SYSTEM_BASE`](@ref per_unit)), validation range: `(0, 4)`
 - `x::Float64`: Reactance in pu ([`SYSTEM_BASE`](@ref per_unit)), validation range: `(0, 4)`
 - `b::FromTo`: Shunt susceptance in pu ([`SYSTEM_BASE`](@ref per_unit)), specified both on the `from` and `to` ends of the line. These are commonly modeled with the same value, validation range: `(0, 100)`
-- `rating::Float64`: Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to
+- `rating::Float64`: Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base
 - `angle_limits::MinMax`: Minimum and maximum angle limits (radians)
 - `rating_b::Union{Nothing, Float64}`: (default: `nothing`) Second current rating; entered in MVA.
 - `rating_c::Union{Nothing, Float64}`: (default: `nothing`) Third current rating; entered in MVA.
@@ -61,7 +61,7 @@ mutable struct Line <: ACTransmission
     x::Float64
     "Shunt susceptance in pu ([`SYSTEM_BASE`](@ref per_unit)), specified both on the `from` and `to` ends of the line. These are commonly modeled with the same value"
     b::FromTo
-    "Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to"
+    "Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base"
     rating::Float64
     "Minimum and maximum angle limits (radians)"
     angle_limits::MinMax

--- a/src/models/generated/Line.jl
+++ b/src/models/generated/Line.jl
@@ -148,8 +148,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_b_unitful), ::Type{Line}) =
 get_rating(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`Line`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::Line, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{Line}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{Line}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{Line}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{Line}) = InfrastructureSystems.DU
 """Get [`Line`](@ref) `angle_limits`."""
 get_angle_limits(value::Line) = value.angle_limits
 """Get [`Line`](@ref) `rating_b` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_b_unitful`](@ref)."""

--- a/src/models/generated/MonitoredLine.jl
+++ b/src/models/generated/MonitoredLine.jl
@@ -39,7 +39,7 @@ For example, monitored lines can be used to restrict line flow following a conti
 - `x::Float64`: Reactance in pu ([`SYSTEM_BASE`](@ref per_unit)), validation range: `(0, 4)`
 - `b::FromTo`: Shunt susceptance in pu ([`SYSTEM_BASE`](@ref per_unit)), specified both on the `from` and `to` ends of the line. These are commonly modeled with the same value, validation range: `(0, 2)`
 - `flow_limits::FromTo_ToFrom`: Minimum and maximum permissable flow on the line (MVA), if different from the thermal rating defined in `rating`
-- `rating::Float64`: Thermal rating (MVA). Flow through the transformer must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to
+- `rating::Float64`: Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base
 - `angle_limits::MinMax`: Minimum and maximum angle limits (radians)
 - `rating_b::Union{Nothing, Float64}`: (default: `nothing`) Second current rating; entered in MVA.
 - `rating_c::Union{Nothing, Float64}`: (default: `nothing`) Third current rating; entered in MVA.
@@ -67,7 +67,7 @@ mutable struct MonitoredLine <: ACTransmission
     b::FromTo
     "Minimum and maximum permissable flow on the line (MVA), if different from the thermal rating defined in `rating`"
     flow_limits::FromTo_ToFrom
-    "Thermal rating (MVA). Flow through the transformer must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to"
+    "Thermal rating (MVA). Flow on the line must be between -`rating` and `rating`. When defining a line before it is attached to a `System`, `rating` must be in pu ([`SYSTEM_BASE`](@ref per_unit)) using the base power of the `System` it will be attached to. Displays in device base ([`DEVICE_BASE`](@ref per_unit)) by default, unlike most converted fields which default to system base"
     rating::Float64
     "Minimum and maximum angle limits (radians)"
     angle_limits::MinMax

--- a/src/models/generated/MonitoredLine.jl
+++ b/src/models/generated/MonitoredLine.jl
@@ -161,8 +161,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_flow_limits_unitful), ::Typ
 get_rating(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`MonitoredLine`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::MonitoredLine, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{MonitoredLine}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{MonitoredLine}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.DU
 """Get [`MonitoredLine`](@ref) `angle_limits`."""
 get_angle_limits(value::MonitoredLine) = value.angle_limits
 """Get [`MonitoredLine`](@ref) `rating_b` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_b_unitful`](@ref)."""

--- a/src/models/generated/MotorLoad.jl
+++ b/src/models/generated/MotorLoad.jl
@@ -124,8 +124,8 @@ _get_base_power(value::MotorLoad) = value.base_power
 get_rating(value::MotorLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`MotorLoad`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::MotorLoad, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{MotorLoad}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{MotorLoad}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{MotorLoad}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{MotorLoad}) = InfrastructureSystems.DU
 """Get [`MotorLoad`](@ref) `max_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_active_power_unitful`](@ref)."""
 get_max_active_power(value::MotorLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_active_power), Val(:mva), units))
 """Get [`MotorLoad`](@ref) `max_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_active_power`](@ref)."""

--- a/src/models/generated/PhaseShiftingTransformer.jl
+++ b/src/models/generated/PhaseShiftingTransformer.jl
@@ -179,8 +179,8 @@ get_α(value::PhaseShiftingTransformer) = value.α
 get_rating(value::PhaseShiftingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`PhaseShiftingTransformer`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::PhaseShiftingTransformer, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{PhaseShiftingTransformer}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{PhaseShiftingTransformer}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{PhaseShiftingTransformer}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{PhaseShiftingTransformer}) = InfrastructureSystems.DU
 
 _get_base_power(value::PhaseShiftingTransformer) = value.base_power
 """Get [`PhaseShiftingTransformer`](@ref) `base_voltage_primary`."""

--- a/src/models/generated/PhaseShiftingTransformer3W.jl
+++ b/src/models/generated/PhaseShiftingTransformer3W.jl
@@ -378,8 +378,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_x_tertiary_unitful), ::Type
 get_rating(value::PhaseShiftingTransformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`PhaseShiftingTransformer3W`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::PhaseShiftingTransformer3W, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.DU
 """Get [`PhaseShiftingTransformer3W`](@ref) `r_12` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_r_12_unitful`](@ref)."""
 get_r_12(value::PhaseShiftingTransformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r_12), Val(:ohm), units))
 """Get [`PhaseShiftingTransformer3W`](@ref) `r_12` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r_12`](@ref)."""
@@ -462,20 +462,20 @@ get_available_tertiary(value::PhaseShiftingTransformer3W) = value.available_tert
 get_rating_primary(value::PhaseShiftingTransformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_primary), Val(:mva), units))
 """Get [`PhaseShiftingTransformer3W`](@ref) `rating_primary` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_primary`](@ref)."""
 get_rating_primary_unitful(value::PhaseShiftingTransformer3W, units) = get_value(value, Val(:rating_primary), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating_primary), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_primary_unitful), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_primary), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_primary_unitful), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.DU
 """Get [`PhaseShiftingTransformer3W`](@ref) `rating_secondary` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_secondary_unitful`](@ref)."""
 get_rating_secondary(value::PhaseShiftingTransformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_secondary), Val(:mva), units))
 """Get [`PhaseShiftingTransformer3W`](@ref) `rating_secondary` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_secondary`](@ref)."""
 get_rating_secondary_unitful(value::PhaseShiftingTransformer3W, units) = get_value(value, Val(:rating_secondary), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating_secondary), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_secondary_unitful), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_secondary), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_secondary_unitful), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.DU
 """Get [`PhaseShiftingTransformer3W`](@ref) `rating_tertiary` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_tertiary_unitful`](@ref)."""
 get_rating_tertiary(value::PhaseShiftingTransformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_tertiary), Val(:mva), units))
 """Get [`PhaseShiftingTransformer3W`](@ref) `rating_tertiary` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_tertiary`](@ref)."""
 get_rating_tertiary_unitful(value::PhaseShiftingTransformer3W, units) = get_value(value, Val(:rating_tertiary), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating_tertiary), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_tertiary_unitful), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_tertiary), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_tertiary_unitful), ::Type{PhaseShiftingTransformer3W}) = InfrastructureSystems.DU
 """Get [`PhaseShiftingTransformer3W`](@ref) `phase_angle_limits`."""
 get_phase_angle_limits(value::PhaseShiftingTransformer3W) = value.phase_angle_limits
 """Get [`PhaseShiftingTransformer3W`](@ref) `control_objective_primary`."""

--- a/src/models/generated/RenewableDispatch.jl
+++ b/src/models/generated/RenewableDispatch.jl
@@ -129,8 +129,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::
 get_rating(value::RenewableDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`RenewableDispatch`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::RenewableDispatch, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{RenewableDispatch}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{RenewableDispatch}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{RenewableDispatch}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{RenewableDispatch}) = InfrastructureSystems.DU
 """Get [`RenewableDispatch`](@ref) `prime_mover_type`."""
 get_prime_mover_type(value::RenewableDispatch) = value.prime_mover_type
 """Get [`RenewableDispatch`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""

--- a/src/models/generated/RenewableNonDispatch.jl
+++ b/src/models/generated/RenewableNonDispatch.jl
@@ -119,8 +119,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::
 get_rating(value::RenewableNonDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`RenewableNonDispatch`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::RenewableNonDispatch, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{RenewableNonDispatch}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{RenewableNonDispatch}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{RenewableNonDispatch}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{RenewableNonDispatch}) = InfrastructureSystems.DU
 """Get [`RenewableNonDispatch`](@ref) `prime_mover_type`."""
 get_prime_mover_type(value::RenewableNonDispatch) = value.prime_mover_type
 """Get [`RenewableNonDispatch`](@ref) `power_factor`."""

--- a/src/models/generated/SynchronousCondenser.jl
+++ b/src/models/generated/SynchronousCondenser.jl
@@ -104,8 +104,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::
 get_rating(value::SynchronousCondenser, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`SynchronousCondenser`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::SynchronousCondenser, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{SynchronousCondenser}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{SynchronousCondenser}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{SynchronousCondenser}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{SynchronousCondenser}) = InfrastructureSystems.DU
 """Get [`SynchronousCondenser`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::SynchronousCondenser, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mva), units))
 """Get [`SynchronousCondenser`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""

--- a/src/models/generated/TapTransformer.jl
+++ b/src/models/generated/TapTransformer.jl
@@ -192,8 +192,8 @@ get_tap(value::TapTransformer) = value.tap
 get_rating(value::TapTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`TapTransformer`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::TapTransformer, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{TapTransformer}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{TapTransformer}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{TapTransformer}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{TapTransformer}) = InfrastructureSystems.DU
 
 _get_base_power(value::TapTransformer) = value.base_power
 """Get [`TapTransformer`](@ref) `base_voltage_primary`."""

--- a/src/models/generated/ThermalMultiStart.jl
+++ b/src/models/generated/ThermalMultiStart.jl
@@ -173,8 +173,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::
 get_rating(value::ThermalMultiStart, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`ThermalMultiStart`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::ThermalMultiStart, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{ThermalMultiStart}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.DU
 """Get [`ThermalMultiStart`](@ref) `prime_mover_type`."""
 get_prime_mover_type(value::ThermalMultiStart) = value.prime_mover_type
 """Get [`ThermalMultiStart`](@ref) `fuel`."""

--- a/src/models/generated/ThermalStandard.jl
+++ b/src/models/generated/ThermalStandard.jl
@@ -159,8 +159,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::
 get_rating(value::ThermalStandard, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`ThermalStandard`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::ThermalStandard, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{ThermalStandard}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{ThermalStandard}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{ThermalStandard}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{ThermalStandard}) = InfrastructureSystems.DU
 """Get [`ThermalStandard`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::ThermalStandard, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mva), units))
 """Get [`ThermalStandard`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""

--- a/src/models/generated/Transformer2W.jl
+++ b/src/models/generated/Transformer2W.jl
@@ -160,8 +160,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_primary_shunt_unitful), ::T
 get_rating(value::Transformer2W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`Transformer2W`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::Transformer2W, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{Transformer2W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{Transformer2W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{Transformer2W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{Transformer2W}) = InfrastructureSystems.DU
 
 _get_base_power(value::Transformer2W) = value.base_power
 """Get [`Transformer2W`](@ref) `base_voltage_primary`."""

--- a/src/models/generated/Transformer3W.jl
+++ b/src/models/generated/Transformer3W.jl
@@ -373,8 +373,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_x_tertiary_unitful), ::Type
 get_rating(value::Transformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`Transformer3W`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::Transformer3W, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{Transformer3W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{Transformer3W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{Transformer3W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{Transformer3W}) = InfrastructureSystems.DU
 """Get [`Transformer3W`](@ref) `r_12` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_r_12_unitful`](@ref)."""
 get_r_12(value::Transformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r_12), Val(:ohm), units))
 """Get [`Transformer3W`](@ref) `r_12` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r_12`](@ref)."""
@@ -451,20 +451,20 @@ get_available_tertiary(value::Transformer3W) = value.available_tertiary
 get_rating_primary(value::Transformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_primary), Val(:mva), units))
 """Get [`Transformer3W`](@ref) `rating_primary` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_primary`](@ref)."""
 get_rating_primary_unitful(value::Transformer3W, units) = get_value(value, Val(:rating_primary), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating_primary), ::Type{Transformer3W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_primary_unitful), ::Type{Transformer3W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_primary), ::Type{Transformer3W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_primary_unitful), ::Type{Transformer3W}) = InfrastructureSystems.DU
 """Get [`Transformer3W`](@ref) `rating_secondary` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_secondary_unitful`](@ref)."""
 get_rating_secondary(value::Transformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_secondary), Val(:mva), units))
 """Get [`Transformer3W`](@ref) `rating_secondary` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_secondary`](@ref)."""
 get_rating_secondary_unitful(value::Transformer3W, units) = get_value(value, Val(:rating_secondary), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating_secondary), ::Type{Transformer3W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_secondary_unitful), ::Type{Transformer3W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_secondary), ::Type{Transformer3W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_secondary_unitful), ::Type{Transformer3W}) = InfrastructureSystems.DU
 """Get [`Transformer3W`](@ref) `rating_tertiary` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_tertiary_unitful`](@ref)."""
 get_rating_tertiary(value::Transformer3W, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_tertiary), Val(:mva), units))
 """Get [`Transformer3W`](@ref) `rating_tertiary` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_tertiary`](@ref)."""
 get_rating_tertiary_unitful(value::Transformer3W, units) = get_value(value, Val(:rating_tertiary), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating_tertiary), ::Type{Transformer3W}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_tertiary_unitful), ::Type{Transformer3W}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_tertiary), ::Type{Transformer3W}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_tertiary_unitful), ::Type{Transformer3W}) = InfrastructureSystems.DU
 """Get [`Transformer3W`](@ref) `primary_group_number`."""
 get_primary_group_number(value::Transformer3W) = value.primary_group_number
 """Get [`Transformer3W`](@ref) `secondary_group_number`."""

--- a/src/models/generated/TwoTerminalVSCLine.jl
+++ b/src/models/generated/TwoTerminalVSCLine.jl
@@ -226,8 +226,8 @@ InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful),
 get_rating(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`TwoTerminalVSCLine`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:rating), Val(:mva), units)
-InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
-InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.DU
+InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.DU
 """Get [`TwoTerminalVSCLine`](@ref) `active_power_limits_from` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_from_unitful`](@ref)."""
 get_active_power_limits_from(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_from), Val(:mva), units))
 """Get [`TwoTerminalVSCLine`](@ref) `active_power_limits_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_from`](@ref)."""

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -1,25 +1,42 @@
 # "smart" summary and REPL printing
 
+# The `_unitful` companion of a generated getter returns a unit-tagged value
+# (a `RelativeQuantity` printing as "1.0 DU"/"0.3 SU", or a `Unitful.Quantity`
+# printing as "30.0 MW") instead of a bare number, so display can show the
+# unit system explicitly without any extra formatting code here.
+function _unitful_getter(getter_func::Function)
+    name = Symbol(string(nameof(getter_func)), "_unitful")
+    return hasproperty(PowerSystems, name) ? getproperty(PowerSystems, name) : nothing
+end
+
 # Getters for unit-bearing fields declare their display-units choice via the
 # `IS.display_units_arg` trait (set by the struct-generator template, default
-# `missing` for plain getters). Prefer the trait's unit (typically `SU`),
-# falling back to `NU` if the component isn't system-attached.
-function _show_accessor_value(getter_func::Function, ist::Component)
-    arg = IS.display_units_arg(getter_func, typeof(ist))
-    ismissing(arg) && return getter_func(ist)
+# `SU` for converted fields unless overridden per field in the descriptor,
+# e.g. `rating` fields default to `DU`). Pass `units` to force a specific
+# display unit system (e.g. `MW`, `SU`, `DU`, `NU`) instead of resolving the
+# trait; an explicit request that fails is an error, not a silent fallback.
+function _show_accessor_value(getter_func::Function, ist::Component; units = nothing)
+    trait_arg = IS.display_units_arg(getter_func, typeof(ist))
+    # Fields without a units trait (e.g. `get_name`) aren't unit-convertible at
+    # all — an explicit `units` override must not force a units argument onto
+    # a getter that doesn't accept one.
+    ismissing(trait_arg) && return getter_func(ist)
+    arg = units === nothing ? trait_arg : units
+    unitful_func = something(_unitful_getter(getter_func), getter_func)
     try
-        return getter_func(ist, arg)
+        return unitful_func(ist, arg)
     catch err
+        units !== nothing && rethrow()
         err isa ErrorException && occursin("not attached", err.msg) || rethrow()
         # NU can also fail (it may need the system base or a base voltage).
         # Display must never error: fall back to the raw stored value, which
         # the DU conversion returns without touching any base. Only swallow
         # the engine's own ErrorExceptions — a MethodError here is a bug.
         try
-            return getter_func(ist, NU)
+            return unitful_func(ist, NU)
         catch err2
             err2 isa ErrorException || rethrow()
-            return getter_func(ist, DU)
+            return unitful_func(ist, DU)
         end
     end
 end
@@ -95,12 +112,20 @@ function Base.show(io::IO, ist::Component)
     return
 end
 
-function Base.show(io::IO, ::MIME"text/plain", ist::Component)
-    if !has_units_setting(ist)
-        @warn(
-            "Component is not attached to a System; displaying in natural units."
-        )
-    end
+"""
+Print `ist` to `io` in the same verbose form as the REPL's `text/plain` display of a
+`Component`. Pass `units` (e.g. `MW`, `SU`, `DU`, `NU`) to force every unit-converted
+field to display in that unit system instead of resolving each field's own
+`display_units_arg` default (system base when attached, natural units otherwise, and
+device base for capacity/`rating`-style fields).
+
+# Examples
+```julia
+show_component(gen)
+show_component(gen; units = MW)
+```
+"""
+function show_component(io::IO, ist::Component; units = nothing)
     print(io, summary(ist), ":")
     for name in fieldnames(typeof(ist))
         obj = getproperty(ist, name)
@@ -116,7 +141,7 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
             val = summary(getproperty(ist, name))
         elseif hasproperty(PowerSystems, getter_name)
             getter_func = getproperty(PowerSystems, getter_name)
-            val = _show_accessor_value(getter_func, ist)
+            val = _show_accessor_value(getter_func, ist; units = units)
         else
             val = getproperty(ist, name)
         end
@@ -133,6 +158,42 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
     return
 end
 
+show_component(ist::Component; units = nothing) = show_component(stdout, ist; units = units)
+
+function Base.show(io::IO, ::MIME"text/plain", ist::Component)
+    if !has_units_setting(ist)
+        @warn(
+            "Component is not attached to a System; displaying in natural units."
+        )
+    end
+    show_component(io, ist)
+    return
+end
+
+# Resolve a Vector-form `additional_columns` entry into a column accessor
+# function, mirroring IS's own field-value resolution (nested components and
+# component vectors are summarized; unit-converted fields go through
+# `_show_accessor_value` so they print with an explicit unit suffix).
+function _column_accessor(component_type::Type{<:Component}, column, units)
+    getter_name = Symbol("get_$column")
+    getter_func =
+        if hasproperty(PowerSystems, getter_name)
+            getproperty(PowerSystems, getter_name)
+        else
+            nothing
+        end
+    return function (component)
+        val = getproperty(component, column)
+        if val isa InfrastructureSystemsType ||
+           val isa Vector{<:InfrastructureSystemsComponent}
+            return summary(val)
+        elseif getter_func !== nothing
+            return _show_accessor_value(getter_func, component; units = units)
+        end
+        return val
+    end
+end
+
 """
 Show all components of the given type in a table.
 
@@ -142,24 +203,39 @@ Show all components of the given type in a table.
 - `additional_columns::Union{Dict, Vector}`: Additional columns to display.
   The Dict option is a mapping of column name to function. The function must accept
   a component.
-  The Vector option is an array of field names for the `component_type`.
+  The Vector option is an array of field names for the `component_type`; unit-converted
+  fields are printed with an explicit unit suffix (e.g. `"30.0 MW"`, `"1.0 DU"`).
 
-Extra keyword arguments are forwarded to PrettyTables.pretty_table.
+# Keyword Arguments
+- `units`: When `additional_columns` is a `Vector`, force every unit-converted column to
+  display in this unit system (e.g. `MW`, `SU`, `DU`, `NU`) instead of each field's own
+  `display_units_arg` default. Ignored for `Dict`-form `additional_columns`, whose
+  functions compute their own values.
+- Remaining keyword arguments are forwarded to `PrettyTables.pretty_table`.
 
 # Examples
 ```julia
 show_components(sys, ThermalStandard)
 show_components(sys, ThermalStandard, Dict("has_time_series" => x -> has_time_series(x)))
 show_components(sys, ThermalStandard, [:active_power, :reactive_power])
+show_components(sys, ThermalStandard, [:rating]; units = MW)
 ```
 """
 function show_components(
     sys::System,
     component_type::Type{<:Component},
     additional_columns::Union{Dict, Vector} = Dict();
+    units = nothing,
     kwargs...,
 )
-    show_components(stdout, sys, component_type, additional_columns; kwargs...)
+    show_components(
+        stdout,
+        sys,
+        component_type,
+        additional_columns;
+        units = units,
+        kwargs...,
+    )
     return
 end
 
@@ -168,13 +244,58 @@ function show_components(
     sys::System,
     component_type::Type{<:Component},
     additional_columns::Union{Dict, Vector} = Dict();
+    units = nothing,
     kwargs...,
 )
-    IS.show_components(
+    if additional_columns isa Dict
+        IS.show_components(
+            io,
+            sys.data.components,
+            component_type,
+            additional_columns;
+            kwargs...,
+        )
+        return
+    end
+
+    # Build the table ourselves (rather than delegating the Vector case to
+    # `IS.show_components`) so unit-converted columns can go through
+    # `_show_accessor_value` for an explicit unit suffix while still
+    # preserving the caller's column order — `IS.show_components`'s Dict path
+    # alphabetically sorts columns, which would silently reorder them here.
+    if !isconcretetype(component_type)
+        error("$component_type must be a concrete type")
+    end
+    column_labels = ["name"]
+    has_available = :available in fieldnames(component_type)
+    has_available && push!(column_labels, "available")
+    for column in additional_columns
+        push!(column_labels, string(column))
+    end
+
+    comps = get_components(component_type, sys)
+    data = Array{Any, 2}(undef, length(comps), length(column_labels))
+    accessors =
+        [_column_accessor(component_type, column, units) for column in additional_columns]
+    for (i, component) in enumerate(comps)
+        data[i, 1] = get_name(component)
+        j = 2
+        if has_available
+            data[i, 2] = getproperty(component, :available)
+            j += 1
+        end
+        for accessor in accessors
+            data[i, j] = accessor(component)
+            j += 1
+        end
+    end
+
+    PrettyTables.pretty_table(
         io,
-        sys.data.components,
-        component_type,
-        additional_columns;
+        data;
+        column_labels = column_labels,
+        title = IS.strip_module_name(component_type),
+        alignment = :l,
         kwargs...,
     )
     return

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -26,12 +26,16 @@ function _show_accessor_value(getter_func::Function, ist::Component; units = not
     try
         return unitful_func(ist, arg)
     catch err
+        # An explicit `units` request that fails is a caller error worth
+        # surfacing, not something display should paper over — only the
+        # trait's own automatic resolution gets the never-error fallback below.
         units !== nothing && rethrow()
         err isa ErrorException && occursin("not attached", err.msg) || rethrow()
         # NU can also fail (it may need the system base or a base voltage).
-        # Display must never error: fall back to the raw stored value, which
-        # the DU conversion returns without touching any base. Only swallow
-        # the engine's own ErrorExceptions — a MethodError here is a bug.
+        # Automatic resolution must never error: fall back to the raw stored
+        # value, which the DU conversion returns without touching any base.
+        # Only swallow the engine's own ErrorExceptions — a MethodError here
+        # is a bug.
         try
             return unitful_func(ist, NU)
         catch err2
@@ -163,7 +167,9 @@ show_component(ist::Component; units = nothing) = show_component(stdout, ist; un
 function Base.show(io::IO, ::MIME"text/plain", ist::Component)
     if !has_units_setting(ist)
         @warn(
-            "Component is not attached to a System; displaying in natural units."
+            "Component is not attached to a System; each field displays in its own " *
+            "fallback units (natural units, or device base for fields like `rating` " *
+            "that default to device-base display)."
         )
     end
     show_component(io, ist)
@@ -259,10 +265,10 @@ function show_components(
     end
 
     # Build the table ourselves (rather than delegating the Vector case to
-    # `IS.show_components`) so unit-converted columns can go through
-    # `_show_accessor_value` for an explicit unit suffix while still
-    # preserving the caller's column order — `IS.show_components`'s Dict path
-    # alphabetically sorts columns, which would silently reorder them here.
+    # `IS.show_components`) because IS's Vector-column path always resolves
+    # each column's own `display_units_arg` trait and has no `units` kwarg to
+    # override it — there's no way to force every column into one unit system
+    # (e.g. `units = MW`) through the IS entry point.
     if !isconcretetype(component_type)
         error("$component_type must be a concrete type")
     end

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -1,20 +1,15 @@
 # "smart" summary and REPL printing
 
-# The `_unitful` companion of a generated getter returns a unit-tagged value
-# (a `RelativeQuantity` printing as "1.0 DU"/"0.3 SU", or a `Unitful.Quantity`
-# printing as "30.0 MW") instead of a bare number, so display can show the
-# unit system explicitly without any extra formatting code here.
-function _unitful_getter(getter_func::Function)
-    name = Symbol(string(nameof(getter_func)), "_unitful")
-    return hasproperty(PowerSystems, name) ? getproperty(PowerSystems, name) : nothing
-end
-
 # Getters for unit-bearing fields declare their display-units choice via the
 # `IS.display_units_arg` trait (set by the struct-generator template, default
 # `SU` for converted fields unless overridden per field in the descriptor,
 # e.g. `rating` fields default to `DU`). Pass `units` to force a specific
 # display unit system (e.g. `MW`, `SU`, `DU`, `NU`) instead of resolving the
 # trait; an explicit request that fails is an error, not a silent fallback.
+# `IS.unitful_variant` resolves the getter's `_unitful` companion (a
+# `RelativeQuantity` printing as "1.0 DU"/"0.3 SU", or a `Unitful.Quantity`
+# printing as "30.0 MW") instead of a bare number, so display can show the
+# unit system explicitly without any extra formatting code here.
 function _show_accessor_value(getter_func::Function, ist::Component; units = nothing)
     trait_arg = IS.display_units_arg(getter_func, typeof(ist))
     # Fields without a units trait (e.g. `get_name`) aren't unit-convertible at
@@ -22,7 +17,7 @@ function _show_accessor_value(getter_func::Function, ist::Component; units = not
     # a getter that doesn't accept one.
     ismissing(trait_arg) && return getter_func(ist)
     arg = units === nothing ? trait_arg : units
-    unitful_func = something(_unitful_getter(getter_func), getter_func)
+    unitful_func = IS.unitful_variant(getter_func)
     try
         return unitful_func(ist, arg)
     catch err
@@ -176,30 +171,6 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
     return
 end
 
-# Resolve a Vector-form `additional_columns` entry into a column accessor
-# function, mirroring IS's own field-value resolution (nested components and
-# component vectors are summarized; unit-converted fields go through
-# `_show_accessor_value` so they print with an explicit unit suffix).
-function _column_accessor(component_type::Type{<:Component}, column, units)
-    getter_name = Symbol("get_$column")
-    getter_func =
-        if hasproperty(PowerSystems, getter_name)
-            getproperty(PowerSystems, getter_name)
-        else
-            nothing
-        end
-    return function (component)
-        val = getproperty(component, column)
-        if val isa InfrastructureSystemsType ||
-           val isa Vector{<:InfrastructureSystemsComponent}
-            return summary(val)
-        elseif getter_func !== nothing
-            return _show_accessor_value(getter_func, component; units = units)
-        end
-        return val
-    end
-end
-
 """
 Show all components of the given type in a table.
 
@@ -253,55 +224,12 @@ function show_components(
     units = nothing,
     kwargs...,
 )
-    if additional_columns isa Dict
-        IS.show_components(
-            io,
-            sys.data.components,
-            component_type,
-            additional_columns;
-            kwargs...,
-        )
-        return
-    end
-
-    # Build the table ourselves (rather than delegating the Vector case to
-    # `IS.show_components`) because IS's Vector-column path always resolves
-    # each column's own `display_units_arg` trait and has no `units` kwarg to
-    # override it — there's no way to force every column into one unit system
-    # (e.g. `units = MW`) through the IS entry point.
-    if !isconcretetype(component_type)
-        error("$component_type must be a concrete type")
-    end
-    column_labels = ["name"]
-    has_available = :available in fieldnames(component_type)
-    has_available && push!(column_labels, "available")
-    for column in additional_columns
-        push!(column_labels, string(column))
-    end
-
-    comps = get_components(component_type, sys)
-    data = Array{Any, 2}(undef, length(comps), length(column_labels))
-    accessors =
-        [_column_accessor(component_type, column, units) for column in additional_columns]
-    for (i, component) in enumerate(comps)
-        data[i, 1] = get_name(component)
-        j = 2
-        if has_available
-            data[i, 2] = getproperty(component, :available)
-            j += 1
-        end
-        for accessor in accessors
-            data[i, j] = accessor(component)
-            j += 1
-        end
-    end
-
-    PrettyTables.pretty_table(
+    IS.show_components(
         io,
-        data;
-        column_labels = column_labels,
-        title = IS.strip_module_name(component_type),
-        alignment = :l,
+        sys.data.components,
+        component_type,
+        additional_columns;
+        units = units,
         kwargs...,
     )
     return

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,7 +20,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/show-components-units-override"}
 PowerSystemCaseBuilder = {url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl", rev = "psy6"}
 
 [compat]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,7 +20,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/show-components-units-override"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "0289b7180303d166daf25fbeb7bacecf1a40b466"}
 PowerSystemCaseBuilder = {url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl", rev = "psy6"}
 
 [compat]

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -238,9 +238,11 @@ end
     end
 end
 
-@testset "_unitful_getter resolves the _unitful companion" begin
-    @test PowerSystems._unitful_getter(get_rating) === get_rating_unitful
-    @test PowerSystems._unitful_getter(get_name) === nothing
+@testset "IS.unitful_variant resolves the _unitful companion" begin
+    @test IS.unitful_variant(get_rating) === get_rating_unitful
+    # No `_unitful` companion registered for `get_name`: falls back to the
+    # getter itself rather than erroring.
+    @test IS.unitful_variant(get_name) === get_name
 end
 
 @testset "_show_accessor_value returns unit-tagged values" begin

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -199,3 +199,131 @@ end
     @test IS.display_units_arg(get_requirement_unitful, ConstantReserve{ReserveUp}) ===
           IS.SU
 end
+
+@testset "rating fields default to device-base display, unlike other converted fields" begin
+    # `rating`/`rating_primary`/`rating_secondary`/`rating_tertiary` fields default to
+    # DU regardless of System attachment (issue #1128); other `needs_conversion` fields
+    # keep the SU default (which falls back to NU when unattached, see the
+    # "Test show units" testset below).
+    rating_getters = [
+        (Line, get_rating),
+        (MonitoredLine, get_rating),
+        (PhaseShiftingTransformer, get_rating),
+        (TapTransformer, get_rating),
+        (Transformer2W, get_rating),
+        (Transformer3W, get_rating),
+        (Transformer3W, get_rating_primary),
+        (Transformer3W, get_rating_secondary),
+        (Transformer3W, get_rating_tertiary),
+        (PhaseShiftingTransformer3W, get_rating_primary),
+        (TwoTerminalVSCLine, get_rating),
+        (RenewableDispatch, get_rating),
+        (ThermalStandard, get_rating),
+        (EnergyReservoirStorage, get_rating),
+    ]
+    for (T, getter) in rating_getters
+        @test IS.display_units_arg(getter, T) === IS.DU
+        unitful_getter =
+            getproperty(PowerSystems, Symbol(string(nameof(getter)), "_unitful"))
+        @test IS.display_units_arg(unitful_getter, T) === IS.DU
+    end
+
+    non_rating_getters = [
+        (ThermalStandard, get_active_power),
+        (ThermalStandard, get_reactive_power),
+        (Line, get_r),
+    ]
+    for (T, getter) in non_rating_getters
+        @test IS.display_units_arg(getter, T) === IS.SU
+    end
+end
+
+@testset "_unitful_getter resolves the _unitful companion" begin
+    @test PowerSystems._unitful_getter(get_rating) === get_rating_unitful
+    @test PowerSystems._unitful_getter(get_name) === nothing
+end
+
+@testset "_show_accessor_value returns unit-tagged values" begin
+    sys, gen = _sys_with_thermal(; system_base = 100.0, device_base = 250.0)
+
+    # rating: always DU, regardless of System attachment.
+    rating_val = PowerSystems._show_accessor_value(get_rating, gen)
+    @test rating_val isa RelativeQuantity
+    @test rating_val == 1.0 * DU
+
+    # active_power: attached defaults to SU.
+    active_power_val = PowerSystems._show_accessor_value(get_active_power, gen)
+    @test active_power_val isa RelativeQuantity
+    @test active_power_val == 1.25 * SU
+
+    # An explicit `units` override takes precedence over the trait default.
+    forced_val = PowerSystems._show_accessor_value(get_active_power, gen; units = MW)
+    @test forced_val isa Unitful.Quantity
+    @test Unitful.ustrip(forced_val) ≈ 125.0
+
+    # Fields without a units trait (e.g. get_name) ignore `units` entirely.
+    @test PowerSystems._show_accessor_value(get_name, gen; units = MW) == "g1"
+end
+
+@testset "show_component prints explicit unit suffixes" begin
+    sys, gen = _sys_with_thermal(; system_base = 100.0, device_base = 250.0)
+
+    attached_out = sprint(show_component, gen)
+    @test occursin("active_power: 1.25 SU", attached_out)
+    @test occursin("rating: 1.0 DU", attached_out)
+
+    io = IOBuffer()
+    show_component(io, gen; units = MW)
+    forced_out = String(take!(io))
+    @test occursin("active_power: 125.0 MW", forced_out)
+    @test occursin("rating: 250.0 MW", forced_out)
+
+    bus = first(get_components(ACBus, sys))
+    detached = ThermalStandard(;
+        name = "detached", available = true, status = true, bus = bus,
+        active_power = 0.5, reactive_power = 0.1, rating = 1.0,
+        active_power_limits = (min = 0.0, max = 1.0),
+        reactive_power_limits = (min = -1.0, max = 1.0),
+        ramp_limits = nothing,
+        operation_cost = ThermalGenerationCost(nothing),
+        base_power = 250.0,
+    )
+    detached_out = sprint(show_component, detached)
+    @test occursin("active_power: 125.0 MW", detached_out) # SU fails, falls back to NU
+    @test occursin("rating: 1.0 DU", detached_out) # DU regardless of attachment
+
+    # An explicit override that fails (SU on an unattached component) errors
+    # rather than silently falling back to NU/DU.
+    @test_throws Exception show_component(devnull, detached; units = SU)
+end
+
+@testset "show_components preserves caller column order and honors units kwarg" begin
+    sys, gen = _sys_with_thermal(; system_base = 100.0, device_base = 250.0)
+
+    # Column order must reflect the caller's Vector, not alphabetical order
+    # (which would put active_power before reactive_power/rating).
+    io = IOBuffer()
+    show_components(io, sys, ThermalStandard, [:reactive_power, :rating, :active_power])
+    text = String(take!(io))
+    reactive_idx = first(findfirst("reactive_power", text))
+    rating_idx = first(findfirst("rating", text))
+    active_idx = first(findlast("active_power", text))
+    @test reactive_idx < rating_idx < active_idx
+
+    io2 = IOBuffer()
+    show_components(io2, sys, ThermalStandard, [:rating, :active_power]; units = MW)
+    text2 = String(take!(io2))
+    @test occursin("250.0 MW", text2)
+    @test occursin("125.0 MW", text2)
+
+    # Dict-form additional_columns are unaffected by the units kwarg machinery.
+    io3 = IOBuffer()
+    show_components(
+        io3,
+        sys,
+        ThermalStandard,
+        Dict("doubled" => x -> 2 * get_rating(x, DU)),
+    )
+    text3 = String(take!(io3))
+    @test occursin("2.0", text3)
+end


### PR DESCRIPTION
## Summary

Implements the display convention I proposed on #1128:

1. **Unattached components**: `needs_conversion` fields display in natural units (e.g. `active_power: 0.0 MW`) — this already fell out of the existing SU→NU fallback in `_show_accessor_value`, but is now visible since values print with an explicit unit suffix.
2. **`rating`/`rating_primary`/`rating_secondary`/`rating_tertiary` fields** now default to **device base** display (`DU`) regardless of whether the component is attached to a `System` — a device's rating isn't meaningfully rescaled by whatever system it happens to be added to. This is a per-field descriptor override (`"display_units": "DU"`), not a template change, applied to the 26 fields literally named `rating`/`rating_primary`/`rating_secondary`/`rating_tertiary` across 20 structs.
3. **Attached components**: other converted fields keep displaying in system base (`SU`), as before.
4. **Explicit unit suffixes**: every converted field now prints as `"30.0 MW"`, `"1.0 DU"`, `"0.3 SU"`, etc., instead of a bare number — achieved by displaying the getter's existing `_unitful` companion (whose `RelativeQuantity`/`Unitful.Quantity` return value already has a `Base.show` method) instead of the unit-stripped one.
5. **`units` override kwarg**: added a new `show_component(io, ist; units=nothing)` function (used internally by `Base.show(io, ::MIME"text/plain", ::Component)`) and a `units` kwarg on `show_components` to force every converted field/column to a specific unit system for that call, e.g. `show_component(gen; units = MW)` or `show_components(sys, ThermalStandard, [:rating]; units = MW)`. An explicit request that can't be satisfied (e.g. `SU` on an unattached component) throws rather than silently falling back.

## Update: `show_components`'s Vector-form columns now delegate to IS

Earlier revisions reimplemented `show_components`'s `Vector`-form table-building
directly in PSY, because `IS.show_components`'s `Vector` path had no way to (a)
force every column into one `units` system or (b) print the unit-tagged
`_unitful` companion instead of a bare number. Per review discussion below,
that duplication is now resolved upstream instead of copy-pasted:
**Sienna-Platform/InfrastructureSystems.jl#595** adds an `IS.unitful_variant`
trait and a `units` kwarg to `IS.show_components`/`_resolve_column_accessors`,
so PSY's `show_components` is back to a thin forwarding wrapper, and
`_show_accessor_value` resolves through `IS.unitful_variant` instead of a
locally-duplicated `_unitful_getter`.

**This PR now depends on IS PR #595.** `[sources]` is temporarily pinned to
the branch backing that PR (`lk/show-components-units-override`) instead of
`IS4` for development; restore the pin to `IS4` once #595 merges and IS4 picks
it up, before this PR merges into `psy6`.

## Test plan
- [x] `julia --project=test test/runtests.jl test_printing` — all new + existing assertions pass (only a pre-existing, unrelated `PowerSystemCaseBuilder` data-build error remains, confirmed present on `psy6`/`IS4` without this branch's changes too)
- [x] `julia --project=test test/runtests.jl test_base_power` — no regressions
- [x] Added test coverage: `display_units_arg` defaults for rating vs. non-rating fields, `IS.unitful_variant` resolution, `_show_accessor_value` unit-tagged return values + explicit-override error behavior, `show_component` suffix output (attached/detached/forced), and `show_components` column-order preservation + `units` kwarg + `Dict`-form regression check
- [x] IS-side: `julia --project=test test/runtests.jl` (IS) — 8672 tests, 0 failures
- [x] Basic type-stability/allocation check on the new `unitful_variant`/`units`-override paths (no `Core.Box` from the closure in `_resolve_column_accessors`; `_show_accessor_value` infers to a concrete `RelativeQuantity`/`Quantity` type and allocates the same either way)
- [x] Formatter run — no additional changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
