### PR TITLE
Make InterconnectingConverter DC current unit-aware (power-equivalent on base_power)

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -5231,16 +5231,20 @@
                 },
                 {
                     "name": "dc_current",
-                    "comment": "DC current (A) on the converter",
+                    "comment": "DC current on the converter, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)",
                     "null_value": "0.0",
                     "data_type": "Float64",
+                    "needs_conversion": true,
+                    "conversion_unit": ":mva",
                     "default": "0.0"
                 },
                 {
                     "name": "max_dc_current",
-                    "comment": "Maximum stable dc current limits (A)",
+                    "comment": "Maximum stable DC current limit, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)",
                     "null_value": "0.0",
                     "data_type": "Float64",
+                    "needs_conversion": true,
+                    "conversion_unit": ":mva",
                     "default": "1e8"
                 },
                 {

--- a/src/models/generated/InterconnectingConverter.jl
+++ b/src/models/generated/InterconnectingConverter.jl
@@ -41,8 +41,8 @@ Interconnecting Power Converter (IPC) for transforming power from an ACBus to a 
 - `active_power_limits::MinMax`: Minimum and maximum stable active power levels (MW)
 - `base_power::Float64`: Base power of the converter in MVA, validation range: `(0.0001, nothing)`
 - `reactive_power_limits::Union{Nothing, MinMax}`: (default: `nothing`) Minimum and maximum reactive power limits. Set to `Nothing` if not applicable
-- `dc_current::Float64`: (default: `0.0`) DC current (A) on the converter
-- `max_dc_current::Float64`: (default: `1e8`) Maximum stable dc current limits (A)
+- `dc_current::Float64`: (default: `0.0`) DC current on the converter, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)
+- `max_dc_current::Float64`: (default: `1e8`) Maximum stable DC current limit, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)
 - `loss_function::Union{LinearCurve, QuadraticCurve}`: (default: `LinearCurve(0.0)`) Linear or quadratic loss function with respect to the converter current
 - `dc_control::VSCDCControlModes`: (default: `VSCDCControlModes.DC_VOLTAGE`) DC-side control mode of the converter; see [`VSCDCControlModes`](@ref).
 - `ac_control::VSCACControlModes`: (default: `VSCACControlModes.AC_REACTIVE_POWER`) AC-side control mode of the converter; see [`VSCACControlModes`](@ref).
@@ -73,9 +73,9 @@ mutable struct InterconnectingConverter <: StaticInjection
     base_power::Float64
     "Minimum and maximum reactive power limits. Set to `Nothing` if not applicable"
     reactive_power_limits::Union{Nothing, MinMax}
-    "DC current (A) on the converter"
+    "DC current on the converter, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)"
     dc_current::Float64
-    "Maximum stable dc current limits (A)"
+    "Maximum stable DC current limit, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)"
     max_dc_current::Float64
     "Linear or quadratic loss function with respect to the converter current"
     loss_function::Union{LinearCurve, QuadraticCurve}
