### PR TITLE
remove last pieces of stateful units system

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "0289b7180303d166daf25fbeb7bacecf1a40b466"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "units-refactor-is4"}
 
 [compat]
 DataStructures = "^0.19"

--- a/docs/src/explanation/per_unit.md
+++ b/docs/src/explanation/per_unit.md
@@ -48,7 +48,10 @@ clear error instead of producing a silently wrong number.
 
 ## Migration guide: stateful → explicit units
 
-Code written against PowerSystems 5 used a mutable system-wide unit setting:
+Code written against PowerSystems 5 used a mutable system-wide unit setting. That entire
+stateful-override mechanism (`set_units_base_system!`, `with_units_base`, `get_units_base`)
+has been removed — it caused real bugs and, once units became explicit at every call
+site, had no effect on any conversion result to begin with.
 
 | PowerSystems 5 (stateful)                                                       | PowerSystems 6 (explicit)                                                                       |
 |:------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------- |
@@ -63,9 +66,6 @@ Notes:
   - Time-series retrieval passes a units argument to two-argument scaling-factor
     multipliers; the default for PowerSystems components is `SU`. One-argument multipliers
     (custom closures) are still invoked with the owner only.
-  - The `UnitSystem` enum (`get_units_base`, `set_units_base_system!`,
-    `with_units_base`) is system metadata only (shown in the `System` summary); it does
-    not affect any conversion.
   - `CostCurve`/`FuelCurve` take the marker instances (`NaturalUnit()`,
     `SystemBaseUnit()`, `DeviceBaseUnit()`) for `power_units`.
 
@@ -85,7 +85,7 @@ problems won't converge when using natural units (for example in
 ## Detachment
 
 Unit-aware getters require the component to be attached to a `System`. The system base power
-is resolved at call time through the component's internal `units_info` slot, which is
+is resolved at call time through the component's internal `base_value` slot, which is
 populated by `add_component!` and cleared by `remove_component!`. Calling a unit-aware
 getter on a detached component raises an error:
 
@@ -103,22 +103,11 @@ meaningless without a known base.
 
 ## The system base is immutable
 
-`SystemUnitsSettings.base_value` is a `const` field set at `System` construction from the
-`base_power` argument. It cannot be changed after construction. `set_units_base_system!`
-changes only the display label stored in `unit_system` — it has no effect on what any
-getter returns:
-
-```julia
-sys = System(100.0)                          # base_power = 100 MVA
-add_component!(sys, gen)
-
-before = get_active_power(gen, SU)
-set_units_base_system!(sys, "NATURAL_UNITS") # display label only
-@assert get_active_power(gen, SU) == before  # conversion result is unchanged
-```
-
-`get_units_base` and `with_units_base` read and temporarily set the same display label.
-None of them affect conversion results.
+`System.base_power` is set once at construction (from the `base_power` argument) and
+cannot be changed afterward — there is no `set_base_power!(::System, ...)`. Each attached
+component's knowledge of that value is a plain `Float64`, kept up to date by
+`add_component!`/`remove_component!`; there is no mutable, system-wide unit setting that
+could change what a getter returns.
 
 ## Conversion errors
 

--- a/docs/src/how_to/use_context_managers.md
+++ b/docs/src/how_to/use_context_managers.md
@@ -10,73 +10,17 @@ ensuring cleanup even if errors occur.
 
 ## Available Context Managers
 
-PowerSystems provides three main context managers:
+PowerSystems provides two main context managers:
 
- 1. [`with_units_base`](@ref) - Temporarily change unit system for getting/setting component data
- 2. [`begin_supplemental_attributes_update`](@ref) - Optimize bulk addition/removal of supplemental attributes
- 3. [`begin_time_series_update`](@ref) - Optimize bulk addition of time series data
-
-## Using `with_units_base`
-
-The [`with_units_base`](@ref) function temporarily changes the [unit system](@ref per_unit)
-for a `System` or `Component`, executes your code, then automatically restores the original
-unit system. This is useful when you need to retrieve or set values in a specific unit system
-without permanently changing the system's configuration.
+ 1. [`begin_supplemental_attributes_update`](@ref) - Optimize bulk addition/removal of supplemental attributes
+ 2. [`begin_time_series_update`](@ref) - Optimize bulk addition of time series data
 
 !!! note
 
