### PR TITLE
add switched shunt control flag

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -160,13 +160,15 @@ IS.@scoped_enum(
     DISCRETE_REACTIVE_PLANT = 3,
     DISCRETE_REACTIVE_VSC = 4,
     DISCRETE_ADMITTANCE_REMOTE = 5,
+    DISCRETE_REACTIVE_FACTS = 6,
 )
 @doc"
 Control mode of a switched shunt. The enumerator maps the integer MODSW control-mode field
 of a switched-shunt record to a named mode: `FIXED` = 0, `DISCRETE_VOLTAGE` = 1,
 `CONTINUOUS_VOLTAGE` = 2, `DISCRETE_REACTIVE_PLANT` = 3, `DISCRETE_REACTIVE_VSC` = 4,
-`DISCRETE_ADMITTANCE_REMOTE` = 5; `UNDEFINED` = -99 when unset. The names describe each mode;
-consult your source data's own documentation for the precise definition of each control mode.
+`DISCRETE_ADMITTANCE_REMOTE` = 5, `DISCRETE_REACTIVE_FACTS` = 6; `UNDEFINED` = -99 when
+unset. The names describe each mode; consult your source data's own documentation for the
+precise definition of each control mode.
 " SwitchedAdmittanceControlMode
 
 IS.@scoped_enum(


### PR DESCRIPTION
Adds a missing control flag from PSSE to the enum. 