@@ -167,10 +167,18 @@ get_reactive_power_limits(value::InterconnectingConverter, units) = Infrastructu
 get_reactive_power_limits_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:reactive_power_limits), Val(:mva), units)
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
-"""Get [`InterconnectingConverter`](@ref) `dc_current`."""
-get_dc_current(value::InterconnectingConverter) = value.dc_current
-"""Get [`InterconnectingConverter`](@ref) `max_dc_current`."""
-get_max_dc_current(value::InterconnectingConverter) = value.max_dc_current
+"""Get [`InterconnectingConverter`](@ref) `dc_current` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_dc_current_unitful`](@ref)."""
+get_dc_current(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:dc_current), Val(:mva), units))
+"""Get [`InterconnectingConverter`](@ref) `dc_current` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_dc_current`](@ref)."""
+get_dc_current_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:dc_current), Val(:mva), units)
+InfrastructureSystems.display_units_arg(::typeof(get_dc_current), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_dc_current_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
+"""Get [`InterconnectingConverter`](@ref) `max_dc_current` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_dc_current_unitful`](@ref)."""
+get_max_dc_current(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_dc_current), Val(:mva), units))
+"""Get [`InterconnectingConverter`](@ref) `max_dc_current` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_dc_current`](@ref)."""
+get_max_dc_current_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:max_dc_current), Val(:mva), units)
+InfrastructureSystems.display_units_arg(::typeof(get_max_dc_current), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
+InfrastructureSystems.display_units_arg(::typeof(get_max_dc_current_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 """Get [`InterconnectingConverter`](@ref) `loss_function`."""
 get_loss_function(value::InterconnectingConverter) = value.loss_function
 """Get [`InterconnectingConverter`](@ref) `dc_control`."""
@@ -207,9 +215,9 @@ set_active_power_limits!(value::InterconnectingConverter, val) = value.active_po
 """Set [`InterconnectingConverter`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::InterconnectingConverter, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mva))
 """Set [`InterconnectingConverter`](@ref) `dc_current`."""
-set_dc_current!(value::InterconnectingConverter, val) = value.dc_current = val
+set_dc_current!(value::InterconnectingConverter, val) = value.dc_current = set_value(value, Val(:dc_current), val, Val(:mva))
 """Set [`InterconnectingConverter`](@ref) `max_dc_current`."""
-set_max_dc_current!(value::InterconnectingConverter, val) = value.max_dc_current = val
+set_max_dc_current!(value::InterconnectingConverter, val) = value.max_dc_current = set_value(value, Val(:max_dc_current), val, Val(:mva))
 """Set [`InterconnectingConverter`](@ref) `loss_function`."""
 set_loss_function!(value::InterconnectingConverter, val) = value.loss_function = val
 """Set [`InterconnectingConverter`](@ref) `dc_control`."""

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -569,6 +569,7 @@ export get_dc_control
 export get_dc_control_from
 export get_dc_control_to
 export get_dc_current
+export get_dc_current_unitful
 export get_dc_dc_inductor
 export get_dc_link_capacitance
 export get_dc_setpoint
@@ -694,6 +695,7 @@ export get_max_current_reactive_power_unitful
 export get_max_dc_current
 export get_max_dc_current_from
 export get_max_dc_current_to
+export get_max_dc_current_unitful
 export get_max_flow
 export get_max_flow_unitful
 export get_max_impedance_active_power


### PR DESCRIPTION
## What

`InterconnectingConverter.dc_current` and `max_dc_current` had only bare, single-argument getters that returned the raw stored field — no unit-system conversion — unlike `active_power`/`rating`, which convert via the converter `base_power`.

Under the IS4/psy6 stateless-units model, consumers (e.g. PowerOperationsModels) work in system base. Leaving the DC current on the converter's own base produced **incorrect scaling whenever `base_power != system_base`**: the AC-side quantities scaled with `base_power` while the DC current did not.

## Change

- Annotate `dc_current` and `max_dc_current` in the descriptor with `needs_conversion: true` and `conversion_unit: ":mva"`.
- Regenerate `InterconnectingConverter.jl`.

The contract: these fields are **per-unit power-equivalent on the converter `base_power`** (`I ≈ P` at 1.0 pu DC voltage), matching how the operational models treat the DC current. `get_max_dc_current(d, PSY.SU)` now converts to system base exactly like `get_active_power(d, PSY.SU)`.

## Breaking

The bare single-arg getters (`get_dc_current(d)`, `get_max_dc_current(d)`) are replaced by the unit-aware `get_*(d, units)` form (and setters now take a unit-bearing value), consistent with every other convertible field. Callers must pass a unit system (e.g. `PSY.SU`). No in-repo callers use the bare form; the PowerOperationsModels consumer update is a follow-up.

## Verification

- Package loads; `IS.test_generated_structs` reports the descriptor and generated files are in sync.
- Generated getters are identical in form to the proven `active_power` `Val(:mva)` conversion.

Docstrings updated from "(A)" to the per-unit power-equivalent contract.