-    You can specify the unit system using either the `UnitSystem` enum (e.g.,
-    `UnitSystem.NATURAL_UNITS`) or a string (e.g., `"NATURAL_UNITS"`). Both forms are
-    supported and equivalent.
-
-### Example: Getting Component Data in Natural Units
-
-```julia
-using PowerSystems
-using PowerSystemCaseBuilder
-
-# Load a system
-sys = build_system(PSISystems, "c_sys5_pjm")
-gen = first(get_components(ThermalStandard, sys))
-
-# Get active power in natural units (MW) regardless of system's unit base
-active_power_mw = with_units_base(sys, UnitSystem.NATURAL_UNITS) do
-    get_active_power(gen)
-end
-
-# The system's unit base is automatically restored after the block
-```
-
-### Example: Setting Multiple Component Values in Natural Units
-
-```julia
-# Temporarily change units to add/modify multiple components in natural units
-with_units_base(sys, "NATURAL_UNITS") do
-    for gen in get_components(ThermalStandard, sys)
-        # Set values in MW, MVA, etc.
-        set_active_power!(gen, 150.0)  # MW
-        set_rating!(gen, 200.0)        # MVA
-    end
-end
-
-# System automatically returns to original unit base
-```
-
-### Component-Level Context Manager
-
-You can also use `with_units_base` on individual components:
-
-```julia
-active_power_mw = with_units_base(gen, UnitSystem.NATURAL_UNITS) do
-    get_active_power(gen)
-end
-```
-
-!!! tip
-
-    The `with_units_base` context manager is particularly useful when you need to work with
-    data in natural units (MW, MVA, etc.) while keeping your system configured in per-unit
-    for optimization or simulation purposes.
+    Earlier versions of PowerSystems also provided a `with_units_base` context manager for
+    temporarily changing a stateful, system-wide unit setting. Units are explicit at every
+    call site now (see [Per-unit Conventions](@ref per_unit)), so that mechanism has been
+    removed.
 
 ## Using `begin_supplemental_attributes_update`
 
