### PR TITLE
Add regression tests for TwoTerminalVSCLine Bool control modes

### DIFF
--- a/src/models/serialization.jl
+++ b/src/models/serialization.jl
@@ -117,6 +117,23 @@ function IS.deserialize(::Type{Device}, data::Dict)
     return
 end
 
+# Systems serialized before the VSC control modes became scoped enums store these fields as
+# `Bool`. The generic scoped-enum deserializer only understands the value name, so dispatch on
+# `Bool` to make the mapping explicit instead of leaning on `Bool <: Integer`.
+function IS.deserialize(::Type{VSCDCControlModes}, regulates_dc_voltage::Bool)
+    if regulates_dc_voltage
+        return VSCDCControlModes.DC_VOLTAGE
+    end
+    return VSCDCControlModes.DC_POWER
+end
+
+function IS.deserialize(::Type{VSCACControlModes}, regulates_ac_voltage::Bool)
+    if regulates_ac_voltage
+        return VSCACControlModes.AC_VOLTAGE
+    end
+    return VSCACControlModes.AC_REACTIVE_POWER
+end
+
 function _check_uuid_in_component_cache(uuid::Base.UUID, component_cache)
     if !haskey(component_cache, uuid)
         error(

--- a/test/test_constructors.jl
+++ b/test/test_constructors.jl
@@ -128,3 +128,42 @@ end
     ts = Scenarios("scalingfactor", data, Hour(1))
     @test ts isa PowerSystems.TimeSeriesData
 end
+
+@testset "Test VSC control mode enum values match the legacy Bool semantics" begin
+    # A `Bool` in these fields resolves through IS's generic `convert(::Type{T}, ::Integer)`,
+    # so the voltage-controlling mode must stay at 1 and its counterpart at 0. Reordering
+    # either enum silently inverts every legacy value.
+    @test convert(VSCDCControlModes, false) == VSCDCControlModes.DC_POWER
+    @test convert(VSCDCControlModes, true) == VSCDCControlModes.DC_VOLTAGE
+    @test convert(VSCACControlModes, false) == VSCACControlModes.AC_REACTIVE_POWER
+    @test convert(VSCACControlModes, true) == VSCACControlModes.AC_VOLTAGE
+end
+
+@testset "Test TwoTerminalVSCLine construction with Bool control modes" begin
+    bus_from = ACBus(1, "bus_from", true, ACBusTypes.REF, 0.0, 1.0,
+        (min = 0.9, max = 1.1), 230.0)
+    bus_to = ACBus(2, "bus_to", true, ACBusTypes.PV, 0.0, 1.0,
+        (min = 0.9, max = 1.1), 230.0)
+    vsc = TwoTerminalVSCLine(;
+        name = "vsc",
+        available = true,
+        arc = Arc(bus_from, bus_to),
+        active_power_flow = 0.0,
+        rating = 2.0,
+        active_power_limits_from = (min = -2.0, max = 2.0),
+        active_power_limits_to = (min = -2.0, max = 2.0),
+        dc_control_from = true,
+        ac_control_from = false,
+        dc_control_to = false,
+        ac_control_to = true,
+    )
+    @test get_dc_control_from(vsc) == VSCDCControlModes.DC_VOLTAGE
+    @test get_ac_control_from(vsc) == VSCACControlModes.AC_REACTIVE_POWER
+    @test get_dc_control_to(vsc) == VSCDCControlModes.DC_POWER
+    @test get_ac_control_to(vsc) == VSCACControlModes.AC_VOLTAGE
+
+    set_dc_control_from!(vsc, false)
+    set_ac_control_to!(vsc, false)
+    @test get_dc_control_from(vsc) == VSCDCControlModes.DC_POWER
+    @test get_ac_control_to(vsc) == VSCACControlModes.AC_REACTIVE_POWER
+end

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -456,3 +456,36 @@ end
     # fields absent in the old schema fall back to their defaults
     @test get_rated_dc_voltage(vsc) == 0.0
 end
+
+@testset "Test deserialization of TwoTerminalVSCLine control modes stored as Bools" begin
+    # Some serialized systems carry `Bool` values in the `*_control_*` fields rather than the
+    # scoped-enum names. `Bool <: Integer`, so IS's generic scoped-enum `convert` resolves them
+    # in the keyword constructor that the component deserializer calls.
+    bus_from = ACBus(1, "bus_from", true, ACBusTypes.REF, 0.0, 1.0,
+        (min = 0.9, max = 1.1), 230.0)
+    bus_to = ACBus(2, "bus_to", true, ACBusTypes.PV, 0.0, 1.0,
+        (min = 0.9, max = 1.1), 230.0)
+    arc = Arc(bus_from, bus_to)
+    vsc = TwoTerminalVSCLine(;
+        name = "vsc_bool_modes",
+        available = true,
+        arc = arc,
+        active_power_flow = 0.1,
+        rating = 2.0,
+        active_power_limits_from = (min = -2.0, max = 2.0),
+        active_power_limits_to = (min = -2.0, max = 2.0),
+    )
+
+    data = IS.serialize(vsc)
+    data["dc_control_from"] = true
+    data["ac_control_from"] = false
+    data["dc_control_to"] = false
+    data["ac_control_to"] = true
+
+    component_cache = Dict(IS.get_uuid(arc) => arc)
+    round_tripped = IS.deserialize(TwoTerminalVSCLine, data, component_cache)
+    @test get_dc_control_from(round_tripped) == VSCDCControlModes.DC_VOLTAGE
+    @test get_ac_control_from(round_tripped) == VSCACControlModes.AC_REACTIVE_POWER
+    @test get_dc_control_to(round_tripped) == VSCDCControlModes.DC_POWER
+    @test get_ac_control_to(round_tripped) == VSCACControlModes.AC_VOLTAGE
+end


### PR DESCRIPTION
Legacy serialized systems and older callers carry Bool values in the dc_control_* / ac_control_* fields instead of the VSCDCControlModes / VSCACControlModes scoped enums. That already resolves correctly through IS's generic convert(::Type{T}, ::Integer) plus Bool <: Integer, but nothing pinned the behavior.
