### PR TITLE
Declare loss curve fields as LossCurve so their units are explicit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/issue-1728-loss-curve-units"}
 
 [compat]
 DataStructures = "^0.19"

--- a/docs/src/api/public.md
+++ b/docs/src/api/public.md
@@ -74,6 +74,17 @@ Order = [:type, :function]
 Filter = t -> !(t isa Union) && nameof(t) in names(PowerSystems)
 ```
 
+## Curves with Units
+
+```@autodocs
+Modules = [IS]
+Pages   = ["value_curve_with_units.jl",
+            "loss_curve.jl",
+           ]
+Order = [:type, :function]
+Filter = t -> !(t isa Union) && nameof(t) in names(PowerSystems)
+```
+
 ## Time Series
 
 ```@autodocs

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -95,12 +95,13 @@ export get_points
 export get_x_coords
 export get_y_coords
 
-# from IS value_curve.jl, cost_aliases.jl, and production_variable_cost_curve.jl
+# from IS value_curve.jl, cost_aliases.jl, production_variable_cost_curve.jl, and loss_curve.jl
 export ValueCurve
 export InputOutputCurve, IncrementalCurve, AverageRateCurve
 export LinearCurve, QuadraticCurve
 export PiecewisePointCurve, PiecewiseIncrementalCurve, PiecewiseAverageCurve
-export ProductionVariableCostCurve, CostCurve, FuelCurve
+export ValueCurveWithUnits, ProductionVariableCostCurve, CostCurve, FuelCurve
+export LossCurve
 export get_function_data, get_initial_input, get_input_at_zero
 export get_value_curve, get_power_units
 
@@ -833,7 +834,9 @@ import InfrastructureSystems:
     get_initial_input,
     get_input_at_zero,
     get_average_rates,
+    ValueCurveWithUnits,
     ProductionVariableCostCurve,
+    LossCurve,
     CostCurve,
     FuelCurve,
     get_value_curve,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -125,7 +125,7 @@ function TwoTerminalHVDCLine(
     active_power_limits_to,
     reactive_power_limits_from,
     reactive_power_limits_to,
-    loss = LinearCurve(0.0),
+    loss = LossCurve(LinearCurve(0.0)),
     services = Device[],
     ext = Dict{String, Any}(),
 )
@@ -161,7 +161,7 @@ function TwoTerminalHVDCLine(;
     active_power_limits_to,
     reactive_power_limits_from,
     reactive_power_limits_to,
-    loss = LinearCurve(0.0),
+    loss = LossCurve(LinearCurve(0.0)),
     services = Device[],
     ext = Dict{String, Any}(),
     internal = InfrastructureSystemsInternal(),

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -1423,10 +1423,10 @@
                 },
                 {
                     "name": "loss",
-                    "comment": "Loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, PiecewiseIncrementalCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "comment": "Loss model coefficients, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model with a constant loss and a proportional loss rate (loss per unit of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.",
+                    "null_value": "LossCurve(LinearCurve(0.0))",
+                    "data_type": "Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0))"
                 },
                 {
                     "name": "services",
@@ -1566,10 +1566,10 @@
                 },
                 {
                     "name": "converter_loss_from",
-                    "comment": "Loss model coefficients in the `from` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, QuadraticCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "comment": "Loss model coefficients in the `from` bus converter, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model or quadratic. Same converter data is used in both ends.",
+                    "null_value": "LossCurve(LinearCurve(0.0))",
+                    "data_type": "Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0))"
                 },
                 {
                     "name": "max_dc_current_from",
@@ -1661,10 +1661,10 @@
                 },
                 {
                     "name": "converter_loss_to",
-                    "comment": "Loss model coefficients in the `to` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, QuadraticCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "comment": "Loss model coefficients in the `to` bus converter, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model or quadratic. Same converter data is used in both ends.",
+                    "null_value": "LossCurve(LinearCurve(0.0))",
+                    "data_type": "Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0))"
                 },
                 {
                     "name": "max_dc_current_to",
@@ -2045,10 +2045,10 @@
                 },
                 {
                     "name": "loss",
-                    "comment": "A generic loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, PiecewiseIncrementalCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "comment": "A generic loss model coefficients, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model with a constant loss and a proportional loss rate (loss per unit of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.",
+                    "null_value": "LossCurve(LinearCurve(0.0))",
+                    "data_type": "Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0))"
                 },
                 {
                     "name": "services",
@@ -4150,10 +4150,10 @@
                 },
                 {
                     "name": "loss_function",
-                    "comment": "Linear or quadratic loss function with respect to the converter current",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, QuadraticCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "comment": "Linear or quadratic loss function with respect to the converter current, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes",
+                    "null_value": "LossCurve(LinearCurve(0.0))",
+                    "data_type": "Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0))"
                 },
                 {
                     "name": "dc_control",

--- a/src/models/generated/InterconnectingConverter.jl
+++ b/src/models/generated/InterconnectingConverter.jl
@@ -17,7 +17,7 @@ This file is auto-generated. Do not edit.
         reactive_power_limits::Union{Nothing, MinMax}
         dc_current::Float64
         max_dc_current::Float64
-        loss_function::Union{LinearCurve, QuadraticCurve}
+        loss_function::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}
         dc_control::VSCDCControlModes
         ac_control::VSCACControlModes
         dc_setpoint::Float64
@@ -47,7 +47,7 @@ Interconnecting Power Converter (IPC) for transforming power from an ACBus to a 
 - `reactive_power_limits::Union{Nothing, MinMax}`: (default: `nothing`) Minimum and maximum reactive power limits. Set to `Nothing` if not applicable
 - `dc_current::Float64`: (default: `0.0`) DC current on the converter, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)
 - `max_dc_current::Float64`: (default: `1e8`) Maximum stable DC current limit, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)