@@ -223,11 +167,10 @@ end
  3. **Nested context managers**: You can nest context managers if needed:
 
     ```julia
-    with_units_base(sys, "NATURAL_UNITS") do
+    begin_supplemental_attributes_update(sys) do
         begin_time_series_update(sys) do
-            # Add time series with natural unit scaling factors
             for gen in get_components(Generator, sys)
-                # ... add time series ...
+                # ... add supplemental attributes and time series ...
             end
         end
     end

--- a/docs/src/tutorials/creating_system.jl
+++ b/docs/src/tutorials/creating_system.jl
@@ -228,10 +228,8 @@ get_bus(retrieved_component)
 #     below.
 
 # ## Per-Unit Conversions with Explicit Units
-# Now, let's use a getter function to look up the solar generator's `rating`. As of
-# PowerSystems 6, every unit-bearing accessor takes an explicit `units` argument; there is no
-# system-wide setting that changes what getters return (see [Per-unit Conventions](@ref per_unit)).
-# Ask for the rating in **system base** (`SU`):
+# Now, let's use a getter function to look up the solar generator's `rating`
+# Ask for the rating in **system base**, `SU` (see [Per-unit Conventions](@ref per_unit)).
 
 get_rating(retrieved_component, SU)
 
@@ -254,18 +252,11 @@ get_rating(retrieved_component, DU)
 # This reads 1.0 — 5.0 MVA per-unitized by the device's own `base_power` of 5.0 MVA, which is
 # the format we used to originally define the device.
 #
-# The legacy `UnitSystem` enum (`get_units_base`, `set_units_base_system!`, `with_units_base`)
-# still exists, but it is now **system metadata only**: it is shown in the `System` summary and
-# no longer changes what the accessors return.
-
-get_units_base(sys)
-
-# Recall that you can always print the [`System`](@ref) to check its settings, including this
-# units-base metadata:
+# Units are explicit at every call site — there is no stateful, system-wide unit setting to
+# check or change. Recall that you can always print the [`System`](@ref) to check its
+# settings, including its base power:
 
 sys
-
-# See the units base is printed as one of the [`System`](@ref) properties.
 
 # ## Next Steps
 # In this tutorial, you manually created a power [`System`](@ref), added and then retrieved its components,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -553,8 +553,6 @@ export get_description
 export set_description!
 export get_frequency
 export get_frequency_droop
-export set_units_base_system!
-export with_units_base
 export to_json
 export from_json
 export serialize
@@ -577,7 +575,6 @@ export get_filter
 export get_V_ref
 export get_P_ref
 export get_saturation_coeffs
-export get_units_base
 export get_runchecks
 export get_from_to_flow_limit
 export get_to_from_flow_limit
@@ -747,8 +744,8 @@ import InfrastructureSystems:
     get_next_time,
     reset!,
     has_supplemental_attributes,
-    get_units_info,
-    set_units_info!,
+    get_base_value,
+    set_base_value!,
     to_json,
     from_json,
     serialize,
@@ -760,7 +757,6 @@ import InfrastructureSystems:
     NormalizationFactor,
     NormalizationTypes,
     UnitSystem,
-    SystemUnitsSettings,
     open_file_logger,
     make_logging_config_file,
     validate_struct,

--- a/src/base.jl
+++ b/src/base.jl
@@ -9,7 +9,6 @@ const SYSTEM_KWARGS = Set((
     :time_series_directory,
     :time_series_in_memory,
     :time_series_read_only,
-    :unit_system,
     :enable_compression,
     :compression,
     :name,
@@ -61,9 +60,6 @@ System(; kwargs...)
 - `enable_compression::Bool=false`: Enable compression of time series data in HDF5.
 - `compression::CompressionSettings`: Allows customization of HDF5 compression settings.
 - `config_path::String`: specify path to validation config file
-- `unit_system::String`: (Default = `"SYSTEM_BASE"`) Set the unit system for
-    [per-unitization](@ref per_unit) while getting and setting data (`"SYSTEM_BASE"`,
-        `"DEVICE_BASE"`, or `"NATURAL_UNITS"`)
 - `internal::IS.InfrastructureSystemsInternal`: Internal structure for [`InfrastructureSystems.jl`](https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/). This is used only during JSON de-seralization, do not pass it when building a `System` manually.
 
 By default, time series data is stored in an HDF5 file in the tmp file system to prevent
@@ -100,14 +96,14 @@ struct System <: IS.ComponentContainer
     frequency::Float64 # [Hz]
     bus_numbers::Set{Int}
     runchecks::Base.RefValue{Bool}
-    units_settings::SystemUnitsSettings
+    base_power::Float64
     time_series_directory::Union{Nothing, String}
     metadata::SystemMetadata
     internal::IS.InfrastructureSystemsInternal
 
     function System(
         data,
-        units_settings::SystemUnitsSettings,
+        base_power::Float64,
         internal::IS.InfrastructureSystemsInternal;
         runchecks = true,
         frequency = DEFAULT_SYSTEM_FREQUENCY,
@@ -124,18 +120,13 @@ struct System <: IS.ComponentContainer
         # elsewhere.
         unsupported = setdiff(keys(kwargs), SYSTEM_KWARGS)
         !isempty(unsupported) && error("Unsupported kwargs = $unsupported")
-        if !isnothing(get(kwargs, :unit_system, nothing))
-            @warn(
-                "unit_system kwarg ignored. The value in SystemUnitsSetting takes precedence"
-            )
-        end
         bus_numbers = Set(get_number.(IS.get_components(ACBus, data)))
         return new(
             data,
             frequency,
             bus_numbers,
             Base.RefValue{Bool}(runchecks),
-            units_settings,
+            base_power,
             time_series_directory,
             SystemMetadata(name, description),
             internal,
@@ -144,10 +135,7 @@ struct System <: IS.ComponentContainer
 end
 
 function System(data, base_power::Number, internal; kwargs...)
-    unit_system_ = get(kwargs, :unit_system, "SYSTEM_BASE")
-    unit_system = UNIT_SYSTEM_MAPPING[unit_system_]
-    units_settings = SystemUnitsSettings(base_power, unit_system)
-    return System(data, units_settings, internal; kwargs...)
+    return System(data, Float64(base_power), internal; kwargs...)
 end
 
 """Construct an empty `System`. Useful for building a System while parsing raw data."""
@@ -451,7 +439,7 @@ get_ext(sys::System) = IS.get_ext(sys.internal)
 """
 Unitless system base power (MVA) — internal anchor for unit conversion.
 """
-_get_base_power(sys::System) = sys.units_settings.base_value
+_get_base_power(sys::System) = sys.base_power
 
 """
 Return the system's base power as a bare `Float64` in natural units (MVA).
@@ -501,125 +489,14 @@ end
 
 function set_units_setting!(
     component::Component,
-    settings::Union{SystemUnitsSettings, Nothing},
+    value::Union{Float64, Nothing},
 )
-    set_units_info!(get_internal(component), settings)
+    IS.set_base_value!(component, value)
     return
-end
-
-function _set_units_base!(system::System, settings::UnitSystem)
-    to_change = (system.units_settings.unit_system != settings)
-    to_change && (system.units_settings.unit_system = settings)
-    return (to_change, settings)
-end
-
-_set_units_base!(system::System, settings::String) =
-    _set_units_base!(system::System, UNIT_SYSTEM_MAPPING[uppercase(settings)])
-
-"""
-Set the system's stored [units base](@ref per_unit) setting. This is system
-metadata only; the unit-aware getters and setters take their units explicitly.
-
-# Examples
-```julia
-set_units_base_system!(sys, "NATURAL_UNITS")
-```
-```julia
-set_units_base_system!(sys, UnitSystem.SYSTEM_BASE)
-```
-"""
-function set_units_base_system!(system::System, units::Union{UnitSystem, String})
-    changed, new_units = _set_units_base!(system::System, units)
-    changed && @info "Unit System changed to $new_units"
-    return
-end
-
-_get_units_base(system::System) = system.units_settings.unit_system
-
-"""
-Get the system's stored [units base](@ref per_unit) setting.
-"""
-function get_units_base(system::System)
-    return string(_get_units_base(system))
-end
-
-"""
-A "context manager" that temporarily sets the [`System`](@ref)'s [units base](@ref per_unit)
-setting to the given value, executes the function, then restores the previous setting.
-
-Note that the unit-aware getters and setters take their units explicitly (e.g.
-`get_active_power(gen, NU)`); this setting only affects code that reads the system's
-configured units base via [`get_units_base`](@ref).
-
-# Examples
-```julia
-with_units_base(sys, UnitSystem.NATURAL_UNITS) do
-    get_units_base(sys)  # "NATURAL_UNITS" within the block; restored afterward
-end
-```
-"""
-function with_units_base(f::Function, sys::System, units::Union{UnitSystem, String})
-    old_units = _get_units_base(sys)
-    _set_units_base!(sys, units)
-    try
-        f()
-    finally
-        _set_units_base!(sys, old_units)
-    end
-end
-
-_set_units_base!(c::Component, settings::String) =
-    _set_units_base!(c::Component, UNIT_SYSTEM_MAPPING[uppercase(settings)])
-
-function _set_units_base!(c::Component, settings::UnitSystem)
-    units_info = IS.get_units_info(get_internal(c))
-    isnothing(units_info) && error("Component $(get_name(c)) is not attached to a system.")
-    old_base_value = units_info.base_value
-    set_units_setting!(
-        c,
-        SystemUnitsSettings(old_base_value, settings),
-    )
-    return
-end
-
-"""
-A "context manager" that temporarily sets the [`Component`](@ref)'s [units base](@ref per_unit)
-setting to the given value, executes the function, then restores the previous setting.
-
-Note that the unit-aware getters and setters take their units explicitly (e.g.
-`get_active_power(component, NU)`); this setting only affects code that reads the
-component's configured units base.
-
-# Examples
-```julia
-with_units_base(component, UnitSystem.NATURAL_UNITS) do
-    get_units_setting(component)  # carries NATURAL_UNITS within the block; restored afterward
-end
-```
-"""
-function with_units_base(f::Function, c::Component, units::Union{UnitSystem, String})
-    internal = get_internal(c)
-    old_units_info = IS.get_units_info(internal)
-    _set_units_base!(c, units)
-    temp_units_info = IS.get_units_info(internal)
-    try
-        f()
-    finally
-        # Only restore if units_info is still temp_units_info.
-        # The user may have changed it in the function body, e.g. by removing the component
-        # and attaching it to a different system.
-        IS.get_units_info(internal) === temp_units_info || error(
-            "Units info was modified during with_units_base.")
-        IS.set_units_info!(internal, old_units_info)
-    end
-end
-
-function get_units_setting(component::T) where {T <: Component}
-    return get_units_info(get_internal(component))
 end
 
 function has_units_setting(component::T) where {T <: Component}
-    return !isnothing(get_units_setting(component))
+    return !isnothing(IS.get_base_value(component))
 end
 
 """
@@ -673,7 +550,7 @@ function add_component!(
     skip_validation = false,
     kwargs...,
 ) where {T <: Component}
-    set_units_setting!(component, sys.units_settings)
+    set_units_setting!(component, sys.base_power)
     @assert has_units_setting(component)
 
     check_topology(sys, component)
@@ -831,7 +708,7 @@ function _add_service!(
         throw_if_not_attached(device, sys)
     end
 
-    set_units_setting!(service, sys.units_settings)
+    set_units_setting!(service, sys.base_power)
     # Since this isn't atomic, order is important. Add to system before adding to devices.
     IS.add_component!(sys.data, service; skip_validation = skip_validation, kwargs...)
 
@@ -879,7 +756,7 @@ function _add_service!(
 )
     skip_validation = _validate_or_skip!(sys, service, skip_validation)
     _validate_types_for_interface(sys, contributing_devices)
-    set_units_setting!(service, sys.units_settings)
+    set_units_setting!(service, sys.base_power)
     # Since this isn't atomic, order is important. Add to system before adding to devices.
     IS.add_component!(sys.data, service; skip_validation = skip_validation, kwargs...)
 
@@ -897,7 +774,7 @@ function _add_service!(
 )
     skip_validation = _validate_or_skip!(sys, service, skip_validation)
     _validate_types_for_agc(contributing_devices)
-    set_units_setting!(service, sys.units_settings)
+    set_units_setting!(service, sys.base_power)
     # Since this isn't atomic, order is important. Add to system before adding to devices.
     IS.add_component!(sys.data, service; skip_validation = skip_validation, kwargs...)
 
@@ -967,7 +844,7 @@ function add_service!(
         throw_if_not_attached(_service, sys)
     end
 
-    set_units_setting!(service, sys.units_settings)
+    set_units_setting!(service, sys.base_power)
     IS.add_component!(sys.data, service; skip_validation = skip_validation, kwargs...)
     return
 end
@@ -1003,7 +880,7 @@ function add_service!(
     skip_validation = _validate_or_skip!(sys, service, skip_validation)
     set_contributing_services!(sys, service, contributing_services)
 
-    set_units_setting!(service, sys.units_settings)
+    set_units_setting!(service, sys.base_power)
     IS.add_component!(sys.data, service; skip_validation = skip_validation, kwargs...)
     return
 end
@@ -1220,7 +1097,7 @@ Throws an exception if the component is attached to a system.
 """
 function set_name!(component::Component, name::AbstractString)
     # The units setting is nothing until the component is attached to the system.
-    if get_units_setting(component) !== nothing
+    if has_units_setting(component)
         # This is not allowed because components are stored in the system in a Dict
         # keyed by name.
         error(
@@ -1233,7 +1110,7 @@ function set_name!(component::Component, name::AbstractString)
 end
 
 function clear_units!(component::Component)
-    IS.set_units_info!(get_internal(component), nothing)
+    set_units_setting!(component, nothing)
     return
 end
 
@@ -2462,7 +2339,7 @@ function from_dict(
     # already handled here.
     handled = (
         "data",
-        "units_settings",
+        "base_power",
         "bus_numbers",
         "internal",
         "data_format_version",
@@ -2480,7 +2357,7 @@ function from_dict(
         parsed_kwargs[:runchecks] = kwargs[:runchecks]
     end
 
-    units = IS.deserialize(SystemUnitsSettings, raw["units_settings"])
+    base_power = raw["base_power"]
     data = IS.deserialize(
         IS.SystemData,
         raw["data"];
@@ -2494,7 +2371,7 @@ function from_dict(
     internal = IS.deserialize(InfrastructureSystemsInternal, raw["internal"])
     sys = System(
         data,
-        units,
+        base_power,
         internal;
         name = name,
         description = description,
@@ -3340,7 +3217,7 @@ function _copy_internal_for_conversion(component::Component)
     internal = get_internal(component)
     return InfrastructureSystemsInternal(;
         uuid = deepcopy(internal.uuid),
-        units_info = deepcopy(IS.get_units_info(internal)),
+        base_value = IS.get_base_value(internal),
         shared_system_references = nothing,
         ext = deepcopy(internal.ext),
     )
@@ -3417,17 +3294,13 @@ function fast_deepcopy_system(
     )
     new_sys = System(
         new_data,
-        deepcopy(sys.units_settings),
+        sys.base_power,
         deepcopy(sys.internal);
         runchecks = deepcopy(sys.runchecks[]),
         frequency = deepcopy(sys.frequency),
         time_series_directory = deepcopy(sys.time_series_directory),
         name = deepcopy(sys.metadata.name),
         description = deepcopy(sys.metadata.description))
-    # deepcopying sys.data separately from sys.units_settings broke the shared units references, so we have to fix them here
-    for comp in iterate_components(new_sys)
-        IS.set_units_info!(get_internal(comp), new_sys.units_settings)
-    end
     return new_sys
 end
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -2934,6 +2934,7 @@ function handle_component_removal!(sys::System, component::StaticInjectionSubsys
     _handle_component_removal_common!(component)
     subcomponents = collect(get_subcomponents(component))
     for subcomponent in subcomponents
+        clear_units!(subcomponent)
         IS.remove_masked_component!(sys.data, subcomponent)
     end
 end

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -1,10 +1,3 @@
-const UNIT_SYSTEM_MAPPING = Dict(
-    "SYSTEM_BASE" => IS.UnitSystem.SYSTEM_BASE,
-    "DEVICE_BASE" => IS.UnitSystem.DEVICE_BASE,
-    "NATURAL_UNITS" => IS.UnitSystem.NATURAL_UNITS,
-    "NA" => nothing,
-)
-
 const MinMax = NamedTuple{(:min, :max), Tuple{Float64, Float64}}
 const UpDown = NamedTuple{(:up, :down), Tuple{Float64, Float64}}
 const StartUpShutDown = NamedTuple{(:startup, :shutdown), Tuple{Float64, Float64}}

--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -1,7 +1,7 @@
 @inline function _get_system_base_power(c::Component)
-    units_info = IS.get_units_info(get_internal(c))
-    isnothing(units_info) && error("Component $(get_name(c)) is not attached to a system.")
-    return units_info.base_value
+    base_value = IS.get_base_value(c)
+    isnothing(base_value) && error("Component $(get_name(c)) is not attached to a system.")
+    return base_value
 end
 
 """

--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -474,11 +474,11 @@ end
 
 function set_units_setting!(
     value::HybridSystem,
-    settings::Union{SystemUnitsSettings, Nothing},
+    settings::Union{Float64, Nothing},
 )
-    set_units_info!(get_internal(value), settings)
+    IS.set_base_value!(value, settings)
     for component in _get_components(value)
-        set_units_info!(get_internal(component), settings)
+        IS.set_base_value!(component, settings)
     end
     return
 end

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -130,10 +130,9 @@ function show_component(io::IO, ist::Component; units = nothing)
         obj = getproperty(ist, name)
         getter_name = Symbol("get_$name")
         if obj isa InfrastructureSystemsInternal
-            units_info = IS.get_units_info(obj)
-            if !isnothing(units_info)
-                print(io, "\n   ")
-                show(io, MIME"text/plain"(), units_info)
+            base_value = IS.get_base_value(obj)
+            if !isnothing(base_value)
+                print(io, "\n   System base power (MVA): ", base_value)
             end
             continue
         elseif obj isa InfrastructureSystemsType ||

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -46,7 +46,6 @@ function show_system_table(io::IO, sys::System; kwargs...)
     table = [
         "Name" isnothing(get_name(sys)) ? "" : get_name(sys)
         "Description" isnothing(get_description(sys)) ? "" : get_description(sys)
-        "System Units Base" string(get_units_base(sys))
         "Base Power" string(_get_base_power(sys))
         "Base Frequency" string(get_frequency(sys))
         "Num Components" string(num_components)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,7 +20,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "0289b7180303d166daf25fbeb7bacecf1a40b466"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "units-refactor-is4"}
 PowerSystemCaseBuilder = {url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl", rev = "psy6"}
 
 [compat]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -21,7 +21,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
 InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "units-refactor-is4"}
-PowerSystemCaseBuilder = {url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl", rev = "psy6"}
+PowerSystemCaseBuilder = {url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl", rev = "fix/remove-set-units-base-system-call"}
 
 [compat]
 InfrastructureSystems = "3"

--- a/test/test_base_power.jl
+++ b/test/test_base_power.jl
@@ -186,10 +186,9 @@ end
 @testset "Unit-aware set_base_power_{12,23,13}! on ThreeWindingTransformer" begin
     system_base = 100.0
     xfmr = Transformer3W(nothing)
-    # Stand in for system attachment: set units_info so SU dispatch can read the
+    # Stand in for system attachment: set base_value so SU dispatch can read the
     # system base without building a full three-bus star-topology system.
-    IS.get_internal(xfmr).units_info =
-        PSY.SystemUnitsSettings(system_base, IS.UnitSystem.SYSTEM_BASE)
+    IS.set_base_value!(xfmr, system_base)
 
     for (setter, getter, internal) in (
         (set_base_power_12!, get_base_power_12, PSY._get_base_power_12),
@@ -215,8 +214,7 @@ end
     system_base = 100.0
     device_base = 250.0
     xfmr = Transformer3W(nothing)
-    IS.get_internal(xfmr).units_info =
-        PSY.SystemUnitsSettings(system_base, IS.UnitSystem.SYSTEM_BASE)
+    IS.set_base_value!(xfmr, system_base)
 
     for (setter, getter, getter_unitful) in (
         (set_base_power_12!, get_base_power_12, get_base_power_12_unitful),
@@ -254,13 +252,12 @@ end
     end
 end
 
-# Detached Transformer3W with seeded units_info (system base 100), distinct
+# Detached Transformer3W with seeded base_value (system base 100), distinct
 # per-winding base powers (15/20/25 MVA), and base voltages (230/138/69 kV) —
 # deliberately all different so a wrong-base selection is caught.
 function _make_test_3w_xfmr(; system_base = 100.0)
     xfmr = Transformer3W(nothing)
-    IS.get_internal(xfmr).units_info =
-        PSY.SystemUnitsSettings(system_base, IS.UnitSystem.SYSTEM_BASE)
+    IS.set_base_value!(xfmr, system_base)
     set_base_power_12!(xfmr, 15.0)
     set_base_power_23!(xfmr, 20.0)
     set_base_power_13!(xfmr, 25.0)
@@ -400,12 +397,4 @@ end
     @test_logs (:warn, "Invalid range") match_mode = :any add_component!(sys, gen)
     gen2 = thermal_with_base_power(bus, "Test Gen with Non-Zero Base Power", 100.0)
     @test_nowarn add_component!(sys, gen2)
-    # uncomment if we correct to non-zero base power.
-    #=
-    with_units_base(sys, "SYSTEM_BASE") do
-        gen_added = PSY.get_component(PSY.ThermalStandard, sys, "Test Gen with Zero Base Power")
-        PSY.set_reactive_power!(gen_added, 0.0)
-        @test !isnan(PSY.get_reactive_power(gen_added))
-    end
-    =#
 end

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -624,9 +624,10 @@ end
             ),
         )
 
-        # We copy the SystemData separately from the other System fields, so the egal-ity of these references could get broken
+        # base_power is a plain Float64 now (not a shared mutable object), so equality
+        # rather than identity is the correct check here.
         generator = get_component(ThermalStandard, sys2, "322_CT_6")
-        @test sys2.units_settings === generator.internal.units_info
+        @test sys2.base_power == generator.internal.base_value
     end
 end
 

--- a/test/test_units.jl
+++ b/test/test_units.jl
@@ -215,7 +215,7 @@ end
     @test sprint(show, 1.0MVA) == "1.0 MVA"
 end
 
-@testset "units_info lifecycle" begin
+@testset "base_value lifecycle" begin
     # sys_a: 100 MVA base; gen stored at device base (250 MVA default from _sys_with_thermal)
     sys_a, gen = _sys_with_thermal()
     p_a = get_active_power(gen, SU)
@@ -236,23 +236,50 @@ end
     @test get_active_power(gen, SU) ≈ 2.0 * p_a
 end
 
-@testset "deepcopy rebinds units_info to the copy" begin
+@testset "deepcopy preserves each component's base value" begin
     sys, gen = _sys_with_thermal()
 
     sys2 = deepcopy(sys)
     gen2 = get_component(ThermalStandard, sys2, get_name(gen))
-    @test IS.get_units_info(IS.get_internal(gen2)) === sys2.units_settings
-    @test IS.get_units_info(IS.get_internal(gen2)) !== sys.units_settings
+    @test IS.get_base_value(gen2) == sys2.base_power
+    @test IS.get_base_value(gen2) == IS.get_base_value(gen)
 end
 
-@testset "deserialized components share the system settings object" begin
+@testset "deserialized components carry the system's base value" begin
     sys, gen = _sys_with_thermal()
     path = joinpath(mktempdir(), "sys.json")
     to_json(sys, path)
     sys2 = System(path)
     gen2 = get_component(ThermalStandard, sys2, get_name(gen))
-    @test IS.get_units_info(IS.get_internal(gen2)) === sys2.units_settings
+    @test IS.get_base_value(gen2) == sys2.base_power
     @test get_active_power(gen2, SU) ≈ get_active_power(gen, SU)
+end
+
+@testset "HybridSystem attach/detach propagates base value to subcomponents" begin
+    sys = System(100.0)
+    bus = ACBus(;
+        number = 1, name = "b1", available = true,
+        bustype = ACBusTypes.REF, angle = 0.0, magnitude = 1.0,
+        voltage_limits = (min = 0.9, max = 1.1), base_voltage = 138.0,
+    )
+    add_component!(sys, bus)
+    h_sys = HybridSystem(;
+        name = "h1", available = true, status = true, bus = bus,
+        active_power = 1.0, reactive_power = 1.0,
+        thermal_unit = ThermalStandard(nothing),
+        electric_load = PowerLoad(nothing),
+        storage = EnergyReservoirStorage(nothing),
+        renewable_unit = RenewableDispatch(nothing),
+        base_power = 100.0,
+        operation_cost = MarketBidCost(nothing),
+    )
+    subcomponents = collect(PSY._get_components(h_sys))
+    @test length(subcomponents) == 4
+    add_component!(sys, h_sys)
+    @test all(c -> IS.get_base_value(c) !== nothing, subcomponents)
+
+    remove_component!(sys, h_sys)
+    @test all(c -> IS.get_base_value(c) === nothing, subcomponents)
 end
 
 @testset "convert_units rejects marker/value mismatches" begin
@@ -304,10 +331,7 @@ end
 # only includes test_units.jl itself).
 function _local_make_test_3w_xfmr(; system_base = 100.0)
     xfmr = Transformer3W(nothing)
-    IS.set_units_info!(
-        IS.get_internal(xfmr),
-        PSY.SystemUnitsSettings(system_base, IS.UnitSystem.SYSTEM_BASE),
-    )
+    IS.set_base_value!(xfmr, system_base)
     set_base_power_12!(xfmr, 15.0)
     set_base_power_23!(xfmr, 20.0)
     set_base_power_13!(xfmr, 25.0)
@@ -352,15 +376,6 @@ end
     @inferred set_active_power!(gen, 0.4 * SU)
 end
 
-@testset "conversions ignore the display unit_system" begin
-    sys, gen = _sys_with_thermal()
-
-    before = get_active_power(gen, SU)
-    set_units_base_system!(sys, "NATURAL_UNITS")
-    @test get_active_power(gen, SU) == before
-    set_units_base_system!(sys, "SYSTEM_BASE")
-end
-
 @testset "time series multiplier units default to SU" begin
     sys, gen = _sys_with_thermal()
 
@@ -386,10 +401,4 @@ end
 
     base_nu = get_max_active_power(gen, NU) / get_max_active_power(gen, SU)
     @test vals_nu ≈ vals_su .* base_nu
-end
-
-@testset "_set_units_base! errors on detached component" begin
-    sys, gen = _sys_with_thermal()
-    remove_component!(sys, gen)
-    @test_throws ErrorException with_units_base(() -> nothing, gen, "NATURAL_UNITS")
 end


### PR DESCRIPTION
Right now, `internal` still carries around  a `units_setting` (two fields, `units_info` and `base_value`), even though the stateful `units_info` is no longer wired up to anything. This PR replaces that with a single `base_value::Union{Float64, Nothing}` for the system's base power (or `nothing` if not attached).

Claude also discovered that when we remove a `HybridSystem` from a system, we remove its components, but fail to clear their units settings. Is that purposeful? Seems like a bug to me, but I'm not familiar with `HybridSystem` components.

Requires IS [#596](https://github.com/Sienna-Platform/InfrastructureSystems.jl/pull/596) and PSB PR [#206](https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl/pull/206).