### PR TITLE
Broaden `_set_value`'s `Float64` restriction to `Real` (fixes #1721)

### DIFF
--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -184,7 +184,7 @@ function set_value(c::Component, _, val, conversion_unit)
     return _set_value(c, val, conversion_unit)
 end
 
-function _set_value(c::Component, value::Float64, conversion_unit)::Float64
+function _set_value(c::Component, value::Real, conversion_unit)::Float64
     return (1 / _get_multiplier(c, conversion_unit)) * value
 end
 
@@ -440,7 +440,7 @@ end
 function set_value(
     c::ThreeWindingTransformer,
     field,
-    val::Float64,
+    val::Real,
     conversion_unit,
 )
     settings = get_internal(c).units_info

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -235,6 +235,22 @@ end
     @test active_power_mw == get_active_power(gen)
 end
 
+@testset "Test set_value with non-Float64 Real" begin
+    sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys"; add_forecasts = false)
+    set_units_base_system!(sys, "NATURAL_UNITS")
+    line = first(get_components(Line, sys))
+    rating = get_rating(line)
+
+    set_rating!(line, rating)
+    @test get_rating(line) == rating
+
+    set_rating!(line, Int(round(rating)))
+    @test get_rating(line) == round(rating)
+
+    set_rating!(line, Rational(Int(round(rating * 10)), 10))
+    @test get_rating(line) ≈ rating
+end
+
 @testset "Test with_units_base on component" begin
     sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys"; add_forecasts = false)
     set_units_base_system!(sys, "SYSTEM_BASE")


### PR DESCRIPTION
`set_foo!(comp, v::Int)` previously fell through to the generic `_set_value fallback`, which skips unit conversion and stores the raw value with only a `@warn`. Widening the dispatch to `Real` (covering `Int`, `Rational`, etc.) routes non-`Float64` numeric inputs through the same conversion-factor logic as `Float64`. See #1721 for details