### PR TITLE
add ReserveDemandCurveGroup

### DIFF
--- a/docs/src/model_library/reserves.md
+++ b/docs/src/model_library/reserves.md
@@ -31,7 +31,16 @@ Private = false
 
 ```@autodocs
 Modules = [PowerSystems]
-Pages   = ["generated/ReserveDemandCurve.jl"]
+Pages   = ["cost_functions/ReserveDemandCurve.jl"]
+Public = true
+Private = false
+```
+
+## Reserve Demand Curve Group
+
+```@autodocs
+Modules = [PowerSystems]
+Pages   = ["cost_functions/ReserveDemandCurveGroup.jl"]
 Public = true
 Private = false
 ```

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -354,6 +354,7 @@ export set_basis_and_energy_unit!
 
 export Service
 export AbstractReserve
+export ReserveGroup
 export Reserve
 export ReserveNonSpinning
 export ReserveDirection

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -364,6 +364,7 @@ export ConstantReserve
 export VariableReserve
 export AGC
 export ReserveDemandCurve
+export ReserveDemandCurveGroup
 export ReserveDemandTimeSeriesCurve
 export ConstantReserveGroup
 export ConstantReserveNonSpinning
@@ -929,6 +930,7 @@ include("models/generated/includes.jl")
 include("models/transformer_circuits.jl")
 
 include("models/cost_functions/ReserveDemandCurve.jl")
+include("models/cost_functions/ReserveDemandCurveGroup.jl")
 include("models/cost_functions/ReserveDemandTimeSeriesCurve.jl")
 
 #Methods for devices

--- a/src/base.jl
+++ b/src/base.jl
@@ -826,15 +826,17 @@ function add_service!(device::Device, service::Service, sys::System)
 end
 
 """
-Similar to [`add_component!`](@ref) but for ConstantReserveGroup.
+Similar to [`add_component!`](@ref) but for a [`ReserveGroup`](@ref).
+
+Every contributing service must already be attached to the system.
 
 # Arguments
 - `sys::System`: system
-- `service::ConstantReserveGroup`: service to add
+- `service::ReserveGroup`: reserve group to add
 """
 function add_service!(
     sys::System,
-    service::Union{ConstantReserveGroup, ReserveDemandCurveGroup};
+    service::ReserveGroup;
     skip_validation = false,
     kwargs...,
 )