-- `loss_function::Union{LinearCurve, QuadraticCurve}`: (default: `LinearCurve(0.0)`) Linear or quadratic loss function with respect to the converter current
+- `loss_function::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}`: (default: `LossCurve(LinearCurve(0.0))`) Linear or quadratic loss function with respect to the converter current, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes
 - `dc_control::VSCDCControlModes`: (default: `VSCDCControlModes.DC_VOLTAGE`) DC-side control mode of the converter; see [`VSCDCControlModes`](@ref).
 - `ac_control::VSCACControlModes`: (default: `VSCACControlModes.AC_REACTIVE_POWER`) AC-side control mode of the converter; see [`VSCACControlModes`](@ref).
 - `dc_setpoint::Float64`: (default: `0.0`) DC-voltage target (when dc_voltage_control is true) or active-power order (when false), in per unit.
@@ -85,8 +85,8 @@ mutable struct InterconnectingConverter <: StaticInjection
     dc_current::Float64
     "Maximum stable DC current limit, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)"
     max_dc_current::Float64
-    "Linear or quadratic loss function with respect to the converter current"
-    loss_function::Union{LinearCurve, QuadraticCurve}
+    "Linear or quadratic loss function with respect to the converter current, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes"
+    loss_function::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}
     "DC-side control mode of the converter; see [`VSCDCControlModes`](@ref)."
     dc_control::VSCDCControlModes
     "AC-side control mode of the converter; see [`VSCACControlModes`](@ref)."
@@ -115,11 +115,11 @@ mutable struct InterconnectingConverter <: StaticInjection
     internal::InfrastructureSystemsInternal
 end
 
