### PR TITLE
Take time series `features` as a Dict instead of slurped keyword arguments

### DIFF
--- a/docs/src/how_to/read_time_series_by_timestamp.md
+++ b/docs/src/how_to/read_time_series_by_timestamp.md
@@ -128,8 +128,8 @@ println(get_static_time_series_reader_grid(reader))
 StaticGrid(initial_timestamp=DateTime("2024-01-01T00:00:00"), resolution=Millisecond(3600000), length=24)
 ```
 
-`resolution` is required and pins the reader to one resolution; `name` and any feature
-key/value pairs narrow the match further:
+`resolution` is required and pins the reader to one resolution; `name` and a `features`
+dictionary narrow the match further:
 
 ```julia
 build_static_time_series_reader(sys; resolution = resolution, name = "load")
@@ -137,7 +137,7 @@ build_static_time_series_reader(
     sys;
     resolution = resolution,
     name = "load",
-    scenario = "high",
+    features = Dict("scenario" => "high"),
 )
 ```
 

--- a/docs/src/tutorials/working_with_time_series.jl
+++ b/docs/src/tutorials/working_with_time_series.jl
@@ -108,7 +108,7 @@ wind_time_series = SingleTimeSeries(;
 # [PowerSimulations.jl](https://sienna-platform.github.io/PowerSimulations.jl/stable/formulation_library/RenewableGen/)
 # for simulations.
 # So far, this time series has been defined, but not attached to our [`System`](@ref) in any way. Now,
-# attach it to `wind1` using [`add_time_series!`](@ref add_time_series!(sys::System, component::Component, time_series::TimeSeriesData; features...)):
+# attach it to `wind1` using [`add_time_series!`](@ref add_time_series!(sys::System, component::Component, time_series::TimeSeriesData; features::Union{Nothing, Dict} = nothing)):
 
 add_time_series!(system, wind1, wind_time_series);
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -1523,8 +1523,8 @@ ts3 = SingleTimeSeries(
     data = time_array_2,
 )
 key1 = add_time_series!(system, component, ts1)
-key2 = add_time_series!(system, component, ts2, scenario = "high")
-key3 = add_time_series!(system, component, ts3, scenario = "low")
+key2 = add_time_series!(system, component, ts2; features = Dict("scenario" => "high"))
+key3 = add_time_series!(system, component, ts3; features = Dict("scenario" => "low"))
 ts1_b = get_time_series(component, key1)
 ts2_b = get_time_series(component, key2)
 ts3_b = get_time_series(component, key3)
@@ -1534,9 +1534,9 @@ function add_time_series!(
     sys::System,
     component::Component,
     time_series::TimeSeriesData;
-    features...,
+    features::Union{Nothing, Dict} = nothing,
 )
-    return IS.add_time_series!(sys.data, component, time_series; features...)
+    return IS.add_time_series!(sys.data, component, time_series; features = features)
 end
 
 """
@@ -1551,9 +1551,9 @@ function add_time_series!(
     sys::System,
     attribute::SupplementalAttribute,
     time_series::TimeSeriesData;
-    features...,
+    features::Union{Nothing, Dict} = nothing,
 )
-    return IS.add_time_series!(sys.data, attribute, time_series; features...)
+    return IS.add_time_series!(sys.data, attribute, time_series; features = features)
 end
 
 """
@@ -1570,9 +1570,9 @@ function add_time_series!(
     sys::System,
     components,
     time_series::TimeSeriesData;
-    features...,
+    features::Union{Nothing, Dict} = nothing,
 )
-    return IS.add_time_series!(sys.data, components, time_series; features...)
+    return IS.add_time_series!(sys.data, components, time_series; features = features)
 end
 
 #=
@@ -1669,9 +1669,15 @@ build_forecast_reader(
     ::Type{T};
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features...,
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: Forecast} =
-    IS.build_forecast_reader(sys.data, T; resolution = resolution, name = name, features...)
+    IS.build_forecast_reader(
+        sys.data,
+        T;
+        resolution = resolution,
+        name = name,
+        features = features,
+    )
 
 """
 Build a `StaticTimeSeriesReader` over every `SingleTimeSeries` in the system.
@@ -1686,13 +1692,13 @@ build_static_time_series_reader(
     sys::System;
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features...,
+    features::Union{Nothing, Dict} = nothing,
 ) =
     IS.build_static_time_series_reader(
         sys.data;
         resolution = resolution,
         name = name,
-        features...,
+        features = features,
     )
 
 """
@@ -1790,7 +1796,7 @@ function remove_time_series!(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     return IS.remove_time_series!(
         sys.data,
@@ -1799,7 +1805,7 @@ function remove_time_series!(
         name;
         resolution = resolution,
         interval = interval,
-        features...,
+        features = features,
     )
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,7 +6,6 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
 InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -21,9 +20,9 @@ PowerInvestmentsOpenAPIModels = "33cb4396-f4d9-4f59-8585-787ebb56cb1b"
 PowerOpenAPIModels = "0730f07c-cff6-4c3b-a9df-c546153be50a"
 PowerOperationsOpenAPIModels = "a372b6d7-45a2-44c2-8199-6a724b72e8ff"
 PowerSystemCaseBuilder = "f00506e0-b84f-492a-93c2-c0a9afc4364e"
+PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 PowerTableDataParser = "2b750c0e-0bff-11f1-9200-1befd75df6be"
 PowerTimeSeriesOpenAPIModels = "8c2f6a0d-6b0e-4d0a-9d8f-2b5e6a4f9c31"
-PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -31,27 +30,19 @@ TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
-# `[sources]` applies ONLY to the top-level project, so a dev'd package's own [sources] are NOT
-# inherited by this environment. The OpenAPI model packages are unregistered, so without
-# repeating them here the test env cannot resolve them at all. PowerDynamics-
-# OpenAPIModels and PowerInvestmentsOpenAPIModels aren't PSY deps directly, but PowerOpenAPIModels
-# (registry version 0.1.0) depends on both and neither is registered, so this env must pin them
-# too or the resolve fails on "has no known versions". Keep these in step with the revs in
-# ../Project.toml.
 [sources]
 InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
-PowerTableDataParser = {rev = "psy6", url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl"}
+PowerCoreOpenAPIModels = {rev = "main", subdir = "PowerCoreOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerDynamicsOpenAPIModels = {rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 PowerFlowFileParser = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl"}
+PowerInvestmentsOpenAPIModels = {rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerOpenAPIModels = {rev = "main", subdir = "PowerOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerOperationsOpenAPIModels = {rev = "main", subdir = "PowerOperationsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 PowerSystemCaseBuilder = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl"}
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
-PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl"}
-PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl"}
-PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOpenAPIModels.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
-PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
+PowerTableDataParser = {rev = "psy6", url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl"}
+PowerTimeSeriesOpenAPIModels = {rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 
 [compat]
-InfraStore = "0.9"
 InfrastructureSystems = "3"
 JSON = "^1.5"
 julia = "^1.10"

--- a/test/test_time_series_features.jl
+++ b/test/test_time_series_features.jl
@@ -1,0 +1,259 @@
+# Coverage for the `features` keyword on the `System`-level time series API. These wrappers
+# take a single `features::Union{Nothing, Dict} = nothing` keyword rather than slurping
+# arbitrary keyword arguments, so the tests here pin both the accepted shape and the
+# filtering behavior it drives.
+
+"""Build a system with `count` `ThermalStandard` units on one bus."""
+function _features_test_system(count::Int = 2)
+    sys = System(100.0)
+    bus = ACBus(nothing)
+    bus.bustype = ACBusTypes.REF
+    add_component!(sys, bus)
+    gens = ThermalStandard[]
+    for i in 1:count
+        gen = ThermalStandard(nothing)
+        gen.name = string(i)
+        gen.bus = bus
+        add_component!(sys, gen)
+        push!(gens, gen)
+    end
+    return sys, gens
+end
+
+const _FEATURES_INITIAL_TIME = Dates.DateTime("2020-01-01T00:00:00")
+const _FEATURES_RESOLUTION = Dates.Hour(1)
+const _FEATURES_LENGTH = 24
+
+function _features_sts(name, values)
+    timestamps = collect(
+        range(
+            _FEATURES_INITIAL_TIME;
+            step = _FEATURES_RESOLUTION,
+            length = _FEATURES_LENGTH,
+        ),
+    )
+    return SingleTimeSeries(;
+        name = name,
+        data = TimeSeries.TimeArray(timestamps, values),
+    )
+end
+
+function _features_forecast(name, values; interval = Dates.Hour(24))
+    initial_times = [_FEATURES_INITIAL_TIME, _FEATURES_INITIAL_TIME + interval]
+    data = SortedDict(it => values for it in initial_times)
+    return Deterministic(name, data, _FEATURES_RESOLUTION)
+end
+
+@testset "Test add_time_series! features on a component" begin
+    sys, gens = _features_test_system(1)
+    gen = gens[1]
+    name = "max_active_power"
+
+    high = Dict("scenario" => "high")
+    low = Dict("scenario" => "low")
+    key_high = add_time_series!(sys, gen, _features_sts(name, collect(1.0:24.0));
+        features = high)
+    key_low = add_time_series!(sys, gen, _features_sts(name, collect(25.0:48.0));
+        features = low)
+
+    # Same type and name; only the features separate them.
+    @test IS.get_features(key_high) == Dict{String, Any}("scenario" => "high")
+    @test IS.get_features(key_low) == Dict{String, Any}("scenario" => "low")
+    @test key_high != key_low
+    @test length(get_time_series_keys(gen)) == 2
+
+    @test get_time_series_values(SingleTimeSeries, gen, name; features = high)[1] == 1.0
+    @test get_time_series_values(SingleTimeSeries, gen, name; features = low)[1] == 25.0
+    @test has_time_series(gen, SingleTimeSeries, name; features = high)
+    @test only(get_time_series_keys(gen; features = high)) == key_high
+
+    # Without features the lookup is ambiguous.
+    @test_throws ArgumentError get_time_series(SingleTimeSeries, gen, name)
+
+    # `features` is one keyword taking a `Dict`, not slurped keyword arguments.
+    @test_throws MethodError add_time_series!(
+        sys,
+        gen,
+        _features_sts("other", collect(1.0:24.0));
+        scenario = "high",
+    )
+
+    # Feature values are restricted to `Bool`, `Real`, and `String`.
+    @test_throws ArgumentError add_time_series!(
+        sys,
+        gen,
+        _features_sts("other", collect(1.0:24.0));
+        features = Dict("scenario" => [1, 2]),
+    )
+
+    # The default is `nothing`, and passing it explicitly is the same as omitting it.
+    key_plain = add_time_series!(sys, gen, _features_sts("plain", collect(1.0:24.0));
+        features = nothing)
+    @test isempty(IS.get_features(key_plain))
+    @test get_time_series_values(SingleTimeSeries, gen, "plain")[1] == 1.0
+end
+
+@testset "Test add_time_series! features on multiple components" begin
+    sys, gens = _features_test_system(2)
+    name = "max_active_power"
+    high = Dict("scenario" => "high")
+
+    key = add_time_series!(sys, gens, _features_sts(name, collect(1.0:24.0));
+        features = high)
+    @test IS.get_features(key) == Dict{String, Any}("scenario" => "high")
+
+    # Every component gets the features, and the array itself is still stored once.
+    keys_by_gen = [only(get_time_series_keys(g; name = name)) for g in gens]
+    @test all(k -> IS.get_features(k) == Dict{String, Any}("scenario" => "high"),
+        keys_by_gen)
+    hashes = [get_time_series_hash(g, k) for (g, k) in zip(gens, keys_by_gen)]
+    @test hashes[1] == hashes[2]
+
+    for gen in gens
+        @test get_time_series_values(SingleTimeSeries, gen, name; features = high)[1] == 1.0
+    end
+end
+
+@testset "Test add_time_series! features on a supplemental attribute" begin
+    sys, gens = _features_test_system(1)
+    gen = gens[1]
+    outage = GeometricDistributionForcedOutage(;
+        mean_time_to_recovery = 1.0,
+        outage_transition_probability = 0.5,
+    )
+    add_supplemental_attribute!(sys, gen, outage)
+
+    name = "outage_rate"
+    # Feature values may also be numeric.
+    key_2030 = add_time_series!(sys, outage, _features_sts(name, collect(1.0:24.0));
+        features = Dict("year" => 2030))
+    key_2040 = add_time_series!(sys, outage, _features_sts(name, collect(25.0:48.0));
+        features = Dict("year" => 2040))
+
+    @test IS.get_features(key_2030) == Dict{String, Any}("year" => 2030)
+    @test IS.get_features(key_2040) == Dict{String, Any}("year" => 2040)
+    @test get_time_series_values(SingleTimeSeries, outage, name;
+        features = Dict("year" => 2030))[1] == 1.0
+    @test get_time_series_values(SingleTimeSeries, outage, name;
+        features = Dict("year" => 2040))[1] == 25.0
+    @test_throws ArgumentError get_time_series(SingleTimeSeries, outage, name)
+end
+
+@testset "Test build_forecast_reader features filter" begin
+    sys, gens = _features_test_system(2)
+    name = "max_active_power"
+    horizon = 24
+    high = Dict("scenario" => "high")
+    low = Dict("scenario" => "low")
+
+    # "high" is shared by both generators; "low" belongs to the first alone.
+    add_time_series!(sys, gens, _features_forecast(name, collect(1.0:horizon));
+        features = high)
+    add_time_series!(sys, gens[1],
+        _features_forecast(name, collect(101.0:(100 + horizon))); features = low)
+
+    reader_all = build_forecast_reader(sys, Deterministic;
+        resolution = _FEATURES_RESOLUTION)
+    @test length(reader_all) == 3
+
+    reader_high = build_forecast_reader(sys, Deterministic;
+        resolution = _FEATURES_RESOLUTION, features = high)
+    @test length(reader_high) == 2
+    @test Set(get_name(e.owner) for e in get_forecast_reader_entries(reader_high)) ==
+          Set(["1", "2"])
+    # Both entries resolve to the one shared array.
+    @test get_num_forecast_slots(reader_high) == 1
+
+    reader_low = build_forecast_reader(sys, Deterministic;
+        resolution = _FEATURES_RESOLUTION, features = low)
+    @test length(reader_low) == 1
+    @test only(get_name(e.owner) for e in get_forecast_reader_entries(reader_low)) == "1"
+
+    read_forecast_window!(reader_low, _FEATURES_INITIAL_TIME)
+    @test get_forecast_window(reader_low, 1) == collect(101.0:(100 + horizon))
+
+    read_forecast_window!(reader_high, _FEATURES_INITIAL_TIME)
+    @test get_forecast_window(reader_high, 1) == collect(1.0:horizon)
+
+    # `name` and `features` narrow together.
+    @test length(
+        build_forecast_reader(sys, Deterministic;
+            resolution = _FEATURES_RESOLUTION, name = name, features = low),
+    ) == 1
+    # A filter that matches nothing is an error in the store, not an empty reader.
+    @test_throws Exception build_forecast_reader(sys, Deterministic;
+        resolution = _FEATURES_RESOLUTION, name = "no_such_name", features = low)
+end
+
+@testset "Test build_static_time_series_reader features filter" begin
+    sys, gens = _features_test_system(2)
+    name = "max_active_power"
+    high = Dict("scenario" => "high")
+    low = Dict("scenario" => "low")
+
+    high_values = collect(1.0:24.0)
+    low_values = collect(101.0:124.0)
+    add_time_series!(sys, gens, _features_sts(name, high_values); features = high)
+    add_time_series!(sys, gens[1], _features_sts(name, low_values); features = low)
+
+    reader_all = build_static_time_series_reader(sys; resolution = _FEATURES_RESOLUTION)
+    @test length(reader_all) == 3
+
+    reader_high = build_static_time_series_reader(sys;
+        resolution = _FEATURES_RESOLUTION, features = high)
+    @test length(reader_high) == 2
+    @test Set(
+        get_name(e.owner) for e in get_static_time_series_reader_entries(
+            reader_high,
+        )
+    ) == Set(["1", "2"])
+    @test get_num_static_time_series_groups(reader_high) == 1
+
+    reader_low = build_static_time_series_reader(sys;
+        resolution = _FEATURES_RESOLUTION, features = low)
+    @test length(reader_low) == 1
+
+    timestamps = collect(
+        range(
+            _FEATURES_INITIAL_TIME;
+            step = _FEATURES_RESOLUTION,
+            length = _FEATURES_LENGTH,
+        ),
+    )
+    for (k, timestamp) in enumerate(timestamps)
+        read_static_time_series_values!(reader_low, timestamp)
+        @test get_static_time_series_value(reader_low, 1) == low_values[k]
+        read_static_time_series_values!(reader_high, timestamp)
+        @test get_static_time_series_value(reader_high, 1) == high_values[k]
+    end
+
+    @test_throws Exception build_static_time_series_reader(sys;
+        resolution = _FEATURES_RESOLUTION, name = "no_such_name", features = high)
+end
+
+@testset "Test remove_time_series! features filter" begin
+    sys, gens = _features_test_system(2)
+    name = "max_active_power"
+    high = Dict("scenario" => "high")
+    low = Dict("scenario" => "low")
+
+    add_time_series!(sys, gens, _features_forecast(name, collect(1.0:24.0));
+        features = high)
+    add_time_series!(sys, gens[1], _features_forecast(name, collect(101.0:124.0));
+        features = low)
+    @test length(get_time_series_keys(gens[1])) == 2
+
+    remove_time_series!(sys, Deterministic, gens[1], name; features = low)
+    @test !has_time_series(gens[1], Deterministic, name; features = low)
+    @test has_time_series(gens[1], Deterministic, name; features = high)
+    # The other owner of the shared array is untouched.
+    @test length(get_time_series_keys(gens[2])) == 1
+
+    # Omitting `features` removes every variant matching the type and name.
+    add_time_series!(sys, gens[1], _features_forecast(name, collect(201.0:224.0));
+        features = low)
+    @test length(get_time_series_keys(gens[1])) == 2
+    remove_time_series!(sys, Deterministic, gens[1], name)
+    @test isempty(get_time_series_keys(gens[1]))
+    @test length(get_time_series_keys(gens[2])) == 1
+end


### PR DESCRIPTION
## What

The `System`-level time series wrappers slurped `features...` and splatted them back into InfrastructureSystems. IS4 takes a single `features::Union{Nothing, Dict} = nothing` keyword, so the wrappers now mirror it:

- `add_time_series!` — component, supplemental attribute, and multi-component methods
- `build_forecast_reader`
- `build_static_time_series_reader`
- `remove_time_series!`

## Tests

Nothing in the suite passed `features` at all, so `test/test_time_series_features.jl` is new. It covers each changed method:

- features round-trip onto the returned `TimeSeriesKey`, and drive feature-scoped retrieval
- the ambiguity `ArgumentError` when two variants share a type and name and no features are given
- a featured array shared across components still stores one copy (equal hashes)
- numeric feature values on a supplemental attribute owner
- both readers filtering by features, including the shared-array slot/group counts
- `remove_time_series!` dropping only the matching variant, and removing every variant when `features` is omitted

It also pins the new signature: a bare `scenario = "high"` keyword is now a `MethodError`, and feature values outside `Bool`/`Real`/`String` are rejected.

## Docs

The `add_time_series!` docstring example and the reader how-to both showed the old bare-keyword spelling, which no longer works. Updated those, plus the tutorial's `@ref` signature.

## Also

Dropped the unused direct `InfraStore` dependency from the test environment.

## Verification

Full suite passes (14343 tests). The docs build has pre-existing failures on `psy6` unrelated to this change (the removed `.m` parser, dropped transformer types, missing IS symbols); none of them reference anything touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pk7idXmkivp83jRoJ4yyAM