@@ -849,10 +851,20 @@ function add_service!(
     return
 end
 
-"""Set a reserve group's `contributing_services`, checking each is attached to the system."""
+"""
+Set a [`ReserveGroup`](@ref)'s `contributing_services`, checking each is attached to the system.
+
+This is the only supported way to set group membership; the group types deliberately expose no
+unchecked two-argument setter.
+
+# Arguments
+- `sys::System`: system
+- `service::ReserveGroup`: reserve group to modify
+- `val::Vector{<:Service}`: contributing services, each already attached to `sys`
+"""
 function set_contributing_services!(
     sys::System,
-    service::Union{ConstantReserveGroup, ReserveDemandCurveGroup},
+    service::ReserveGroup,
     val::Vector{<:Service},
 )
     for _service in val
@@ -863,16 +875,16 @@ function set_contributing_services!(
 end
 
 """
-Similar to [`add_component!`](@ref) but for ConstantReserveGroup.
+Similar to [`add_component!`](@ref) but for a [`ReserveGroup`](@ref).
 
 # Arguments
 - `sys::System`: system
-- `service::ConstantReserveGroup`: service to add
-- `contributing_services`: contributing services to the group
+- `service::ReserveGroup`: reserve group to add
+- `contributing_services`: contributing services to the group, each already attached to `sys`
 """
 function add_service!(
     sys::System,
-    service::Union{ConstantReserveGroup, ReserveDemandCurveGroup},
+    service::ReserveGroup,
     contributing_services::Vector{<:Service};
     skip_validation = false,
     kwargs...,
@@ -1129,19 +1141,15 @@ end
 """
 Throws ArgumentError if a PowerSystems rule blocks removal from the system.
 """
-function check_component_removal(sys::System, service::T) where {T <: Service}
-    if T == ConstantReserveGroup
-        return
-    end
-    groupservices = get_components(ConstantReserveGroup, sys)
-    for groupservice in groupservices
+function check_component_removal(sys::System, service::Service)
+    for groupservice in get_components(ReserveGroup, sys)
         if service ∈ get_contributing_services(groupservice)
             throw(
                 ArgumentError(
-                    "service $(get_name(service)) cannot be removed with an attached ConstantReserveGroup",
+                    "service $(get_name(service)) cannot be removed while it contributes to " *
+                    "$(nameof(typeof(groupservice))) $(get_name(groupservice))",
                 ),
             )
-            return
         end
     end
 end
@@ -2462,21 +2470,22 @@ function deserialize_components!(sys::System, raw)
     # Most components have buses.
     # Static injection devices can contain dynamic injection devices.
     # StaticInjectionSubsystem instances have StaticInjection subcomponents.
+    # ReserveGroup instances reference other services, so they are deferred until last.
     deserialize_and_add!(; include_types = [Area, LoadZone])
     deserialize_and_add!(; include_types = [AbstractReserve])
     deserialize_and_add!(; include_types = [AGC])
     deserialize_and_add!(; include_types = [Bus])
     deserialize_and_add!(;
         include_types = [Arc, Service],
-        skip_types = [ConstantReserveGroup],
+        skip_types = [ReserveGroup],
     )
     deserialize_and_add!(;
         include_types = [HydroTurbine, HydroPumpTurbine],
-        skip_types = [ConstantReserveGroup, HydroReservoir],
+        skip_types = [ReserveGroup, HydroReservoir],
     )
     deserialize_and_add!(; include_types = [HydroReservoir])
     deserialize_and_add!(; include_types = [Branch])
-    deserialize_and_add!(; include_types = [ConstantReserveGroup, DynamicInjection])
+    deserialize_and_add!(; include_types = [ReserveGroup, DynamicInjection])
     deserialize_and_add!(; skip_types = [StaticInjectionSubsystem])
     deserialize_and_add!()
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -834,7 +834,7 @@ Similar to [`add_component!`](@ref) but for ConstantReserveGroup.
 """
 function add_service!(
     sys::System,
-    service::ConstantReserveGroup;
+    service::Union{ConstantReserveGroup, ReserveDemandCurveGroup};
     skip_validation = false,
     kwargs...,
 )
@@ -849,10 +849,10 @@ function add_service!(
     return
 end
 
-"""Set ConstantReserveGroup contributing_services with check"""
+"""Set a reserve group's `contributing_services`, checking each is attached to the system."""
 function set_contributing_services!(
     sys::System,
-    service::ConstantReserveGroup,
+    service::Union{ConstantReserveGroup, ReserveDemandCurveGroup},
     val::Vector{<:Service},
 )
     for _service in val
@@ -872,7 +872,7 @@ Similar to [`add_component!`](@ref) but for ConstantReserveGroup.
 """
 function add_service!(
     sys::System,
-    service::ConstantReserveGroup,
+    service::Union{ConstantReserveGroup, ReserveDemandCurveGroup},
     contributing_services::Vector{<:Service};
     skip_validation = false,
     kwargs...,

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -6659,7 +6659,7 @@
                     "exclude_setter": true
                 }
             ],
-            "supertype": "Service"
+            "supertype": "ReserveGroup"
         },
         {
             "struct_name": "VariableReserve",
@@ -19754,6 +19754,108 @@
                 },
                 {
                     "name": "states"
+                },
+                {
+                    "name": "ext"
+                },
+                {
+                    "name": "internal"
+                }
+            ]
+        },
+        {
+            "struct_name": "ReserveDemandCurve",
+            "docstring": "Hand-written struct; listed so validation resolves the type instead of warning.",
+            "fields": [
+                {
+                    "name": "variable"
+                },
+                {
+                    "name": "name"
+                },
+                {
+                    "name": "available"
+                },
+                {
+                    "name": "time_frame"
+                },
+                {
+                    "name": "sustained_time"
+                },
+                {
+                    "name": "max_participation_factor"
+                },
+                {
+                    "name": "deployed_fraction"
+                },
+                {
+                    "name": "ext"
+                },
+                {
+                    "name": "internal"
+                }
+            ]
+        },
+        {
+            "struct_name": "ReserveDemandCurveGroup",
+            "docstring": "Hand-written struct; listed so validation resolves the type instead of warning.",
+            "fields": [
+                {
+                    "name": "variable"
+                },
+                {
+                    "name": "name"
+                },
+                {
+                    "name": "available"
+                },
+                {
+                    "name": "time_frame"
+                },
+                {
+                    "name": "sustained_time"
+                },
+                {
+                    "name": "max_participation_factor"
+                },
+                {
+                    "name": "deployed_fraction"
+                },
+                {
+                    "name": "contributing_services"
+                },
+                {
+                    "name": "ext"
+                },
+                {
+                    "name": "internal"
+                }
+            ]
+        },
+        {
+            "struct_name": "ReserveDemandTimeSeriesCurve",
+            "docstring": "Hand-written struct; listed so validation resolves the type instead of warning.",
+            "fields": [
+                {
+                    "name": "variable"
+                },
+                {
+                    "name": "name"
+                },
+                {
+                    "name": "available"
+                },
+                {
+                    "name": "time_frame"
+                },
+                {
+                    "name": "sustained_time"
+                },
+                {
+                    "name": "max_participation_factor"
+                },
+                {
+                    "name": "deployed_fraction"
                 },
                 {
                     "name": "ext"

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -208,6 +208,7 @@ end
 # ── STATIC ReserveDemandCurve GETTERS ──────────────────────────────────────
 
 get_variable_cost(service::ReserveDemandCurve; kwargs...) = get_variable(service)
+get_variable_cost(service::ReserveDemandCurveGroup; kwargs...) = get_variable(service)
 
 # ── TIME-SERIES ReserveDemandTimeSeriesCurve GETTERS ──────────────────────
 
@@ -550,6 +551,16 @@ end
 function set_variable_cost!(
     ::System,
     component::ReserveDemandCurve,
+    data::CostCurve{PiecewiseIncrementalCurve, U},
+) where {U <: IS.AbstractUnitSystem}
+    name = get_name(component)
+    _validate_reserve_demand_curve(data, name)
+    set_variable!(component, data)
+end
+
+function set_variable_cost!(
+    ::System,
+    component::ReserveDemandCurveGroup,
     data::CostCurve{PiecewiseIncrementalCurve, U},
 ) where {U <: IS.AbstractUnitSystem}
     name = get_name(component)

--- a/src/models/cost_functions/ReserveDemandCurveGroup.jl
+++ b/src/models/cost_functions/ReserveDemandCurveGroup.jl
@@ -1,0 +1,156 @@
+"""
+$(TYPEDEF)
+$(TYPEDFIELDS)
+
+    ReserveDemandCurveGroup{T}(variable, name, available, time_frame, sustained_time, max_participation_factor, deployed_fraction, contributing_services, ext, internal)
+    ReserveDemandCurveGroup{T}(; variable, name, available, time_frame, sustained_time, max_participation_factor, deployed_fraction, contributing_services, ext)
+
+A group reserve product priced by a single Ancillary Service Demand Curve (ASDC) whose demand is
+met by the awards of a set of `contributing_services` (its sub-type reserves). It combines the
+demand-curve pricing of [`ReserveDemandCurve`](@ref) with the service aggregation of
+[`ConstantReserveGroup`](@ref): the group carries one elastic demand and clears at one price
+(MCPC), while the per-sub-type caps and offers live on the contributing services.
+
+Example: ERCOT Responsive Reserve (RRS), whose single ASDC/MCPC is met by the PFR, FFR, and UFR
+sub-type services, each with its own offers and capability caps.
+
+The demand curve is a discretized set of `(Reserve capacity (MW), Price (\$/MWh))` steps; the
+`ReserveDirection` `T` sets whether the group is [`ReserveUp`](@ref), [`ReserveDown`](@ref), or
+[`ReserveSymmetric`](@ref).
+"""
+mutable struct ReserveDemandCurveGroup{T <: ReserveDirection, U <: IS.AbstractUnitSystem} <:
+               Service
+    "Group Ancillary Service Demand Curve (ASDC)"
+    variable::CostCurve{PiecewiseIncrementalCurve, U}
+    "Name of the component"
+    name::String
+    "Indicator of whether the component is connected and online"
+    available::Bool
+    "The saturation time_frame in minutes to provide reserve contribution"
+    time_frame::Float64
+    "The time in seconds that the reserve contribution must be sustained at a specified level"
+    sustained_time::Float64
+    "The maximum portion [0, 1.0] of the reserve that can be contributed per device"
+    max_participation_factor::Float64
+    "Fraction of service procurement that is assumed to be actually deployed"
+    deployed_fraction::Float64
+    "The sub-type reserve services whose awards meet this group's demand"
+    contributing_services::Vector{Service}
+    "An extra dictionary for users to add metadata that are not used in simulation"
+    ext::Dict{String, Any}
+    "PowerSystems.jl internal reference"
+    internal::InfrastructureSystemsInternal
+end
+
+function ReserveDemandCurveGroup{T}(
+    variable,
+    name,
+    available,
+    time_frame,
+    sustained_time = 3600.0,
+    max_participation_factor = 1.0,
+    deployed_fraction = 0.0,
+    contributing_services = Vector{Service}(),
+    ext = Dict{String, Any}(),
+) where {T <: ReserveDirection}
+    U = typeof(get_power_units(variable))
+    ReserveDemandCurveGroup{T, U}(
+        variable, name, available, time_frame, sustained_time,
+        max_participation_factor, deployed_fraction, contributing_services, ext,
+        InfrastructureSystemsInternal(),
+    )
+end
+
+function ReserveDemandCurveGroup{T}(;
+    variable,
+    name,
+    available,
+    time_frame,
+    sustained_time = 3600.0,
+    max_participation_factor = 1.0,
+    deployed_fraction = 0.0,
+    contributing_services = Vector{Service}(),
+    ext = Dict{String, Any}(),
+    internal = InfrastructureSystemsInternal(),
+) where {T <: ReserveDirection}
+    U = typeof(get_power_units(variable))
+    ReserveDemandCurveGroup{T, U}(
+        variable, name, available, time_frame, sustained_time,
+        max_participation_factor, deployed_fraction, contributing_services, ext, internal,
+    )
+end
+
+# Kwarg constructor on the fully-parameterized type — needed by deserialization, which resolves
+# `ReserveDemandCurveGroup{T, U}` from metadata and calls it with kwargs.
+function ReserveDemandCurveGroup{T, U}(;
+    variable,
+    name,
+    available,
+    time_frame,
+    sustained_time = 3600.0,
+    max_participation_factor = 1.0,
+    deployed_fraction = 0.0,
+    contributing_services = Vector{Service}(),
+    ext = Dict{String, Any}(),
+    internal = InfrastructureSystemsInternal(),
+) where {T <: ReserveDirection, U <: IS.AbstractUnitSystem}
+    ReserveDemandCurveGroup{T, U}(
+        variable, name, available, time_frame, sustained_time,
+        max_participation_factor, deployed_fraction, contributing_services, ext, internal,
+    )
+end
+
+# Constructor for demo purposes; non-functional.
+function ReserveDemandCurveGroup{T}(::Nothing) where {T <: ReserveDirection}
+    ReserveDemandCurveGroup{T}(;
+        variable = ZERO_OFFER_CURVE,
+        name = "init",
+        available = false,
+        time_frame = 0.0,
+        sustained_time = 0.0,
+        max_participation_factor = 1.0,
+        deployed_fraction = 0.0,
+        contributing_services = Vector{Service}(),
+    )
+end
+
+"""Get [`ReserveDemandCurveGroup`](@ref) `variable`."""
+get_variable(value::ReserveDemandCurveGroup) = value.variable
+"""Get [`ReserveDemandCurveGroup`](@ref) `name`."""
+get_name(value::ReserveDemandCurveGroup) = value.name
+"""Get [`ReserveDemandCurveGroup`](@ref) `available`."""
+get_available(value::ReserveDemandCurveGroup) = value.available
+"""Get [`ReserveDemandCurveGroup`](@ref) `time_frame`."""
+get_time_frame(value::ReserveDemandCurveGroup) = value.time_frame
+"""Get [`ReserveDemandCurveGroup`](@ref) `sustained_time`."""
+get_sustained_time(value::ReserveDemandCurveGroup) = value.sustained_time
+"""Get [`ReserveDemandCurveGroup`](@ref) `max_participation_factor`."""
+get_max_participation_factor(value::ReserveDemandCurveGroup) =
+    value.max_participation_factor
+"""Get [`ReserveDemandCurveGroup`](@ref) `deployed_fraction`."""
+get_deployed_fraction(value::ReserveDemandCurveGroup) = value.deployed_fraction
+"""Get [`ReserveDemandCurveGroup`](@ref) `contributing_services`."""
+get_contributing_services(value::ReserveDemandCurveGroup) = value.contributing_services
+"""Get [`ReserveDemandCurveGroup`](@ref) `ext`."""
+get_ext(value::ReserveDemandCurveGroup) = value.ext
+"""Get [`ReserveDemandCurveGroup`](@ref) `internal`."""
+get_internal(value::ReserveDemandCurveGroup) = value.internal
+
+"""Set [`ReserveDemandCurveGroup`](@ref) `variable`."""
+set_variable!(value::ReserveDemandCurveGroup, val) = value.variable = val
+"""Set [`ReserveDemandCurveGroup`](@ref) `available`."""
+set_available!(value::ReserveDemandCurveGroup, val) = value.available = val
+"""Set [`ReserveDemandCurveGroup`](@ref) `time_frame`."""
+set_time_frame!(value::ReserveDemandCurveGroup, val) = value.time_frame = val
+"""Set [`ReserveDemandCurveGroup`](@ref) `sustained_time`."""
+set_sustained_time!(value::ReserveDemandCurveGroup, val) = value.sustained_time = val
+"""Set [`ReserveDemandCurveGroup`](@ref) `max_participation_factor`."""
+set_max_participation_factor!(value::ReserveDemandCurveGroup, val) =
+    value.max_participation_factor = val
+"""Set [`ReserveDemandCurveGroup`](@ref) `deployed_fraction`."""
+set_deployed_fraction!(value::ReserveDemandCurveGroup, val) = value.deployed_fraction = val
+"""Set [`ReserveDemandCurveGroup`](@ref) `contributing_services`."""
+set_contributing_services!(value::ReserveDemandCurveGroup, val) =
+    value.contributing_services = val
+"""Set [`ReserveDemandCurveGroup`](@ref) `ext`."""
+set_ext!(value::ReserveDemandCurveGroup, val) = value.ext = val

--- a/src/models/cost_functions/ReserveDemandCurveGroup.jl
+++ b/src/models/cost_functions/ReserveDemandCurveGroup.jl
@@ -19,7 +19,7 @@ The demand curve is a discretized set of `(Reserve capacity (MW), Price (\$/MWh)
 [`ReserveSymmetric`](@ref).
 """
 mutable struct ReserveDemandCurveGroup{T <: ReserveDirection, U <: IS.AbstractUnitSystem} <:
-               Service
+               ReserveGroup
     "Group Ancillary Service Demand Curve (ASDC)"
     variable::CostCurve{PiecewiseIncrementalCurve, U}
     "Name of the component"
@@ -149,8 +149,9 @@ set_max_participation_factor!(value::ReserveDemandCurveGroup, val) =
     value.max_participation_factor = val
 """Set [`ReserveDemandCurveGroup`](@ref) `deployed_fraction`."""
 set_deployed_fraction!(value::ReserveDemandCurveGroup, val) = value.deployed_fraction = val
-"""Set [`ReserveDemandCurveGroup`](@ref) `contributing_services`."""
-set_contributing_services!(value::ReserveDemandCurveGroup, val) =
-    value.contributing_services = val
+# `contributing_services` has no two-argument setter on purpose: membership must be set with
+# `set_contributing_services!(sys, group, val)`, which checks that every member is attached to
+# the system. `ConstantReserveGroup` suppresses the same setter via `exclude_setter` in the
+# struct descriptor.
 """Set [`ReserveDemandCurveGroup`](@ref) `ext`."""
 set_ext!(value::ReserveDemandCurveGroup, val) = value.ext = val

--- a/src/models/generated/ConstantReserveGroup.jl
+++ b/src/models/generated/ConstantReserveGroup.jl
@@ -5,7 +5,7 @@ This file is auto-generated. Do not edit.
 #! format: off
 
 """
-    mutable struct ConstantReserveGroup{T <: ReserveDirection} <: Service
+    mutable struct ConstantReserveGroup{T <: ReserveDirection} <: ReserveGroup
         name::String
         available::Bool
         requirement::Float64
@@ -28,7 +28,7 @@ This model has a constant procurement requirement, such as 3% of the system base
 - `contributing_services::Vector{Service}`: (default: `Vector{Service}()`) Services that contribute to this group requirement. Services must be added for this constraint to have an effect when conducting simulations in [`PowerSimulations.jl`](https://sienna-platform.github.io/PowerSimulations.jl/latest/)
 - `internal::InfrastructureSystemsInternal`: (**Do not modify.**) PowerSystems.jl internal reference
 """
-mutable struct ConstantReserveGroup{T <: ReserveDirection} <: Service
+mutable struct ConstantReserveGroup{T <: ReserveDirection} <: ReserveGroup
     "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name"
     name::String
     "Indicator of whether the component is connected and online (`true`) or disconnected, offline, or down (`false`). Unavailable components are excluded during simulations"

--- a/src/models/serialization.jl
+++ b/src/models/serialization.jl
@@ -59,7 +59,7 @@ function IS.serialize(component::T) where {T <: _CONTAINS_SHOULD_ENCODE}
     IS.add_serialization_metadata!(data, T)
 
     # This is a temporary workaround until these types are not parameterized.
-    if T <: Reserve || T <: ConstantReserveGroup || T <: ReserveDemandCurveGroup
+    if T <: Reserve || T <: ReserveGroup
         data[IS.METADATA_KEY][IS.CONSTRUCT_WITH_PARAMETERS_KEY] = true
     end
 

--- a/src/models/serialization.jl
+++ b/src/models/serialization.jl
@@ -59,7 +59,7 @@ function IS.serialize(component::T) where {T <: _CONTAINS_SHOULD_ENCODE}
     IS.add_serialization_metadata!(data, T)
 
     # This is a temporary workaround until these types are not parameterized.
-    if T <: Reserve || T <: ConstantReserveGroup
+    if T <: Reserve || T <: ConstantReserveGroup || T <: ReserveDemandCurveGroup
         data[IS.METADATA_KEY][IS.CONSTRUCT_WITH_PARAMETERS_KEY] = true
     end
 

--- a/src/models/services.jl
+++ b/src/models/services.jl
@@ -9,7 +9,20 @@ such as the sudden loss of a transmission line or generator.
 abstract type Service <: Component end
 
 """
-All PowerSystems [Service](@ref) types support time series. This can be overridden for custom 
+Supertype for reserve products whose requirement is met by a group of contributing services
+
+A reserve group aggregates other [`Service`](@ref) instances: the group carries the
+requirement (a constant one for [`ConstantReserveGroup`](@ref), an elastic demand curve for
+[`ReserveDemandCurveGroup`](@ref)) while the per-service caps and offers live on the
+contributing services themselves.
+
+Group members are set with [`set_contributing_services!`](@ref) and read with
+`get_contributing_services`.
+"""
+abstract type ReserveGroup <: Service end
+
+"""
+All PowerSystems [Service](@ref) types support time series. This can be overridden for custom
 types that do not support time series.
 """
 supports_time_series(::Service) = true

--- a/test/test_services.jl
+++ b/test/test_services.jl
@@ -309,6 +309,53 @@ end
     @test contributing_services == expected_contributing_services
 end
 
+@testset "Test ReserveDemandCurveGroup" begin
+    sys = System(100.0)
+    devices = Vector{ThermalStandard}()
+    for i in 1:2
+        bus = ACBus(nothing)
+        bus.name = "bus" * string(i)
+        bus.number = i
+        add_component!(sys, bus)
+        gen = ThermalStandard(nothing)
+        gen.bus = bus
+        gen.name = "gen" * string(i)
+        add_component!(sys, gen)
+        push!(devices, gen)
+    end
+
+    # Sub-type supply services that the group aggregates (e.g. RRS = PFR + FFR + ...).
+    pfr = VariableReserve{ReserveUp}(nothing)
+    pfr.name = "RRSPFR"
+    ffr = VariableReserve{ReserveUp}(nothing)
+    ffr.name = "RRSFFR"
+    add_service!(sys, pfr, devices)
+    add_service!(sys, ffr, devices)
+
+    # The group carries the demand curve (ASDC); the sub-services carry the supply.
+    curve = make_market_bid_curve([0.0, 100.0, 500.0], [5000.0, 15.0], 0.0;
+        power_units = IS.NaturalUnit())
+    group = ReserveDemandCurveGroup{ReserveUp}(;
+        variable = curve, name = "RRS", available = true, time_frame = 10.0)
+    add_service!(sys, group)
+
+    @test length(collect(get_components(ReserveDemandCurveGroup, sys))) == 1
+    @test get_component(ReserveDemandCurveGroup{ReserveUp}, sys, "RRS") === group
+    @test get_variable_cost(group) isa CostCurve
+
+    # System-checked setter + getter for the contributing services.
+    set_contributing_services!(sys, group, Vector{Service}([pfr, ffr]))
+    @test Set(get_name.(get_contributing_services(group))) == Set(["RRSPFR", "RRSFFR"])
+
+    # Serialize / deserialize round-trip: the group's curve and contributing services survive.
+    sys2, result = validate_serialization(sys)
+    @test result
+    group2 = get_component(ReserveDemandCurveGroup{ReserveUp}, sys2, "RRS")
+    @test group2 !== nothing
+    @test get_variable_cost(group2) isa CostCurve
+    @test Set(get_name.(get_contributing_services(group2))) == Set(["RRSPFR", "RRSFFR"])
+end
+
 @testset "Test ConstantReserveGroup errors" begin
     sys = System(100.0)
     bus = ACBus(nothing)

--- a/test/test_services.jl
+++ b/test/test_services.jl
@@ -316,6 +316,9 @@ end
         bus = ACBus(nothing)
         bus.name = "bus" * string(i)
         bus.number = i
+        # This system is round-tripped below, and deserialization runs `check(sys)`, which
+        # logs an error unless a reference bus is present.
+        i == 1 && set_bustype!(bus, ACBusTypes.REF)
         add_component!(sys, bus)
         gen = ThermalStandard(nothing)
         gen.bus = bus
@@ -354,6 +357,101 @@ end
     @test group2 !== nothing
     @test get_variable_cost(group2) isa CostCurve
     @test Set(get_name.(get_contributing_services(group2))) == Set(["RRSPFR", "RRSFFR"])
+end
+
+@testset "Test ReserveGroup supertype" begin
+    # Both group types share one supertype, so `get_components` and the `add_service!` /
+    # `set_contributing_services!` methods dispatch on `ReserveGroup` rather than a Union.
+    @test ConstantReserveGroup{ReserveUp} <: ReserveGroup
+    @test ReserveDemandCurveGroup{ReserveUp, IS.NaturalUnit} <: ReserveGroup
+    @test ReserveGroup <: Service
+    # Non-group services must not be caught by the supertype.
+    @test !(VariableReserve{ReserveUp} <: ReserveGroup)
+    @test !(ConstantReserveNonSpinning <: ReserveGroup)
+
+    sys = System(100.0)
+    crg = ConstantReserveGroup{ReserveDown}(nothing)
+    add_service!(sys, crg)
+    curve = make_market_bid_curve([0.0, 100.0], [15.0], 0.0;
+        power_units = IS.NaturalUnit())
+    rdcg = ReserveDemandCurveGroup{ReserveUp}(;
+        variable = curve, name = "RRS", available = true, time_frame = 10.0)
+    add_service!(sys, rdcg)
+    @test length(collect(get_components(ReserveGroup, sys))) == 2
+end
+
+@testset "Test hand-written services have validation descriptors" begin
+    # Types outside `auto_generated_structs` need an explicit `struct_validation_descriptors`
+    # entry, or `add_component!` logs "does not exist in validation configuration file,
+    # validation skipped" on a documented public workflow.
+    descriptors = IS.read_validation_descriptor(PSY.POWER_SYSTEM_STRUCT_DESCRIPTOR_FILE)
+    described = Set(d["struct_name"] for d in descriptors)
+    for name in
+        ("ReserveDemandCurve", "ReserveDemandCurveGroup", "ReserveDemandTimeSeriesCurve")
+        @test name in described
+    end
+
+    # End-to-end: adding a group must not emit the validation warning.
+    sys = System(100.0)
+    curve = make_market_bid_curve([0.0, 100.0], [15.0], 0.0;
+        power_units = IS.NaturalUnit())
+    group = ReserveDemandCurveGroup{ReserveUp}(;
+        variable = curve, name = "RRS", available = true, time_frame = 10.0)
+    @test_logs min_level = Logging.Warn add_service!(sys, group)
+end
+
+@testset "Test ReserveGroup membership requires attachment" begin
+    sys = System(100.0)
+    devices = Vector{ThermalStandard}()
+    for i in 1:2
+        bus = ACBus(nothing)
+        bus.name = "bus" * string(i)
+        bus.number = i
+        add_component!(sys, bus)
+        gen = ThermalStandard(nothing)
+        gen.bus = bus
+        gen.name = "gen" * string(i)
+        add_component!(sys, gen)
+        push!(devices, gen)
+    end
+
+    curve = make_market_bid_curve([0.0, 100.0, 500.0], [5000.0, 15.0], 0.0;
+        power_units = IS.NaturalUnit())
+    group = ReserveDemandCurveGroup{ReserveUp}(;
+        variable = curve, name = "RRS", available = true, time_frame = 10.0)
+    add_service!(sys, group)
+
+    # There is no unchecked two-argument setter: membership can only be set through the
+    # `System` method, which validates attachment.
+    detached = VariableReserve{ReserveUp}(nothing)
+    detached.name = "DETACHED"
+    @test !hasmethod(
+        set_contributing_services!,
+        Tuple{ReserveDemandCurveGroup, Vector{Service}},
+    )
+    @test !hasmethod(
+        set_contributing_services!,
+        Tuple{ConstantReserveGroup, Vector{Service}},
+    )
+    @test_throws ArgumentError set_contributing_services!(
+        sys, group, Vector{Service}([detached]))
+    @test isempty(get_contributing_services(group))
+
+    # A concretely typed vector of an attached service is accepted (widened on assignment).
+    pfr = VariableReserve{ReserveUp}(nothing)
+    pfr.name = "RRSPFR"
+    add_service!(sys, pfr, devices)
+    set_contributing_services!(sys, group, [pfr])
+    @test get_contributing_services(group) isa Vector{Service}
+    @test get_name.(get_contributing_services(group)) == ["RRSPFR"]
+
+    # A contributing service cannot be removed while the group still references it.
+    @test_throws ArgumentError remove_component!(sys, pfr)
+    # The group itself is removable, and the member becomes removable afterwards.
+    remove_component!(sys, group)
+    remove_component!(sys, pfr)
+    @test isempty(collect(get_components(ReserveGroup, sys)))
+    @test isempty(collect(get_components(VariableReserve{ReserveUp}, sys)))
 end
 
 @testset "Test ConstantReserveGroup errors" begin


### PR DESCRIPTION
Add a ReserveDemandCurveGroup (similar to ConstantReserveGroup) to stack multiple services to provide a common demand curve (rather than a common requirement).
