### PR TITLE
Fix InfrastructureSystems [sources] pin: commit SHA -> IS4 branch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "0289b7180303d166daf25fbeb7bacecf1a40b466"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
 
 [compat]
 DataStructures = "^0.19"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,7 +20,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "0289b7180303d166daf25fbeb7bacecf1a40b466"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
 PowerSystemCaseBuilder = {url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl", rev = "psy6"}
 
 [compat]


### PR DESCRIPTION
## Summary
- `Project.toml` and `test/Project.toml` had `[sources] InfrastructureSystems` pinned to a fixed commit SHA (`0289b7180303d166daf25fbeb7bacecf1a40b466`) instead of the `IS4` branch.
- Per the co-development convention (see repo `CLAUDE.md`), PSY should pin IS via `[sources]` with `rev = "IS4"` during development, so IS-side fixes on that branch are picked up automatically.
- This PR restores the branch pin in both files.

## Test plan
- [ ] `julia --project=test -e 'using Pkg; Pkg.instantiate()'` resolves against `IS4` HEAD
- [ ] `julia --project=test test/runtests.jl` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)