-function InterconnectingConverter(name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits=nothing, dc_current=0.0, max_dc_current=1e8, loss_function=LinearCurve(0.0), dc_control=VSCDCControlModes.DC_VOLTAGE, ac_control=VSCACControlModes.AC_REACTIVE_POWER, dc_setpoint=0.0, ac_setpoint=1.0, dc_voltage_droop=0.0, remote_bus_control=nothing, rmpct=100.0, power_factor_weighting_fraction=1.0, voltage_limits=(min=0.0, max=999.9), services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+function InterconnectingConverter(name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits=nothing, dc_current=0.0, max_dc_current=1e8, loss_function=LossCurve(LinearCurve(0.0)), dc_control=VSCDCControlModes.DC_VOLTAGE, ac_control=VSCACControlModes.AC_REACTIVE_POWER, dc_setpoint=0.0, ac_setpoint=1.0, dc_voltage_droop=0.0, remote_bus_control=nothing, rmpct=100.0, power_factor_weighting_fraction=1.0, voltage_limits=(min=0.0, max=999.9), services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
     InterconnectingConverter(name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits, dc_current, max_dc_current, loss_function, dc_control, ac_control, dc_setpoint, ac_setpoint, dc_voltage_droop, remote_bus_control, rmpct, power_factor_weighting_fraction, voltage_limits, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function InterconnectingConverter(; name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits=nothing, dc_current=0.0, max_dc_current=1e8, loss_function=LinearCurve(0.0), dc_control=VSCDCControlModes.DC_VOLTAGE, ac_control=VSCACControlModes.AC_REACTIVE_POWER, dc_setpoint=0.0, ac_setpoint=1.0, dc_voltage_droop=0.0, remote_bus_control=nothing, rmpct=100.0, power_factor_weighting_fraction=1.0, voltage_limits=(min=0.0, max=999.9), services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+function InterconnectingConverter(; name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits=nothing, dc_current=0.0, max_dc_current=1e8, loss_function=LossCurve(LinearCurve(0.0)), dc_control=VSCDCControlModes.DC_VOLTAGE, ac_control=VSCACControlModes.AC_REACTIVE_POWER, dc_setpoint=0.0, ac_setpoint=1.0, dc_voltage_droop=0.0, remote_bus_control=nothing, rmpct=100.0, power_factor_weighting_fraction=1.0, voltage_limits=(min=0.0, max=999.9), services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
     InterconnectingConverter(name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits, dc_current, max_dc_current, loss_function, dc_control, ac_control, dc_setpoint, ac_setpoint, dc_voltage_droop, remote_bus_control, rmpct, power_factor_weighting_fraction, voltage_limits, services, dynamic_injector, ext, internal, )
 end
 
@@ -137,7 +137,7 @@ function InterconnectingConverter(::Nothing)
         reactive_power_limits=nothing,
         dc_current=0.0,
         max_dc_current=0.0,
-        loss_function=LinearCurve(0.0),
+        loss_function=LossCurve(LinearCurve(0.0)),
         dc_control=VSCDCControlModes.DC_VOLTAGE,
         ac_control=VSCACControlModes.AC_REACTIVE_POWER,
         dc_setpoint=0.0,

--- a/src/models/generated/TwoTerminalGenericHVDCLine.jl
+++ b/src/models/generated/TwoTerminalGenericHVDCLine.jl
@@ -14,7 +14,7 @@ This file is auto-generated. Do not edit.
         active_power_limits_to::MinMax
         reactive_power_limits_from::MinMax
         reactive_power_limits_to::MinMax
-        loss::Union{LinearCurve, PiecewiseIncrementalCurve}
+        loss::Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}
         services::Vector{Service}
         ext::Dict{String, Any}
         internal::InfrastructureSystemsInternal
@@ -33,7 +33,7 @@ This model is appropriate for operational simulations with a linearized DC power
 - `active_power_limits_to::MinMax`: Minimum and maximum active power flows to the TO node (MW)
 - `reactive_power_limits_from::MinMax`: Minimum and maximum reactive power limits to the FROM node (MVAR)
 - `reactive_power_limits_to::MinMax`: Minimum and maximum reactive power limits to the TO node (MVAR)
-- `loss::Union{LinearCurve, PiecewiseIncrementalCurve}`: (default: `LinearCurve(0.0)`) Loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.
+- `loss::Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}`: (default: `LossCurve(LinearCurve(0.0))`) Loss model coefficients, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model with a constant loss and a proportional loss rate (loss per unit of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
 - `internal::InfrastructureSystemsInternal`: (**Do not modify.**) PowerSystems.jl internal reference
@@ -55,8 +55,8 @@ mutable struct TwoTerminalGenericHVDCLine <: TwoTerminalHVDC
     reactive_power_limits_from::MinMax
     "Minimum and maximum reactive power limits to the TO node (MVAR)"
     reactive_power_limits_to::MinMax
-    "Loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments."
-    loss::Union{LinearCurve, PiecewiseIncrementalCurve}
+    "Loss model coefficients, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model with a constant loss and a proportional loss rate (loss per unit of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments."
+    loss::Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}
     "Services that this device contributes to"
     services::Vector{Service}
     "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation."
@@ -65,11 +65,11 @@ mutable struct TwoTerminalGenericHVDCLine <: TwoTerminalHVDC
     internal::InfrastructureSystemsInternal
 end
 
-function TwoTerminalGenericHVDCLine(name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss=LinearCurve(0.0), services=Device[], ext=Dict{String, Any}(), )
+function TwoTerminalGenericHVDCLine(name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss=LossCurve(LinearCurve(0.0)), services=Device[], ext=Dict{String, Any}(), )
     TwoTerminalGenericHVDCLine(name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss, services, ext, InfrastructureSystemsInternal(), )
 end
 
-function TwoTerminalGenericHVDCLine(; name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss=LinearCurve(0.0), services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+function TwoTerminalGenericHVDCLine(; name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss=LossCurve(LinearCurve(0.0)), services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
     TwoTerminalGenericHVDCLine(name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss, services, ext, internal, )
 end
 
@@ -84,7 +84,7 @@ function TwoTerminalGenericHVDCLine(::Nothing)
         active_power_limits_to=(min=0.0, max=0.0),
         reactive_power_limits_from=(min=0.0, max=0.0),
         reactive_power_limits_to=(min=0.0, max=0.0),
-        loss=LinearCurve(0.0),
+        loss=LossCurve(LinearCurve(0.0)),
         services=Device[],
         ext=Dict{String, Any}(),
     )

--- a/src/models/generated/TwoTerminalLCCLine.jl
+++ b/src/models/generated/TwoTerminalLCCLine.jl
@@ -43,7 +43,7 @@ This file is auto-generated. Do not edit.
         active_power_limits_to::MinMax
         reactive_power_limits_from::MinMax
         reactive_power_limits_to::MinMax
-        loss::Union{LinearCurve, PiecewiseIncrementalCurve}
+        loss::Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}
         services::Vector{Service}
         ext::Dict{String, Any}
         internal::InfrastructureSystemsInternal
@@ -91,7 +91,7 @@ As implemented in PSS/E.
 - `active_power_limits_to::MinMax`: (default: `(min=0.0, max=0.0)`) Minimum and maximum active power flows to the TO node (MW)
 - `reactive_power_limits_from::MinMax`: (default: `(min=0.0, max=0.0)`) Minimum and maximum reactive power limits to the FROM node (MVAR)
 - `reactive_power_limits_to::MinMax`: (default: `(min=0.0, max=0.0)`) Minimum and maximum reactive power limits to the TO node (MVAR)
-- `loss::Union{LinearCurve, PiecewiseIncrementalCurve}`: (default: `LinearCurve(0.0)`) A generic loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.
+- `loss::Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}`: (default: `LossCurve(LinearCurve(0.0))`) A generic loss model coefficients, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model with a constant loss and a proportional loss rate (loss per unit of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
 - `internal::InfrastructureSystemsInternal`: (**Do not modify.**) PowerSystems.jl internal reference
@@ -171,8 +171,8 @@ mutable struct TwoTerminalLCCLine <: TwoTerminalHVDC
     reactive_power_limits_from::MinMax
     "Minimum and maximum reactive power limits to the TO node (MVAR)"
     reactive_power_limits_to::MinMax
-    "A generic loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments."
-    loss::Union{LinearCurve, PiecewiseIncrementalCurve}
+    "A generic loss model coefficients, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model with a constant loss and a proportional loss rate (loss per unit of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments."
+    loss::Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}
     "Services that this device contributes to"
     services::Vector{Service}
     "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation."
@@ -181,11 +181,11 @@ mutable struct TwoTerminalLCCLine <: TwoTerminalHVDC
     internal::InfrastructureSystemsInternal
 end
 
-function TwoTerminalLCCLine(name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode=true, switch_mode_voltage=0.0, compounding_resistance=0.0, min_compounding_voltage=0.0, rectifier_transformer_ratio=1.0, rectifier_tap_setting=1.0, rectifier_tap_limits=(min=0.51, max=1.5), rectifier_tap_step=0.00625, rectifier_delay_angle=0.0, rectifier_capacitor_reactance=0.0, inverter_transformer_ratio=1.0, inverter_tap_setting=1.0, inverter_tap_limits=(min=0.51, max=1.5), inverter_tap_step=0.00625, inverter_extinction_angle=0.0, inverter_capacitor_reactance=0.0, active_power_limits_from=(min=0.0, max=0.0), active_power_limits_to=(min=0.0, max=0.0), reactive_power_limits_from=(min=0.0, max=0.0), reactive_power_limits_to=(min=0.0, max=0.0), loss=LinearCurve(0.0), services=Device[], ext=Dict{String, Any}(), )
+function TwoTerminalLCCLine(name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode=true, switch_mode_voltage=0.0, compounding_resistance=0.0, min_compounding_voltage=0.0, rectifier_transformer_ratio=1.0, rectifier_tap_setting=1.0, rectifier_tap_limits=(min=0.51, max=1.5), rectifier_tap_step=0.00625, rectifier_delay_angle=0.0, rectifier_capacitor_reactance=0.0, inverter_transformer_ratio=1.0, inverter_tap_setting=1.0, inverter_tap_limits=(min=0.51, max=1.5), inverter_tap_step=0.00625, inverter_extinction_angle=0.0, inverter_capacitor_reactance=0.0, active_power_limits_from=(min=0.0, max=0.0), active_power_limits_to=(min=0.0, max=0.0), reactive_power_limits_from=(min=0.0, max=0.0), reactive_power_limits_to=(min=0.0, max=0.0), loss=LossCurve(LinearCurve(0.0)), services=Device[], ext=Dict{String, Any}(), )
     TwoTerminalLCCLine(name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode, switch_mode_voltage, compounding_resistance, min_compounding_voltage, rectifier_transformer_ratio, rectifier_tap_setting, rectifier_tap_limits, rectifier_tap_step, rectifier_delay_angle, rectifier_capacitor_reactance, inverter_transformer_ratio, inverter_tap_setting, inverter_tap_limits, inverter_tap_step, inverter_extinction_angle, inverter_capacitor_reactance, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss, services, ext, InfrastructureSystemsInternal(), )
 end
 
-function TwoTerminalLCCLine(; name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode=true, switch_mode_voltage=0.0, compounding_resistance=0.0, min_compounding_voltage=0.0, rectifier_transformer_ratio=1.0, rectifier_tap_setting=1.0, rectifier_tap_limits=(min=0.51, max=1.5), rectifier_tap_step=0.00625, rectifier_delay_angle=0.0, rectifier_capacitor_reactance=0.0, inverter_transformer_ratio=1.0, inverter_tap_setting=1.0, inverter_tap_limits=(min=0.51, max=1.5), inverter_tap_step=0.00625, inverter_extinction_angle=0.0, inverter_capacitor_reactance=0.0, active_power_limits_from=(min=0.0, max=0.0), active_power_limits_to=(min=0.0, max=0.0), reactive_power_limits_from=(min=0.0, max=0.0), reactive_power_limits_to=(min=0.0, max=0.0), loss=LinearCurve(0.0), services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+function TwoTerminalLCCLine(; name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode=true, switch_mode_voltage=0.0, compounding_resistance=0.0, min_compounding_voltage=0.0, rectifier_transformer_ratio=1.0, rectifier_tap_setting=1.0, rectifier_tap_limits=(min=0.51, max=1.5), rectifier_tap_step=0.00625, rectifier_delay_angle=0.0, rectifier_capacitor_reactance=0.0, inverter_transformer_ratio=1.0, inverter_tap_setting=1.0, inverter_tap_limits=(min=0.51, max=1.5), inverter_tap_step=0.00625, inverter_extinction_angle=0.0, inverter_capacitor_reactance=0.0, active_power_limits_from=(min=0.0, max=0.0), active_power_limits_to=(min=0.0, max=0.0), reactive_power_limits_from=(min=0.0, max=0.0), reactive_power_limits_to=(min=0.0, max=0.0), loss=LossCurve(LinearCurve(0.0)), services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
     TwoTerminalLCCLine(name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode, switch_mode_voltage, compounding_resistance, min_compounding_voltage, rectifier_transformer_ratio, rectifier_tap_setting, rectifier_tap_limits, rectifier_tap_step, rectifier_delay_angle, rectifier_capacitor_reactance, inverter_transformer_ratio, inverter_tap_setting, inverter_tap_limits, inverter_tap_step, inverter_extinction_angle, inverter_capacitor_reactance, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss, services, ext, internal, )
 end
 
@@ -229,7 +229,7 @@ function TwoTerminalLCCLine(::Nothing)
         active_power_limits_to=(min=0.0, max=0.0),
         reactive_power_limits_from=(min=0.0, max=0.0),
         reactive_power_limits_to=(min=0.0, max=0.0),
-        loss=LinearCurve(0.0),
+        loss=LossCurve(LinearCurve(0.0)),
         services=Device[],
         ext=Dict{String, Any}(),
     )

--- a/src/models/generated/TwoTerminalVSCLine.jl
+++ b/src/models/generated/TwoTerminalVSCLine.jl
@@ -20,7 +20,7 @@ This file is auto-generated. Do not edit.
         ac_control_from::VSCACControlModes
         dc_setpoint_from::Float64
         ac_setpoint_from::Float64
-        converter_loss_from::Union{LinearCurve, QuadraticCurve}
+        converter_loss_from::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}
         max_dc_current_from::Float64
         rating_from::Float64
         reactive_power_limits_from::MinMax
@@ -32,7 +32,7 @@ This file is auto-generated. Do not edit.
         ac_control_to::VSCACControlModes
         dc_setpoint_to::Float64
         ac_setpoint_to::Float64
-        converter_loss_to::Union{LinearCurve, QuadraticCurve}
+        converter_loss_to::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}
         max_dc_current_to::Float64
         rating_to::Float64
         reactive_power_limits_to::MinMax
@@ -68,7 +68,7 @@ This model is appropriate for operational simulations with a linearized DC power
 - `ac_control_from::VSCACControlModes`: (default: `VSCACControlModes.AC_VOLTAGE`) AC-side control mode of the `from` converter; see [`VSCACControlModes`](@ref).
 - `dc_setpoint_from::Float64`: (default: `0.0`) Converter DC setpoint on the `from` bus converter, in per-unit. For a DC-voltage-controlling mode (`dc_control_from` is `DC_VOLTAGE` or `DC_VOLTAGE_DROOP`) this is the DC-side voltage in per-unit of `rated_dc_voltage`. For `DC_POWER` this is the active-power demand in per-unit ([`SYSTEM_BASE`](@ref per_unit)); positive means the converter supplies power to the AC network at the `from` bus, negative means it withdraws.
 - `ac_setpoint_from::Float64`: (default: `1.0`) Converter AC setpoint in the `from` bus converter. If `voltage_control_from = true` this number is the AC voltage on the AC side of the converter, entered in [per unit](@ref per_unit). If `voltage_control_from = false`, this value is the power factor setpoint.
-- `converter_loss_from::Union{LinearCurve, QuadraticCurve}`: (default: `LinearCurve(0.0)`) Loss model coefficients in the `from` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.
+- `converter_loss_from::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}`: (default: `LossCurve(LinearCurve(0.0))`) Loss model coefficients in the `from` bus converter, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model or quadratic. Same converter data is used in both ends.
 - `max_dc_current_from::Float64`: (default: `1e8`) Maximum stable dc current limits (A).
 - `rating_from::Float64`: (default: `1e8`) Converter rating in MVA in the `from` bus.
 - `reactive_power_limits_from::MinMax`: (default: `(min=0.0, max=0.0)`) Limits on the Reactive Power at the `from` side.
@@ -80,7 +80,7 @@ This model is appropriate for operational simulations with a linearized DC power
 - `ac_control_to::VSCACControlModes`: (default: `VSCACControlModes.AC_VOLTAGE`) AC-side control mode of the `to` converter; see [`VSCACControlModes`](@ref).
 - `dc_setpoint_to::Float64`: (default: `0.0`) Converter DC setpoint on the `to` bus converter, in per-unit. For a DC-voltage-controlling mode (`dc_control_to` is `DC_VOLTAGE` or `DC_VOLTAGE_DROOP`) this is the DC-side voltage in per-unit of `rated_dc_voltage`. For `DC_POWER` this is the active-power demand in per-unit ([`SYSTEM_BASE`](@ref per_unit)); positive means the converter supplies power to the AC network at the `to` bus, negative means it withdraws.
 - `ac_setpoint_to::Float64`: (default: `1.0`) Converter AC setpoint in the `to` bus converter. If `voltage_control_to = true` this number is the AC voltage on the AC side of the converter, entered in [per unit](@ref per_unit). If `voltage_control_to = false`, this value is the power factor setpoint.
-- `converter_loss_to::Union{LinearCurve, QuadraticCurve}`: (default: `LinearCurve(0.0)`) Loss model coefficients in the `to` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.
+- `converter_loss_to::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}`: (default: `LossCurve(LinearCurve(0.0))`) Loss model coefficients in the `to` bus converter, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model or quadratic. Same converter data is used in both ends.
 - `max_dc_current_to::Float64`: (default: `1e8`) Maximum stable dc current limits (A).
 - `rating_to::Float64`: (default: `1e8`) Converter rating in MVA in the `to` bus.
 - `reactive_power_limits_to::MinMax`: (default: `(min=0.0, max=0.0)`) Limits on the Reactive Power at the `to` side.
@@ -125,8 +125,8 @@ mutable struct TwoTerminalVSCLine <: TwoTerminalHVDC
     dc_setpoint_from::Float64
     "Converter AC setpoint in the `from` bus converter. If `voltage_control_from = true` this number is the AC voltage on the AC side of the converter, entered in [per unit](@ref per_unit). If `voltage_control_from = false`, this value is the power factor setpoint."
     ac_setpoint_from::Float64
-    "Loss model coefficients in the `from` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends."
-    converter_loss_from::Union{LinearCurve, QuadraticCurve}
+    "Loss model coefficients in the `from` bus converter, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model or quadratic. Same converter data is used in both ends."
+    converter_loss_from::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}
     "Maximum stable dc current limits (A)."
     max_dc_current_from::Float64
     "Converter rating in MVA in the `from` bus."
@@ -149,8 +149,8 @@ mutable struct TwoTerminalVSCLine <: TwoTerminalHVDC
     dc_setpoint_to::Float64
     "Converter AC setpoint in the `to` bus converter. If `voltage_control_to = true` this number is the AC voltage on the AC side of the converter, entered in [per unit](@ref per_unit). If `voltage_control_to = false`, this value is the power factor setpoint."
     ac_setpoint_to::Float64
-    "Loss model coefficients in the `to` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends."
-    converter_loss_to::Union{LinearCurve, QuadraticCurve}
+    "Loss model coefficients in the `to` bus converter, as a [`LossCurve`](@ref) whose `power_units` declare the unit system of the curve's axes. It accepts a linear model or quadratic. Same converter data is used in both ends."
+    converter_loss_to::Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}
     "Maximum stable dc current limits (A)."
     max_dc_current_to::Float64
     "Converter rating in MVA in the `to` bus."
@@ -181,11 +181,11 @@ mutable struct TwoTerminalVSCLine <: TwoTerminalHVDC
     internal::InfrastructureSystemsInternal
 end
 
-function TwoTerminalVSCLine(name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g=0.0, dc_current=0.0, reactive_power_from=0.0, dc_control_from=VSCDCControlModes.DC_VOLTAGE, ac_control_from=VSCACControlModes.AC_VOLTAGE, dc_setpoint_from=0.0, ac_setpoint_from=1.0, converter_loss_from=LinearCurve(0.0), max_dc_current_from=1e8, rating_from=1e8, reactive_power_limits_from=(min=0.0, max=0.0), power_factor_weighting_fraction_from=1.0, voltage_limits_from=(min=0.0, max=999.9), dc_voltage_droop_from=0.0, reactive_power_to=0.0, dc_control_to=VSCDCControlModes.DC_VOLTAGE, ac_control_to=VSCACControlModes.AC_VOLTAGE, dc_setpoint_to=0.0, ac_setpoint_to=1.0, converter_loss_to=LinearCurve(0.0), max_dc_current_to=1e8, rating_to=1e8, reactive_power_limits_to=(min=0.0, max=0.0), power_factor_weighting_fraction_to=1.0, voltage_limits_to=(min=0.0, max=999.9), dc_voltage_droop_to=0.0, rated_dc_voltage=0.0, remote_bus_control_from=nothing, remote_bus_control_to=nothing, rmpct_from=100.0, rmpct_to=100.0, services=Device[], ext=Dict{String, Any}(), )
+function TwoTerminalVSCLine(name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g=0.0, dc_current=0.0, reactive_power_from=0.0, dc_control_from=VSCDCControlModes.DC_VOLTAGE, ac_control_from=VSCACControlModes.AC_VOLTAGE, dc_setpoint_from=0.0, ac_setpoint_from=1.0, converter_loss_from=LossCurve(LinearCurve(0.0)), max_dc_current_from=1e8, rating_from=1e8, reactive_power_limits_from=(min=0.0, max=0.0), power_factor_weighting_fraction_from=1.0, voltage_limits_from=(min=0.0, max=999.9), dc_voltage_droop_from=0.0, reactive_power_to=0.0, dc_control_to=VSCDCControlModes.DC_VOLTAGE, ac_control_to=VSCACControlModes.AC_VOLTAGE, dc_setpoint_to=0.0, ac_setpoint_to=1.0, converter_loss_to=LossCurve(LinearCurve(0.0)), max_dc_current_to=1e8, rating_to=1e8, reactive_power_limits_to=(min=0.0, max=0.0), power_factor_weighting_fraction_to=1.0, voltage_limits_to=(min=0.0, max=999.9), dc_voltage_droop_to=0.0, rated_dc_voltage=0.0, remote_bus_control_from=nothing, remote_bus_control_to=nothing, rmpct_from=100.0, rmpct_to=100.0, services=Device[], ext=Dict{String, Any}(), )
     TwoTerminalVSCLine(name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g, dc_current, reactive_power_from, dc_control_from, ac_control_from, dc_setpoint_from, ac_setpoint_from, converter_loss_from, max_dc_current_from, rating_from, reactive_power_limits_from, power_factor_weighting_fraction_from, voltage_limits_from, dc_voltage_droop_from, reactive_power_to, dc_control_to, ac_control_to, dc_setpoint_to, ac_setpoint_to, converter_loss_to, max_dc_current_to, rating_to, reactive_power_limits_to, power_factor_weighting_fraction_to, voltage_limits_to, dc_voltage_droop_to, rated_dc_voltage, remote_bus_control_from, remote_bus_control_to, rmpct_from, rmpct_to, services, ext, InfrastructureSystemsInternal(), )
 end
 
-function TwoTerminalVSCLine(; name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g=0.0, dc_current=0.0, reactive_power_from=0.0, dc_control_from=VSCDCControlModes.DC_VOLTAGE, ac_control_from=VSCACControlModes.AC_VOLTAGE, dc_setpoint_from=0.0, ac_setpoint_from=1.0, converter_loss_from=LinearCurve(0.0), max_dc_current_from=1e8, rating_from=1e8, reactive_power_limits_from=(min=0.0, max=0.0), power_factor_weighting_fraction_from=1.0, voltage_limits_from=(min=0.0, max=999.9), dc_voltage_droop_from=0.0, reactive_power_to=0.0, dc_control_to=VSCDCControlModes.DC_VOLTAGE, ac_control_to=VSCACControlModes.AC_VOLTAGE, dc_setpoint_to=0.0, ac_setpoint_to=1.0, converter_loss_to=LinearCurve(0.0), max_dc_current_to=1e8, rating_to=1e8, reactive_power_limits_to=(min=0.0, max=0.0), power_factor_weighting_fraction_to=1.0, voltage_limits_to=(min=0.0, max=999.9), dc_voltage_droop_to=0.0, rated_dc_voltage=0.0, remote_bus_control_from=nothing, remote_bus_control_to=nothing, rmpct_from=100.0, rmpct_to=100.0, services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+function TwoTerminalVSCLine(; name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g=0.0, dc_current=0.0, reactive_power_from=0.0, dc_control_from=VSCDCControlModes.DC_VOLTAGE, ac_control_from=VSCACControlModes.AC_VOLTAGE, dc_setpoint_from=0.0, ac_setpoint_from=1.0, converter_loss_from=LossCurve(LinearCurve(0.0)), max_dc_current_from=1e8, rating_from=1e8, reactive_power_limits_from=(min=0.0, max=0.0), power_factor_weighting_fraction_from=1.0, voltage_limits_from=(min=0.0, max=999.9), dc_voltage_droop_from=0.0, reactive_power_to=0.0, dc_control_to=VSCDCControlModes.DC_VOLTAGE, ac_control_to=VSCACControlModes.AC_VOLTAGE, dc_setpoint_to=0.0, ac_setpoint_to=1.0, converter_loss_to=LossCurve(LinearCurve(0.0)), max_dc_current_to=1e8, rating_to=1e8, reactive_power_limits_to=(min=0.0, max=0.0), power_factor_weighting_fraction_to=1.0, voltage_limits_to=(min=0.0, max=999.9), dc_voltage_droop_to=0.0, rated_dc_voltage=0.0, remote_bus_control_from=nothing, remote_bus_control_to=nothing, rmpct_from=100.0, rmpct_to=100.0, services=Device[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
     TwoTerminalVSCLine(name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g, dc_current, reactive_power_from, dc_control_from, ac_control_from, dc_setpoint_from, ac_setpoint_from, converter_loss_from, max_dc_current_from, rating_from, reactive_power_limits_from, power_factor_weighting_fraction_from, voltage_limits_from, dc_voltage_droop_from, reactive_power_to, dc_control_to, ac_control_to, dc_setpoint_to, ac_setpoint_to, converter_loss_to, max_dc_current_to, rating_to, reactive_power_limits_to, power_factor_weighting_fraction_to, voltage_limits_to, dc_voltage_droop_to, rated_dc_voltage, remote_bus_control_from, remote_bus_control_to, rmpct_from, rmpct_to, services, ext, internal, )
 end
 
@@ -206,7 +206,7 @@ function TwoTerminalVSCLine(::Nothing)
         ac_control_from=VSCACControlModes.AC_VOLTAGE,
         dc_setpoint_from=0.0,
         ac_setpoint_from=0.0,
-        converter_loss_from=LinearCurve(0.0),
+        converter_loss_from=LossCurve(LinearCurve(0.0)),
         max_dc_current_from=0.0,
         rating_from=0.0,
         reactive_power_limits_from=(min=0.0, max=0.0),
@@ -218,7 +218,7 @@ function TwoTerminalVSCLine(::Nothing)
         ac_control_to=VSCACControlModes.AC_VOLTAGE,
         dc_setpoint_to=0.0,
         ac_setpoint_to=0.0,
-        converter_loss_to=LinearCurve(0.0),
+        converter_loss_to=LossCurve(LinearCurve(0.0)),
         max_dc_current_to=0.0,
         rating_to=0.0,
         reactive_power_limits_to=(min=0.0, max=0.0),

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,7 +20,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/issue-1728-loss-curve-units"}
 PowerSystemCaseBuilder = {url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl", rev = "psy6"}
 
 [compat]

--- a/test/test_loss_curves.jl
+++ b/test/test_loss_curves.jl
@@ -1,0 +1,69 @@
+const LOSS_CURVE_FIELDS = [
+    (TwoTerminalGenericHVDCLine, get_loss, set_loss!),
+    (TwoTerminalLCCLine, get_loss, set_loss!),
+    (InterconnectingConverter, get_loss_function, set_loss_function!),
+]
+
+@testset "Loss curve field types" begin
+    for T in (TwoTerminalGenericHVDCLine, TwoTerminalLCCLine)
+        @test fieldtype(T, :loss) ==
+              Union{LossCurve{LinearCurve}, LossCurve{PiecewiseIncrementalCurve}}
+    end
+    @test fieldtype(InterconnectingConverter, :loss_function) ==
+          Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}
+    for field in (:converter_loss_from, :converter_loss_to)
+        @test fieldtype(TwoTerminalVSCLine, field) ==
+              Union{LossCurve{LinearCurve}, LossCurve{QuadraticCurve}}
+    end
+end
+
+@testset "Loss curve fields default to a LossCurve in natural units" begin
+    for (T, getter, _) in LOSS_CURVE_FIELDS
+        curve = getter(T(nothing))
+        @test get_power_units(curve) == IS.NaturalUnit()
+        @test get_value_curve(curve) == LinearCurve(0.0)
+    end
+
+    vsc = TwoTerminalVSCLine(nothing)
+    for curve in (get_converter_loss_from(vsc), get_converter_loss_to(vsc))
+        @test get_power_units(curve) == IS.NaturalUnit()
+    end
+end
+
+@testset "Loss curves round-trip their unit system through the accessors" begin
+    for (T, getter, setter) in LOSS_CURVE_FIELDS
+        device = T(nothing)
+        for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.DeviceBaseUnit())
+            setter(device, LossCurve(LinearCurve(0.02, 1.5), U))
+            @test get_power_units(getter(device)) == U
+            @test get_value_curve(getter(device)) == LinearCurve(0.02, 1.5)
+        end
+    end
+end
+
+@testset "Loss curves survive serialization with their unit system" begin
+    loss = LossCurve(QuadraticCurve(0.001, 0.02, 0.0), IS.SystemBaseUnit())
+
+    sys = System(100.0)
+    bus = ACBus(nothing)
+    bus.name = "bus1"
+    bus.number = 1
+    bus.bustype = ACBusTypes.REF  # This prevents an error log message
+    add_component!(sys, bus)
+    dc_bus = DCBus(nothing)
+    dc_bus.name = "dc_bus1"
+    dc_bus.number = 2
+    add_component!(sys, dc_bus)
+
+    converter = InterconnectingConverter(nothing)
+    converter.name = "converter1"
+    converter.bus = bus
+    converter.dc_bus = dc_bus
+    set_loss_function!(converter, loss)
+    add_component!(sys, converter)
+
+    sys2 = from_json(to_json(sys), System)
+    round_tripped = get_component(InterconnectingConverter, sys2, "converter1")
+    @test get_loss_function(round_tripped) == loss
+    @test get_power_units(get_loss_function(round_tripped)) == IS.SystemBaseUnit()
+end


### PR DESCRIPTION
Fixes #1728. Pairs with InfrastructureSystems.jl#603 — `Project.toml`/`test/Project.toml` are pinned to that branch so CI resolves; revert to `rev = "IS4"` once it merges.

`TwoTerminalGenericHVDCLine.loss`, `TwoTerminalLCCLine.loss`, `TwoTerminalVSCLine.converter_loss_{from,to}` and `InterconnectingConverter.loss_function` were bare `ValueCurve`s with no units attached. They now take `LossCurve`s, which carry an `AbstractUnitSystem` marker as a type parameter, so the units travel with the value. Permitted curve shapes are unchanged.

`LossCurve` shares the units machinery with the cost curves via the new `ValueCurveWithUnits` supertype, but is not a `ProductionVariableCostCurve`, so cost fields still reject it.

## Note on field typing

The fields go from a union of two concrete types to a union of two `UnionAll`s (open in the units parameter), so `isconcretetype` is now false. In practice this costs nothing:

- **Storage is unchanged** — neither `LinearCurve` nor `PiecewiseIncrementalCurve` is `isbitstype`, so the field was already a boxed pointer.
- **Curve-shape inference is unchanged** — old and new both infer `get_function_data` as `Union{LinearFunctionData, PiecewiseStepData}`. Each arm still pins the curve parameter, and the open units parameter carries no data.
- The one difference is `get_power_units`, which infers `Any` — un-inferable by design, since fixing it would mean fixing the units per field.

For the record: deferring the shape check to a runtime setter validation (bare `LossCurve` field) would be worse, dropping `get_function_data` inference to `Any` for no gain.

## Downstream

Callers must now say which unit system they mean. Not fixed here:

- **PSCB** — `dc_branch_csv_parser!` and `psi_library.jl` pass bare curves; this is what currently fails PSY CI (58 errors, single root cause).
- **PSI / POM** — `isa(loss, PSY.LinearCurve)` guards need to look through the wrapper. POM's `mt_hvdc_models/HVDCsystems.jl` also has the device-base assumption from #1728 written down in a comment; that can now be checked rather than assumed.

Tests: 5685 pass, 0 failed. The 58 errors are the PSCB issue above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)