### PR TITLE
Address time series by association id and type their element values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,8 +25,20 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
+[extras]
+# Present only so the `[sources]` pin below is legal: Pkg requires a sourced package to
+# appear in `deps` or `extras`.
+InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
+
 [sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+# Co-dev branch revs, not IS4/a release: this branch tracks the association-id time series
+# keys and the function-data element codec. InfraStore is pinned here because it reaches
+# this env only through InfrastructureSystems, and `[sources]` are not inherited
+# transitively. Its git rev supplies the Julia wrapper; the matching native library is NOT
+# in the pinned artifacts, so set INFRASTORE_LIB to a locally built libinfrastore_ffi from
+# the same rev. Switch both to a tagged rev at release.
+InfrastructureSystems = {rev = "dt/key-by-association-id", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+InfraStore = {rev = "dt/function-data-values", url = "https://github.com/NatLabRockies/infrastore", subdir = "julia/InfraStore.jl"}
 # Branch revs, not a tagged release: the x-unit accessors these packages expose are generated
 # and not yet released. Switch to a tagged rev at release.
 # PowerDynamics-/PowerInvestmentsOpenAPIModels are not imported here — they are deps of the
@@ -40,6 +52,8 @@ PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerO
 PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
 
 [compat]
+# For the `[extras]`/`[sources]` co-dev pin above; Aqua requires every extra to carry one.
+InfraStore = "0.10"
 DataStructures = "^0.19"
 Dates = "1"
 DocStringExtensions = "^0.9.2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -25,8 +25,20 @@ PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 TypeTree = "04da0e3b-1cad-4b2c-a963-fc1602baf1af"
 
+[extras]
+# Present only so the `[sources]` pin below is legal: Pkg requires a sourced package to
+# appear in `deps` or `extras`.
+InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
+
 [sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+# Co-dev branch revs, not IS4/a release: this branch tracks the association-id time series
+# keys and the function-data element codec. InfraStore is pinned here because it reaches
+# this env only through InfrastructureSystems, and `[sources]` are not inherited
+# transitively. Its git rev supplies the Julia wrapper; the matching native library is NOT
+# in the pinned artifacts, so set INFRASTORE_LIB to a locally built libinfrastore_ffi from
+# the same rev. Switch both to a tagged rev at release.
+InfrastructureSystems = {rev = "dt/key-by-association-id", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+InfraStore = {rev = "dt/function-data-values", url = "https://github.com/NatLabRockies/infrastore", subdir = "julia/InfraStore.jl"}
 PowerCoreOpenAPIModels = {rev = "main", subdir = "PowerCoreOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 PowerDynamicsOpenAPIModels = {rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 PowerFlowFileParser = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl"}

--- a/docs/src/tutorials/working_with_time_series.jl
+++ b/docs/src/tutorials/working_with_time_series.jl
@@ -351,14 +351,16 @@ show_time_series(wind1)
 # time series in MW instead of scaling factors, let's make sure none of our forecasts exceeds
 # the `max_active_power` parameter.
 # Instead of using `get_time_series_array` where we need to remember some details of
-# the time series we're looking up, let's use [`get_time_series_keys`](@ref) to refresh our
-# memories:
+# the time series we're looking up, let's use [`list_metadata`](@ref) to refresh our
+# memories. Each row describes one attached time series — its name, resolution, timing —
+# and carries the key that addresses it:
 
-keys = get_time_series_keys(wind1)
+metadata = list_metadata(wind1)
 
-# See the forecast key is first, so let's retrieve it using [`get_time_series`](@ref):
+# See the forecast row is first. Take its key with [`get_time_series_key`](@ref) and
+# retrieve the series using [`get_time_series`](@ref):
 
-forecast = get_time_series(wind1, keys[1])
+forecast = get_time_series(wind1, get_time_series_key(metadata[1]))
 
 # See that unlike when we used `get_time_series_array`, this returns an object we can
 # manipulate.

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -411,8 +411,7 @@ export ReservoirLocation
 
 # from IS time_series_structs.jl, time_series_cache.jl
 export TimeSeriesKey
-export StaticTimeSeriesKey
-export ForecastKey
+export TimeSeriesMetadata
 export TimeSeriesCounts
 export ForecastCache
 export StaticTimeSeriesCache
@@ -544,7 +543,10 @@ export get_next_time
 export reset!
 export get_horizon
 export get_forecast_initial_times
-export get_time_series_keys
+export list_metadata
+export get_time_series_metadata
+export get_time_series_key
+export get_association_id
 export show_time_series
 export get_resolution
 export get_data
@@ -755,9 +757,7 @@ import InfrastructureSystems:
     Probabilistic,
     SingleTimeSeries,
     NonSequentialTimeSeries,
-    StaticTimeSeriesKey,
     DeterministicSingleTimeSeries,
-    ForecastKey,
     Scenarios,
     ForecastCache,
     StaticTimeSeriesCache,
@@ -766,6 +766,7 @@ import InfrastructureSystems:
     StaticTimeSeriesReader,
     StaticTimeSeriesReaderEntry,
     TimeSeriesKey,
+    TimeSeriesMetadata,
     TimeSeriesCounts,
     InfrastructureSystemsComponent,
     InfrastructureSystemsType,
@@ -816,7 +817,10 @@ import InfrastructureSystems:
     get_time_series_array,
     get_time_series_timestamps,
     get_time_series_values,
-    get_time_series_keys,
+    list_metadata,
+    get_time_series_metadata,
+    get_time_series_key,
+    get_association_id,
     get_time_series_hash,
     read_forecast_window!,
     get_forecast_window,

--- a/src/base.jl
+++ b/src/base.jl
@@ -1743,9 +1743,14 @@ function IS.get_time_series_multiple(
     resolution = nothing,
     interval = nothing,
 )
+    # Resolve the owners before opening the Channel: a Channel wraps whatever its body
+    # throws in a TaskFailedException, which would bury the orphaned-owner ArgumentError
+    # IS raises for a component removed with `remove_time_series = false`.
+    owners = collect(
+        IS.iterate_components_with_time_series(sys.data; time_series_type = type),
+    )
     Channel{TimeSeriesData}() do channel
-        for component in
-            IS.iterate_components_with_time_series(sys.data; time_series_type = type)
+        for component in owners
             for time_series in get_time_series_multiple(
                 component,
                 filter_func;

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -7,6 +7,15 @@ const TurbinePump = NamedTuple{(:turbine, :pump), Tuple{Float64, Float64}}
 const FromTo_ToFrom = NamedTuple{(:from_to, :to_from), Tuple{Float64, Float64}}
 const StartUpStages = NamedTuple{(:hot, :warm, :cold), NTuple{3, Float64}}
 
+"""
+A [`TimeSeriesKey`](@ref) naming a series whose values are the three start-up cost stages.
+
+Stored series carry their value element type in the key's parameter, so a field declared
+as this rejects a key naming a series of anything but 3-tuples at assignment — the point
+where the mistake was made — instead of at the read that would have unpacked them.
+"""
+const StartUpStagesKey = IS.TimeSeriesKey{<:IS.TimeSeriesData{NTuple{3, Float64}}}
+
 # Intended for use with generators that are not multi-start (e.g. ThermalStandard).
 # Operators use `hot` when they don’t have multiple stages.
 "Convert a single start-up cost value to a `StartUpStages`"

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -81,7 +81,7 @@ a single timestep and return one static `CostCurve`.
 """
 function _resolve_ts_cost_curve(
     component::Component,
-    curve::CostCurve{TimeSeriesPiecewiseIncrementalCurve, U},
+    curve::CostCurve{<:TimeSeriesPiecewiseIncrementalCurve, U},
     start_time::Dates.DateTime,
     len::Int,
 ) where {U <: IS.AbstractUnitSystem}
@@ -233,7 +233,7 @@ _get_reserve_variable_cost(
 
 function _get_reserve_variable_cost(
     service::AbstractReserve,
-    variable::CostCurve{TimeSeriesPiecewiseIncrementalCurve},
+    variable::CostCurve{<:TimeSeriesPiecewiseIncrementalCurve},
     start_time::Union{Nothing, Dates.DateTime},
     len::Union{Nothing, Int},
 )
@@ -340,10 +340,15 @@ function get_fuel_cost(component::StaticInjection;
     len::Union{Nothing, Int} = nothing,
 )
     var_cost = _validate_fuel_curve(component)
+    # The fixed value and the time series key are separate fields on `FuelCurve`, and
+    # exactly one of them is set. Whichever it is goes to `_process_get_cost`, which
+    # dispatches on the scalar/key distinction to read or pass through.
+    fixed = get_fuel_cost(var_cost)
+    fuel_cost = isnothing(fixed) ? get_fuel_cost_time_series(var_cost) : fixed
     return _process_get_cost(
         Float64,
         component,
-        get_fuel_cost(var_cost),
+        fuel_cost,
         nothing,
         start_time,
         len,

--- a/src/models/cost_functions/ImportExportTimeSeriesCost.jl
+++ b/src/models/cost_functions/ImportExportTimeSeriesCost.jl
@@ -12,9 +12,9 @@ For static (non-time-varying) bids, use [`ImportExportCost`](@ref).
 """
 mutable struct ImportExportTimeSeriesCost{U <: IS.AbstractUnitSystem} <: OfferCurveCost
     "Import price curves (time series)"
-    import_offer_curves::CostCurve{TimeSeriesPiecewiseIncrementalCurve, U}
+    import_offer_curves::CostCurve{<:TimeSeriesPiecewiseIncrementalCurve, U}
     "Export price curves (time series)"
-    export_offer_curves::CostCurve{TimeSeriesPiecewiseIncrementalCurve, U}
+    export_offer_curves::CostCurve{<:TimeSeriesPiecewiseIncrementalCurve, U}
     "Weekly limit on the amount of energy that can be imported, defined in MWh."
     energy_import_weekly_limit::Float64
     "Weekly limit on the amount of energy that can be exported, defined in MWh."
@@ -77,7 +77,7 @@ set_energy_export_weekly_limit!(value::ImportExportTimeSeriesCost, val) =
     value.energy_export_weekly_limit = val
 
 """
-Make a time-series-backed `CostCurve{TimeSeriesPiecewiseIncrementalCurve}` from a
+Make a time-series-backed `CostCurve{<:TimeSeriesPiecewiseIncrementalCurve}` from a
 `TimeSeriesKey`, suitable for the `import_offer_curves` or `export_offer_curves` field of
 an [`ImportExportTimeSeriesCost`](@ref).
 """

--- a/src/models/cost_functions/MarketBidTimeSeriesCost.jl
+++ b/src/models/cost_functions/MarketBidTimeSeriesCost.jl
@@ -13,14 +13,16 @@ mutable struct MarketBidTimeSeriesCost{U <: IS.AbstractUnitSystem} <: OfferCurve
     "No load cost (time series)"
     no_load_cost::TimeSeriesLinearCurve
     "Key of a time series of `NTuple{3, Float64}` start-up cost stages, resolved to a
-    `StartUpStages` at a chosen timestep by `get_start_up(device, cost; start_time)`"
-    start_up::IS.ConcreteTimeSeriesKey
+    `StartUpStages` at a chosen timestep by `get_start_up(device, cost; start_time)`.
+    The element type is in the key's parameter, so a key naming a series of anything but
+    3-stage tuples is rejected here rather than at the read."
+    start_up::StartUpStagesKey
     "Shut-down cost (time series)"
     shut_down::TimeSeriesLinearCurve
     "Sell Offer Curves data (time series)"
-    incremental_offer_curves::CostCurve{TimeSeriesPiecewiseIncrementalCurve, U}
+    incremental_offer_curves::CostCurve{<:TimeSeriesPiecewiseIncrementalCurve, U}
     "Buy Offer Curves data (time series)"
-    decremental_offer_curves::CostCurve{TimeSeriesPiecewiseIncrementalCurve, U}
+    decremental_offer_curves::CostCurve{<:TimeSeriesPiecewiseIncrementalCurve, U}
     "Bids for the ancillary services"
     ancillary_service_offers::Vector{Service}
 end
@@ -80,7 +82,7 @@ set_ancillary_service_offers!(value::MarketBidTimeSeriesCost, val) =
     value.ancillary_service_offers = val
 
 """
-Make a time-series-backed `CostCurve{TimeSeriesPiecewiseIncrementalCurve}` from
+Make a time-series-backed `CostCurve{<:TimeSeriesPiecewiseIncrementalCurve}` from
 `TimeSeriesKey` references, suitable for the `incremental_offer_curves` or
 `decremental_offer_curves` field of a [`MarketBidTimeSeriesCost`](@ref).
 """

--- a/src/models/reserves.jl
+++ b/src/models/reserves.jl
@@ -80,7 +80,7 @@ mutable struct OnlineReserve{T <: ReserveDirection, U <: IS.AbstractUnitSystem} 
     "Operating reserve demand curve (static or time-series-backed). `ZERO_OFFER_CURVE` means no curve is defined"
     variable::Union{
         CostCurve{PiecewiseIncrementalCurve, U},
-        CostCurve{TimeSeriesPiecewiseIncrementalCurve, U},
+        CostCurve{<:TimeSeriesPiecewiseIncrementalCurve, U},
     }
     "The time in minutes reserve contribution must be sustained at a specified level"
     sustained_time::Float64
@@ -194,7 +194,7 @@ mutable struct OfflineReserve{U <: IS.AbstractUnitSystem} <: AbstractReserve
     "Operating reserve demand curve (static or time-series-backed). `ZERO_OFFER_CURVE` means no curve is defined"
     variable::Union{
         CostCurve{PiecewiseIncrementalCurve, U},
-        CostCurve{TimeSeriesPiecewiseIncrementalCurve, U},
+        CostCurve{<:TimeSeriesPiecewiseIncrementalCurve, U},
     }
     "The time in minutes reserve contribution must be sustained at a specified level"
     sustained_time::Float64
@@ -313,7 +313,7 @@ mutable struct GroupReserve{T <: ReserveDirection, U <: IS.AbstractUnitSystem} <
     "Operating reserve demand curve for the group (static or time-series-backed). `ZERO_OFFER_CURVE` means no curve is defined"
     variable::Union{
         CostCurve{PiecewiseIncrementalCurve, U},
-        CostCurve{TimeSeriesPiecewiseIncrementalCurve, U},
+        CostCurve{<:TimeSeriesPiecewiseIncrementalCurve, U},
     }
     "An extra dictionary for users to add metadata that are not used in simulation"
     ext::Dict{String, Any}
@@ -500,4 +500,4 @@ end
 
 # The `ZERO_OFFER_CURVE` sentinel is a static curve, so a time-series-backed curve is always a
 # real demand curve.
-_is_zero_offer_curve(::CostCurve{TimeSeriesPiecewiseIncrementalCurve}) = false
+_is_zero_offer_curve(::CostCurve{<:TimeSeriesPiecewiseIncrementalCurve}) = false

--- a/src/openapi/cost_conversion.jl
+++ b/src/openapi/cost_conversion.jl
@@ -21,9 +21,11 @@ convert_cost(w::OpenAPI.OneOfAPIModel, store) = convert_cost(w.value, store)
 # that already receives `refs` (e.g. `Source`) should call the explicit-`store` form
 # instead — see `_convert_source_operation_cost`.
 #
-# The binding itself is IS's `with_deserialization_store`: a document naming a series by
-# its association id is deserialization, and that scope is what `IS.deserialize` on a
-# `TimeSeriesKey` reads. These two wrappers exist only to keep the error domain-specific.
+# The scope is PSY's own. IS used to keep one for `TimeSeriesKey` deserialization, but a
+# serialized key now carries its time series and element types alongside the id and
+# rebuilds itself without a catalog. Only this wire format still names a series by a bare
+# `association_id`, so only this import still needs a store to resolve one against.
+const _IMPORT_STORE = Base.ScopedValues.ScopedValue{IS.Store}()
 
 """No sidecar was adopted, so there is nothing to bind; a document that then names a
 time-series-backed cost fails in `_current_import_store`."""
@@ -31,15 +33,17 @@ _with_import_store(f, ::Nothing) = f()
 
 """Bind `store` for the duration of `f()`. `ScopedValue`-based, so a nested import and a
 task spawned inside one both see the innermost binding."""
-_with_import_store(f, store::IS.Store) = IS.with_deserialization_store(f, store)
+_with_import_store(f, store::IS.Store) =
+    Base.ScopedValues.with(f, _IMPORT_STORE => store)
 
 function _current_import_store()
-    IS.has_deserialization_store() || error(
+    store = Base.ScopedValues.get(_IMPORT_STORE)
+    isnothing(store) && error(
         "convert_cost: the document names a time-series-backed cost, but no time series " *
         "store is bound — either this ran outside an active from_openapi(System, doc) " *
         "import, or no time_series_storage_path sidecar was adopted for it",
     )
-    return IS.get_deserialization_store()
+    return something(store)
 end
 
 """Fallback: a PO type that carries no association id converts identically whether or not a
@@ -366,7 +370,7 @@ end
 """
 Time-varying market bid. Mirrors `convert_cost(::PC.MarketBidCost)`: `ancillary_service_offers`
 is left empty here too. Needs `store` for `start_up` (a wire association id resolving to the
-`ConcreteTimeSeriesKey` `MarketBidTimeSeriesCost.start_up` carries) and for the time-series-backed
+`TimeSeriesKey` `MarketBidTimeSeriesCost.start_up` carries) and for the time-series-backed
 offer curves.
 """
 function convert_cost(po::PC.MarketBidTimeSeriesCost, store)

--- a/src/openapi/export_cost_conversion.jl
+++ b/src/openapi/export_cost_conversion.jl
@@ -138,7 +138,7 @@ end
 
 """`nothing` stays `nothing`; a present key emits its `association_id`."""
 _key_association_id(::Nothing) = nothing
-_key_association_id(key::IS.ConcreteTimeSeriesKey) =
+_key_association_id(key::IS.TimeSeriesKey) =
     _record_emitted_association_id(IS.get_association_id(key))
 
 function convert_cost_to_openapi(curve::TimeSeriesInputOutputCurve)

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -73,8 +73,13 @@ function Base.summary(io::IO, data::OperationalCost)
         # Only the most important fields
         (val isa ProductionVariableCostCurve) &&
             push!(field_msgs, "$(field_name): $(typeof(val))")
+        # A key carries only its association id; the name is a catalog column, and a
+        # summary must not query the store to print one.
         (val isa TimeSeriesKey) &&
-            push!(field_msgs, "$(field_name): time series \"$(get_name(val))\"")
+            push!(
+                field_msgs,
+                "$(field_name): time series association_id=$(get_association_id(val))",
+            )
     end
     isempty(field_msgs) && return
     print(io, "$(typeof(data)) composed of ")

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -30,8 +30,20 @@ TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
+[extras]
+# Present only so the `[sources]` pin below is legal: Pkg requires a sourced package to
+# appear in `deps` or `extras`.
+InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
+
 [sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+# Co-dev branch revs, not IS4/a release: this branch tracks the association-id time series
+# keys and the function-data element codec. InfraStore is pinned here because it reaches
+# this env only through InfrastructureSystems, and `[sources]` are not inherited
+# transitively. Its git rev supplies the Julia wrapper; the matching native library is NOT
+# in the pinned artifacts, so set INFRASTORE_LIB to a locally built libinfrastore_ffi from
+# the same rev. Switch both to a tagged rev at release.
+InfrastructureSystems = {rev = "dt/key-by-association-id", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+InfraStore = {rev = "dt/function-data-values", url = "https://github.com/NatLabRockies/infrastore", subdir = "julia/InfraStore.jl"}
 PowerCoreOpenAPIModels = {rev = "main", subdir = "PowerCoreOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 PowerDynamicsOpenAPIModels = {rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 PowerFlowFileParser = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl"}

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -429,7 +429,9 @@ end
         decremental_offer_curves = make_market_bid_ts_curve(dec_key),
     )
 
-    @test get_start_up(mbtc) isa IS.ConcreteTimeSeriesKey
+    # The field is typed by element, so the key that lands in it is one naming a
+    # 3-tuple-valued series and nothing else.
+    @test get_start_up(mbtc) isa PSY.StartUpStagesKey
     @test get_start_up(mbtc) === su_key
 
     resolved_first =
@@ -471,23 +473,62 @@ end
     @test_throws ArgumentError get_export_variable_cost(generator, iec)
 end
 
+@testset "get_fuel_cost resolves a time-series-backed FuelCurve at start_time" begin
+    # `FuelCurve` keeps the fixed value and the time series key in separate fields, so
+    # `get_fuel_cost(::StaticInjection)` has to read whichever one is set. A fixed cost
+    # ignores `start_time`; a keyed one reads the series through it.
+    sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    generator = get_component(ThermalStandard, sys, "322_CT_6")
+
+    timestamps = range(_TS_RESOLVE_INITIAL_TIME; step = _TS_RESOLVE_RESOLUTION, length = 24)
+    prices = collect(1.0:24.0)
+    fuel_key = add_time_series!(
+        sys,
+        generator,
+        IS.SingleTimeSeries(;
+            name = "fuel_price",
+            data = TimeSeries.TimeArray(collect(timestamps), prices),
+        ),
+    )
+
+    old_cost = get_operation_cost(generator)
+    old_variable = get_variable(old_cost)
+    set_operation_cost!(
+        generator,
+        ThermalGenerationCost(;
+            fixed = get_fixed(old_cost),
+            shut_down = get_shut_down(old_cost),
+            start_up = get_start_up(old_cost),
+            variable = FuelCurve(;
+                value_curve = get_value_curve(old_variable),
+                power_units = get_power_units(old_variable),
+                fuel_cost_time_series = fuel_key,
+            ),
+        ),
+    )
+
+    resolved = get_fuel_cost(generator; start_time = _TS_RESOLVE_INITIAL_TIME, len = 3)
+    @test TimeSeries.values(resolved) == prices[1:3]
+    @test TimeSeries.timestamp(resolved) == collect(timestamps)[1:3]
+end
+
 @testset "Time-series ORDC resolves variable cost at start_time" begin
     sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
-    # `ForecastKey` identifies a time series by name/type/timing — it does not
-    # bind to a specific component, so we can bootstrap a key from a throwaway
-    # generator and reuse it after attaching the same forecast to the reserve.
-    bootstrap = get_component(ThermalStandard, sys, "322_CT_6")
-    ts_key = _attach_pwl_forecast(sys, bootstrap, "ordc")
-
-    curve = CostCurve(TimeSeriesPiecewiseIncrementalCurve(ts_key, nothing, nothing))
+    # A key names one stored association, which belongs to one owner — so the reserve's
+    # curve has to be built from the key for the forecast attached to the reserve itself.
+    # (It used to be legal to bootstrap a key off another component and reuse it, back when
+    # a key was name/type/timing and bound to no owner.)
     reserve = OnlineReserve{ReserveUp}(;
-        variable = curve,
         name = "TestOrdc",
         available = true,
         time_frame = 10.0,
     )
     add_component!(sys, reserve)
-    _attach_pwl_forecast(sys, reserve, "ordc")
+    ts_key = _attach_pwl_forecast(sys, reserve, "ordc")
+    set_variable!(
+        reserve,
+        CostCurve(TimeSeriesPiecewiseIncrementalCurve(ts_key, nothing, nothing)),
+    )
 
     resolved = get_variable_cost(reserve; start_time = _TS_RESOLVE_INITIAL_TIME)
     @test get_function_data(get_value_curve(resolved)) == _TS_RESOLVE_PWL_DATA[1]

--- a/test/test_openapi_cost_conversion.jl
+++ b/test/test_openapi_cost_conversion.jl
@@ -351,6 +351,9 @@ end
     # store for the value curve regardless of which form `fuel_cost` takes.
     store = IS.Store(; in_memory = true)
     try
+        # `LinearFunctionData` values, not bare floats: the wire type below is a
+        # `TimeSeriesLinearFunctionData`, and a key naming a `Float64`-valued series
+        # cannot back one — the element type is part of the key's type now.
         series = SingleTimeSeries(;
             name = "heat_rate",
             data = TimeSeries.TimeArray(
@@ -359,7 +362,11 @@ end
                     Dates.DateTime(2024, 1, 1, 1),
                     Dates.DateTime(2024, 1, 1, 2),
                 ],
-                [8.0, 8.5, 9.0],
+                [
+                    IS.LinearFunctionData(8.0, 0.0),
+                    IS.LinearFunctionData(8.5, 0.0),
+                    IS.LinearFunctionData(9.0, 0.0),
+                ],
             ),
         )
         batch = IS.make_add_batch()
@@ -372,7 +379,7 @@ end
             series,
         )
         IS.commit_batch!(store, batch)
-        assoc_id = only(IS.list_time_series_metadata(store)).id
+        assoc_id = IS.get_association_id(only(IS.list_metadata(store)))
 
         fc = PSY._with_import_store(store) do
             PSY.convert_cost(
@@ -482,11 +489,16 @@ end
     # non-1.0 base_power made the two diverge.
     store = IS.Store(; in_memory = true)
     try
+        # An import/export offer curve is backed by `PiecewiseStepData` values; a
+        # `Float64`-valued series' key no longer types as one.
         series = SingleTimeSeries(;
             name = "import_price",
             data = TimeSeries.TimeArray(
                 [Dates.DateTime(2024, 1, 1, 0), Dates.DateTime(2024, 1, 1, 1)],
-                [10.0, 12.0],
+                [
+                    PiecewiseStepData([0.0, 100.0], [10.0]),
+                    PiecewiseStepData([0.0, 100.0], [12.0]),
+                ],
             ),
         )
         batch = IS.make_add_batch()
@@ -499,7 +511,7 @@ end
             series,
         )
         IS.commit_batch!(store, batch)
-        assoc_id = only(IS.list_time_series_metadata(store)).id
+        assoc_id = IS.get_association_id(only(IS.list_metadata(store)))
         ts_key = IS.get_time_series_key(store, Int(assoc_id))
 
         static_cost = ImportExportCost(;

--- a/test/test_openapi_file_io.jl
+++ b/test/test_openapi_file_io.jl
@@ -228,7 +228,9 @@ end
         sys, gen,
         IS.NonSequentialTimeSeries("irregular", TimeSeries.TimeArray(stamps, values)),
     )
-    @test first(IS.get_time_series_keys(gen)) isa IS.NonSequentialTimeSeriesKey
+    # The kind is in the key's type parameter now, not in a separate key type.
+    @test IS.get_time_series_type(first(IS.list_metadata(gen))) <:
+          IS.NonSequentialTimeSeries
 
     mktempdir() do dir
         bundle = joinpath(dir, "irregular")
@@ -266,8 +268,8 @@ end
         # from the adopted sidecar exactly.
         sys2 = from_file(System, bundle)
         gen2 = get_component(ThermalStandard, sys2, "g1")
-        key2 = only(IS.get_time_series_keys(gen2))
-        @test key2 isa IS.NonSequentialTimeSeriesKey
+        key2 = IS.get_time_series_key(only(IS.list_metadata(gen2)))
+        @test key2 isa IS.TimeSeriesKey{<:IS.NonSequentialTimeSeries}
         @test IS.get_timestamps(IS.get_time_series(gen2, key2)) == stamps
         @test IS.get_time_series_values(gen2, key2) == values
     end

--- a/test/test_outages.jl
+++ b/test/test_outages.jl
@@ -83,12 +83,14 @@
     planned_outages = collect(get_supplemental_attributes(PlannedOutage, gen2))
     @test !isempty(planned_outages)
     for outage in planned_outages
-        ts_keys = get_time_series_keys(outage)
-        @test !isempty(ts_keys)
-        for key in ts_keys
-            remove_time_series!(sys, key.time_series_type, outage, key.name)
+        rows = list_metadata(outage)
+        @test !isempty(rows)
+        for md in rows
+            remove_time_series!(
+                sys, IS.get_time_series_type(md), outage, IS.get_name(md),
+            )
         end
-        @test isempty(get_time_series_keys(outage))
+        @test isempty(list_metadata(outage))
     end
 end
 
@@ -297,7 +299,10 @@ end
         IS.get_id(outage) =>
             TimeSeries.values(
                 PSY.get_data(
-                    IS.get_time_series(outage, only(IS.get_time_series_keys(outage))),
+                    IS.get_time_series(
+                        outage,
+                        IS.get_time_series_key(only(IS.list_metadata(outage))),
+                    ),
                 ),
             ) for outage in get_supplemental_attributes(Outage, sys)
     )
@@ -326,7 +331,7 @@ end
     # The attribute-owned series survive value-for-value, keyed by the id that stays stable
     # across the round trip.
     for outage in outages2
-        key = only(IS.get_time_series_keys(outage))
+        key = IS.get_time_series_key(only(IS.list_metadata(outage)))
         values = TimeSeries.values(PSY.get_data(IS.get_time_series(outage, key)))
         @test values == original_series[IS.get_id(outage)]
     end

--- a/test/test_subsystems.jl
+++ b/test/test_subsystems.jl
@@ -723,10 +723,10 @@ end
     # array between each area-1/area-2 pair: 6 forecast associations over 3 arrays.
     @test ts_counts.forecast_count == 3
     @test count(
-        k -> IS.get_time_series_type(k) <: IS.Forecast,
+        md -> IS.get_time_series_type(md) <: IS.Forecast,
         (
-            k for c in get_components(Component, base_sys) for
-            k in IS.get_time_series_keys(c)
+            md for c in get_components(Component, base_sys) for
+            md in IS.list_metadata(c)
         ),
     ) == 6
     subsystem1_ids = get_component_ids(base_sys, "subsystem_1")

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -307,9 +307,11 @@ end
     add_time_series!(sys, gens, make_sts("max_active_power", collect(1.0:24.0)))
     add_time_series!(sys, gens[1], make_sts("solo", collect(25.0:48.0)))
 
-    shared_keys =
-        [only(get_time_series_keys(g; name = "max_active_power")) for g in gens]
-    solo_key = only(get_time_series_keys(gens[1]; name = "solo"))
+    shared_keys = [
+        IS.get_time_series_key(only(list_metadata(g; name = "max_active_power")))
+        for g in gens
+    ]
+    solo_key = IS.get_time_series_key(only(list_metadata(gens[1]; name = "solo")))
     shared_hash = get_time_series_hash(gens[1], shared_keys[1])
     @test get_time_series_hash(gens[2], shared_keys[2]) == shared_hash
     @test get_time_series_hash(gens[1], solo_key) != shared_hash
@@ -491,7 +493,7 @@ end
         error("abort the transaction")
     end
     @test isempty(
-        IS.get_time_series_keys(component; name = "rolled_back"),
+        IS.list_metadata(component; name = "rolled_back"),
     )
 end
 

--- a/test/test_time_series_features.jl
+++ b/test/test_time_series_features.jl
@@ -20,6 +20,17 @@ function _features_test_system(count::Int = 2)
     return sys, gens
 end
 
+"""
+The features stored for `key`, read from `owner`'s catalog rows.
+
+A `TimeSeriesKey` carries only its association id; `features` is a catalog column, so it
+comes from the [`TimeSeriesMetadata`](@ref) row the key addresses.
+"""
+function _features_for(owner, key)
+    md = only(filter(m -> IS.get_time_series_key(m) == key, list_metadata(owner)))
+    return IS.get_features(md)
+end
+
 const _FEATURES_INITIAL_TIME = Dates.DateTime("2020-01-01T00:00:00")
 const _FEATURES_RESOLUTION = Dates.Hour(1)
 const _FEATURES_LENGTH = 24
@@ -57,15 +68,15 @@ end
         features = low)
 
     # Same type and name; only the features separate them.
-    @test IS.get_features(key_high) == Dict{String, Any}("scenario" => "high")
-    @test IS.get_features(key_low) == Dict{String, Any}("scenario" => "low")
+    @test _features_for(gen, key_high) == Dict{String, Any}("scenario" => "high")
+    @test _features_for(gen, key_low) == Dict{String, Any}("scenario" => "low")
     @test key_high != key_low
-    @test length(get_time_series_keys(gen)) == 2
+    @test length(list_metadata(gen)) == 2
 
     @test get_time_series_values(SingleTimeSeries, gen, name; features = high)[1] == 1.0
     @test get_time_series_values(SingleTimeSeries, gen, name; features = low)[1] == 25.0
     @test has_time_series(gen, SingleTimeSeries, name; features = high)
-    @test only(get_time_series_keys(gen; features = high)) == key_high
+    @test IS.get_time_series_key(only(list_metadata(gen; features = high))) == key_high
 
     # Without features the lookup is ambiguous.
     @test_throws ArgumentError get_time_series(SingleTimeSeries, gen, name)
@@ -89,7 +100,7 @@ end
     # The default is `nothing`, and passing it explicitly is the same as omitting it.
     key_plain = add_time_series!(sys, gen, _features_sts("plain", collect(1.0:24.0));
         features = nothing)
-    @test isempty(IS.get_features(key_plain))
+    @test isempty(_features_for(gen, key_plain))
     @test get_time_series_values(SingleTimeSeries, gen, "plain")[1] == 1.0
 end
 
@@ -100,12 +111,14 @@ end
 
     keys = add_time_series!(sys, gens, _features_sts(name, collect(1.0:24.0));
         features = high)
-    @test all(k -> IS.get_features(k) == Dict{String, Any}("scenario" => "high"), keys)
+    @test all(((g, k),) -> _features_for(g, k) == Dict{String, Any}("scenario" => "high"),
+        zip(gens, keys))
 
     # Every component gets the features, and the array itself is still stored once.
-    keys_by_gen = [only(get_time_series_keys(g; name = name)) for g in gens]
-    @test all(k -> IS.get_features(k) == Dict{String, Any}("scenario" => "high"),
-        keys_by_gen)
+    keys_by_gen =
+        [IS.get_time_series_key(only(list_metadata(g; name = name))) for g in gens]
+    @test all(((g, k),) -> _features_for(g, k) == Dict{String, Any}("scenario" => "high"),
+        zip(gens, keys_by_gen))
     hashes = [get_time_series_hash(g, k) for (g, k) in zip(gens, keys_by_gen)]
     @test hashes[1] == hashes[2]
 
@@ -130,8 +143,8 @@ end
     key_2040 = add_time_series!(sys, outage, _features_sts(name, collect(25.0:48.0));
         features = Dict("year" => 2040))
 
-    @test IS.get_features(key_2030) == Dict{String, Any}("year" => 2030)
-    @test IS.get_features(key_2040) == Dict{String, Any}("year" => 2040)
+    @test _features_for(outage, key_2030) == Dict{String, Any}("year" => 2030)
+    @test _features_for(outage, key_2040) == Dict{String, Any}("year" => 2040)
     @test get_time_series_values(SingleTimeSeries, outage, name;
         features = Dict("year" => 2030))[1] == 1.0
     @test get_time_series_values(SingleTimeSeries, outage, name;
@@ -241,19 +254,19 @@ end
         features = high)
     add_time_series!(sys, gens[1], _features_forecast(name, collect(101.0:124.0));
         features = low)
-    @test length(get_time_series_keys(gens[1])) == 2
+    @test length(list_metadata(gens[1])) == 2
 
     remove_time_series!(sys, Deterministic, gens[1], name; features = low)
     @test !has_time_series(gens[1], Deterministic, name; features = low)
     @test has_time_series(gens[1], Deterministic, name; features = high)
     # The other owner of the shared array is untouched.
-    @test length(get_time_series_keys(gens[2])) == 1
+    @test length(list_metadata(gens[2])) == 1
 
     # Omitting `features` removes every variant matching the type and name.
     add_time_series!(sys, gens[1], _features_forecast(name, collect(201.0:224.0));
         features = low)
-    @test length(get_time_series_keys(gens[1])) == 2
+    @test length(list_metadata(gens[1])) == 2
     remove_time_series!(sys, Deterministic, gens[1], name)
-    @test isempty(get_time_series_keys(gens[1]))
-    @test length(get_time_series_keys(gens[2])) == 1
+    @test isempty(list_metadata(gens[1]))
+    @test length(list_metadata(gens[2])) == 1
 end


### PR DESCRIPTION
Tracks the InfrastructureSystems `dt/key-by-association-id` branch and the InfraStore `dt/function-data-values` element codec beneath it, so PSY can use the improved handling of `TimeSeriesFunctionData`.

**This PR cannot merge before its two dependencies do:**
- InfrastructureSystems.jl `dt/key-by-association-id`
- infrastore `dt/function-data-values`

## What changed upstream

`TimeSeriesKey` collapses from a three-type hierarchy into one parametric `TimeSeriesKey{T <: TimeSeriesData}` carrying a store-minted association id. `StaticTimeSeriesKey`, `ForecastKey`, `NonSequentialTimeSeriesKey`, and the `ConcreteTimeSeriesKey` union are gone. The descriptive columns a key used to copy — name, resolution, features, timing — now live on `TimeSeriesMetadata`, enumerated by `list_metadata`, so a caller reads them from a row whose age it knows rather than from a key that could have drifted from the catalog.

`TimeSeriesFunctionData{T}` gained a second parameter bounded by `TimeSeriesData{T}`. That is the part that makes a series' element type checkable.

## What changed here

**Export surface.** Dropped the retired key types. Added `TimeSeriesMetadata`, `list_metadata`, `get_time_series_metadata`, `get_time_series_key`, `get_association_id`.

**Leaning on the element typing.** `StartUpStagesKey` (`src/definitions.jl`) types `MarketBidTimeSeriesCost.start_up`, so a key naming a series of anything but 3-stage tuples is rejected at assignment — where the mistake is made — instead of at the read that would have unpacked it. Two test fixtures turned out to store bare `Float64` series behind `LinearFunctionData` / `PiecewiseStepData` curves; the new bound surfaced both.

**Curve aliases.** The time-series cost aliases are UnionAlls over the series type now, so the sites spelling one as an invariant type parameter need `CostCurve{<:...}`.

**Import store.** IS no longer keeps a deserialization-store scope, a key having become self-describing on the wire. Only PSY's OpenAPI format still names a series by a bare `association_id`, so `cost_conversion.jl` owns that `ScopedValue` now.

## Two defects fixed along the way

- `get_fuel_cost(::StaticInjection)` forwarded `get_fuel_cost(var_cost)`, which is `nothing` for a time-series-backed `FuelCurve` since the field split — so every time-varying fuel cost hit a `MethodError`. It now reads whichever of the two fields is set. Covered by a new regression test, confirmed to fail without the fix.
- `Base.summary(::OperationalCost)` asked a key for its name.

## Build and pins

`[sources]` point at the two co-dev branch revs. `InfraStore` is pinned here because it reaches this environment only through InfrastructureSystems and `[sources]` are not inherited transitively; it sits in `[extras]` because Pkg refuses a `[sources]` entry for a package absent from `deps`/`extras`, and Aqua then requires a `[compat]` entry for it.

Its git rev supplies the **Julia wrapper only** — the pinned Artifacts.toml still points at the released v0.10.0 tarballs, which predate the id-first FFI. Tests need a locally built library from the same rev:

```sh
cargo build --release -p infrastore-ffi   # in the infrastore checkout
export INFRASTORE_LIB=<infrastore>/target/release/libinfrastore_ffi.dylib
julia --project=test test/runtests.jl
```

## Verification

- Full suite green: **14431 / 14431**, run against the pinned git revs rather than local path checkouts.
- The new fuel-cost test was verified to fail without its fix.
- Docs still exit 1, but that is pre-existing and unrelated: a baseline build on `psy6` produces **46** errors against this branch's **40**, a strict subset. The failures are a `TimeArray * Float64` method error and `@ref`s to types removed in the earlier transformer refactor.

## Downstream, not migrated here

Still calling the retired API: PowerOperationsModels (8 sites), PowerSimulations (6), PowerSystemCaseBuilder (1), PowerAnalytics (1). PowerNetworkMatrices, PowerFlows, and SiennaSchemas are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AsmQonwoyXJwZSmY3Lj26