### PR TITLE
Per-component power_units serde and the OpenAPI package split

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,14 +31,9 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
 
 [sources]
-# Co-dev branch revs, not IS4/a release: this branch tracks the association-id time series
-# keys and the function-data element codec. InfraStore is pinned here because it reaches
-# this env only through InfrastructureSystems, and `[sources]` are not inherited
-# transitively. Its git rev supplies the Julia wrapper; the matching native library is NOT
-# in the pinned artifacts, so set INFRASTORE_LIB to a locally built libinfrastore_ffi from
-# the same rev. Switch both to a tagged rev at release.
-InfrastructureSystems = {rev = "dt/key-by-association-id", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
-InfraStore = {rev = "dt/function-data-values", url = "https://github.com/NatLabRockies/infrastore", subdir = "julia/InfraStore.jl"}
+# IS4 carries the association-id keys (dt/key-by-association-id merged 2026-08-31), and
+# InfraStore 0.11 is registered with its own native library - the co-dev pins are retired.
+InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
 # Branch revs, not a tagged release: the x-unit accessors these packages expose are generated
 # and not yet released. Switch to a tagged rev at release.
 # PowerDynamics-/PowerInvestmentsOpenAPIModels are not imported here — they are deps of the
@@ -52,8 +47,8 @@ PowerOperationsOpenAPIModels = {rev = "jd/market_components", subdir = "PowerOpe
 PowerTimeSeriesOpenAPIModels = {rev = "jd/market_components", subdir = "PowerTimeSeriesOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 
 [compat]
-# For the `[extras]`/`[sources]` co-dev pin above; Aqua requires every extra to carry one.
-InfraStore = "0.10"
+# For the `[extras]` entry; Aqua requires every extra to carry a compat bound.
+InfraStore = "0.11"
 DataStructures = "^0.19"
 Dates = "1"
 DocStringExtensions = "^0.9.2"

--- a/Project.toml
+++ b/Project.toml
@@ -32,12 +32,12 @@ InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/
 # PowerDynamics-/PowerInvestmentsOpenAPIModels are not imported here — they are deps of the
 # PowerOpenAPIModels umbrella, and [sources] are not inherited transitively, so this env must
 # pin them itself or a fresh resolve fails on "has no known versions".
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
-PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl"}
-PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl"}
-PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOpenAPIModels.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
-PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
+PowerCoreOpenAPIModels = {rev = "jd/market_components", subdir = "PowerCoreOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerDynamicsOpenAPIModels = {rev = "jd/market_components", subdir = "PowerDynamicsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerInvestmentsOpenAPIModels = {rev = "jd/market_components", subdir = "PowerInvestmentsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerOpenAPIModels = {rev = "jd/market_components", subdir = "PowerOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerOperationsOpenAPIModels = {rev = "jd/market_components", subdir = "PowerOperationsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerTimeSeriesOpenAPIModels = {rev = "jd/market_components", subdir = "PowerTimeSeriesOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 
 [compat]
 DataStructures = "^0.19"

--- a/Project.toml
+++ b/Project.toml
@@ -26,28 +26,30 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extras]
-# Present only so the `[sources]` pin below is legal: Pkg requires a sourced package to
+# Present only so the `[sources]
+# LOCAL PATH CO-DEV PINS (temporary): the power_units/cost-rename regen of PowerOpenAPIModels
+# exists only on local disk, not on `main` yet. Revert to the git pins once pushed/merged.` pin below is legal: Pkg requires a sourced package to
 # appear in `deps` or `extras`.
 InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
-InfraStore = {rev = "dt/function-data-values", url = "https://github.com/NatLabRockies/infrastore", subdir = "julia/InfraStore.jl"}
+InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+InfraStore = {rev = "main", url = "https://github.com/NatLabRockies/infrastore", subdir = "julia/InfraStore.jl"}
 # Branch revs, not a tagged release: the x-unit accessors these packages expose are generated
 # and not yet released. Switch to a tagged rev at release.
 # PowerDynamics-/PowerInvestmentsOpenAPIModels are not imported here — they are deps of the
 # PowerOpenAPIModels umbrella, and [sources] are not inherited transitively, so this env must
 # pin them itself or a fresh resolve fails on "has no known versions".
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
-PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl"}
-PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl"}
-PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOpenAPIModels.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
-PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerDynamicsOpenAPIModels.jl"}
+PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerInvestmentsOpenAPIModels.jl"}
+PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerOperationsOpenAPIModels.jl"}
+PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
 
 [compat]
 # For the `[extras]`/`[sources]` co-dev pin above; Aqua requires every extra to carry one.
-InfraStore = "0.10"
+InfraStore = "0.11"
 DataStructures = "^0.19"
 Dates = "1"
 DocStringExtensions = "^0.9.2"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,9 @@ authors = ["Jose Daniel Lara", "Daniel Thom", "Rodrigo Henriquez-Auba", "Gabriel
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+InfrastructureCoreOpenAPIModels = "1f5e1c8d-e0cc-4dbf-8c6d-f2a3d2ae70a8"
 InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
+InfrastructureTimeSeriesOpenAPIModels = "37a216c8-a490-47cf-89d7-db2cb9618199"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -17,7 +19,6 @@ PowerDynamicsOpenAPIModels = "044a0b22-31f8-4ef6-8282-c9a61b3013f6"
 PowerInvestmentsOpenAPIModels = "33cb4396-f4d9-4f59-8585-787ebb56cb1b"
 PowerOpenAPIModels = "0730f07c-cff6-4c3b-a9df-c546153be50a"
 PowerOperationsOpenAPIModels = "a372b6d7-45a2-44c2-8199-6a724b72e8ff"
-PowerTimeSeriesOpenAPIModels = "8c2f6a0d-6b0e-4d0a-9d8f-2b5e6a4f9c31"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
@@ -35,18 +36,22 @@ InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
 [sources]
 # IS4 carries the association-id keys, and InfraStore 0.11 is registered with its own native
 # library - the co-dev pins are retired.
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
-# Branch revs, not a tagged release: the x-unit accessors these packages expose are generated
-# and not yet released. Switch to a tagged rev at release.
-# PowerDynamics-/PowerInvestmentsOpenAPIModels are not imported here — they are deps of the
-# PowerOpenAPIModels umbrella, and [sources] are not inherited transitively, so this env must
-# pin them itself or a fresh resolve fails on "has no known versions".
+# LOCAL PATH CO-DEV PIN (temporary): IS4's own local checkout already migrated off
+# PowerCoreOpenAPIModels/PowerTimeSeriesOpenAPIModels onto InfrastructureCore-/
+# InfrastructureTimeSeriesOpenAPIModels, uncommitted — the pushed IS4 branch still requires
+# the old (now-unregistered) PowerTimeSeriesOpenAPIModels and fails to resolve. Revert to the
+# git rev once IS4 is pushed.
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "jd/openapi-package-split"}
+# LOCAL PATH CO-DEV PINS (temporary): the InfrastructureCore/InfrastructureTimeSeries package
+# split exists only on local disk, not pushed to jd/schemas-0.1.0 yet. Revert to the git pins
+# once pushed/merged.
+InfrastructureCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "InfrastructureCoreOpenAPIModels.jl"}
+InfrastructureTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "InfrastructureTimeSeriesOpenAPIModels.jl"}
 PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerCoreOpenAPIModels.jl"}
 PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerDynamicsOpenAPIModels.jl"}
 PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerInvestmentsOpenAPIModels.jl"}
 PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerOpenAPIModels.jl"}
 PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerOperationsOpenAPIModels.jl"}
-PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
 
 [compat]
 # For the `[extras]` entry; Aqua requires every extra to carry a compat bound.
@@ -54,7 +59,9 @@ InfraStore = "0.11"
 DataStructures = "^0.19"
 Dates = "1"
 DocStringExtensions = "^0.9.2"
+InfrastructureCoreOpenAPIModels = "0.1"
 InfrastructureSystems = "^3.4"
+InfrastructureTimeSeriesOpenAPIModels = "0.1"
 JSON = "^1.5"
 LinearAlgebra = "1"
 Logging = "1"
@@ -64,7 +71,6 @@ PowerDynamicsOpenAPIModels = "0.1"
 PowerInvestmentsOpenAPIModels = "0.1"
 PowerOpenAPIModels = "0.1"
 PowerOperationsOpenAPIModels = "0.1"
-PowerTimeSeriesOpenAPIModels = "0.1"
 PrecompileTools = "1"
 PrettyTables = "3.1"
 TimeSeries = "0.25"

--- a/docs/src/how_to/market_bid_cost.md
+++ b/docs/src/how_to/market_bid_cost.md
@@ -37,7 +37,7 @@ generator = ThermalStandard(;
     time_limits = (up = 0.015, down = 0.015),
     ramp_limits = (up = 5.0, down = 3.0),
     operation_cost = MarketBidCost(;
-        no_load_cost = 0.0,
+        minimum_energy_offer = 0.0,
         start_up = (hot = 0.0, warm = 0.0, cold = 0.0),
         shut_down = 0.0,
         incremental_offer_curves = proposed_offer_curve,
@@ -84,7 +84,7 @@ generator = ThermalStandard(;
     time_limits = (up = 0.015, down = 0.015),
     ramp_limits = (up = 5.0, down = 3.0),
     operation_cost = MarketBidCost(;
-        no_load_cost = 0.0,
+        minimum_energy_offer = 0.0,
         start_up = (hot = 0.0, warm = 0.0, cold = 0.0),
         shut_down = 0.0,
     ),

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -62,6 +62,8 @@ export get_inverse_operation_exclusion_map
 export get_components_in_exclusion_group
 export get_variable
 export set_variable!
+export get_variable_operation_cost
+export set_variable_operation_cost!
 export Component
 export Device
 export get_max_active_power
@@ -544,7 +546,7 @@ export get_next_time
 export reset!
 export get_horizon
 export get_forecast_initial_times
-export list_metadata
+export list_time_series_metadata
 export get_time_series_metadata
 export get_time_series_key
 export get_association_id
@@ -820,7 +822,7 @@ import InfrastructureSystems:
     get_time_series_array,
     get_time_series_timestamps,
     get_time_series_values,
-    list_metadata,
+    list_time_series_metadata,
     get_time_series_metadata,
     get_time_series_key,
     get_association_id,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -125,7 +125,7 @@ export is_market_bid_curve, make_market_bid_curve, make_market_bid_ts_curve
 export make_import_curve, make_export_curve, make_import_export_ts_curve
 export TimeSeriesLinearCurve, TimeSeriesQuadraticCurve, TimeSeriesPiecewisePointCurve
 export TimeSeriesPiecewiseIncrementalCurve, TimeSeriesPiecewiseAverageCurve
-export get_no_load_cost, set_no_load_cost!, get_start_up, set_start_up!
+export get_minimum_energy_offer, set_minimum_energy_offer!, get_start_up, set_start_up!
 export set_shut_down!
 export get_curtailment_cost
 export set_curtailment_cost!
@@ -363,6 +363,11 @@ export set_energy_unit!
 export set_basis_and_energy_unit!
 
 export Service
+export MarketComponent
+export MarketTransaction
+export TradingHub
+export VirtualParticipant
+export PointToPointBid
 export AbstractReserve
 export Reserve
 export ReserveDirection
@@ -393,6 +398,7 @@ export TransmissionInterface
 
 export AngleUnits
 export ACBusTypes
+export CurveStyles
 export FACTSOperationModes
 export VSCDCControlModes
 export VSCACControlModes
@@ -459,6 +465,11 @@ export remove_service!
 export clear_services!
 export get_services
 export has_service
+export add_trading_hub!
+export has_trading_hub
+export remove_trading_hub!
+export clear_trading_hubs!
+export get_contributing_virtuals
 export remove_turbine!
 export clear_turbines!
 export has_upstream_turbine
@@ -487,6 +498,7 @@ export get_component
 export get_components
 export get_num_components
 export get_associated_components
+export get_associated_buses
 export show_components
 export show_component
 export get_subcomponents
@@ -552,12 +564,15 @@ export iterate_components
 export get_time_series_multiple
 export get_variable_cost
 export get_incremental_variable_cost, get_decremental_variable_cost
-export get_no_load_cost
+export get_minimum_energy_offer
 export get_start_up
 export get_shut_down
 export get_incremental_offer_curves, set_incremental_offer_curves!
 export get_decremental_offer_curves, set_decremental_offer_curves!
 export get_ancillary_service_offers, set_ancillary_service_offers!
+export get_incremental_slope, set_incremental_slope!
+export get_decremental_slope, set_decremental_slope!
+export get_curve_style, set_curve_style!
 export get_import_offer_curves, set_import_offer_curves!
 export get_export_offer_curves, set_export_offer_curves!
 export get_import_variable_cost, get_export_variable_cost
@@ -568,6 +583,7 @@ export set_variable_cost!
 export set_incremental_variable_cost!, set_decremental_variable_cost!
 export set_import_variable_cost!, set_export_variable_cost!
 export set_service_bid!
+export set_hub_bid!
 export iterate_windows
 export get_window
 export transform_single_time_series!
@@ -987,6 +1003,7 @@ include("models/branches.jl")
 
 # Static types
 include("models/services.jl")
+include("models/market_components.jl")
 include("models/reserves.jl")
 include("models/generation.jl")
 include("models/storage.jl")
@@ -1032,6 +1049,14 @@ include("openapi/import_handwritten.jl")
 # Hand-written methods on the generated `TransformerCircuit` type; included after
 # generated/includes.jl so the type is defined.
 include("models/transformer_circuits.jl")
+
+# Hand-written methods on the generated market types; included after
+# generated/includes.jl so the types are defined. Their `MarketComponent`/
+# `MarketTransaction` supertypes stay in models/market_components.jl, which
+# generated/includes.jl needs in scope.
+include("models/trading_hub.jl")
+include("models/virtual_participant.jl")
+include("models/point_to_point_bid.jl")
 
 #Methods for devices
 include("models/components.jl")

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -736,15 +736,17 @@ import JSON
 import Base.to_index
 import PrettyTables
 import Unitful
+import InfrastructureCoreOpenAPIModels
 import PowerCoreOpenAPIModels
 import PowerOperationsOpenAPIModels
-import PowerTimeSeriesOpenAPIModels
+import InfrastructureTimeSeriesOpenAPIModels
 import PowerOpenAPIModels
 import OpenAPI
 import TimeZones
+const IC = InfrastructureCoreOpenAPIModels
 const PC = PowerCoreOpenAPIModels
 const PO = PowerOperationsOpenAPIModels
-const PTS = PowerTimeSeriesOpenAPIModels
+const PTS = InfrastructureTimeSeriesOpenAPIModels
 const PD = PowerOpenAPIModels
 using Unitful: @u_str, @unit, Quantity, Units, uconvert, ustrip
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -865,6 +865,37 @@ function add_service!(device::Device, service::Service, sys::System)
     return
 end
 
+_reject_hub_addition(::Nothing, vp::VirtualParticipant) = nothing
+
+function _reject_hub_addition(settlement_point::Topology, vp::VirtualParticipant)
+    throw(
+        ArgumentError(
+            "$(get_name(vp)) cannot set both settlement_point " *
+            "($(get_name(settlement_point))) and trading_hubs; choose one location mode",
+        ),
+    )
+end
+
+"""
+Associate `hub` with `vp`. Both must already be attached to `sys`.
+"""
+function add_trading_hub!(sys::System, vp::VirtualParticipant, hub::TradingHub)
+    throw_if_not_attached(vp, sys)
+    throw_if_not_attached(hub, sys)
+    _reject_hub_addition(get_settlement_point(vp), vp)
+    add_trading_hub_internal!(vp, hub)
+    return
+end
+
+"""
+Return the `VirtualParticipant`s in `sys` associated with `hub`.
+"""
+function get_contributing_virtuals(sys::System, hub::TradingHub)
+    return [
+        vp for vp in get_components(VirtualParticipant, sys) if has_trading_hub(vp, hub)
+    ]
+end
+
 """
 Similar to [`add_component!`](@ref) but for GroupReserve.
 
@@ -1562,7 +1593,8 @@ Add the same time series data to multiple components.
 This function stores a single copy of the data. Each component will store a reference to
 that data. This is significantly more efficent than calling `add_time_series!` for each
 component individually with the same data because in this case, only one time series
-array is stored.
+array is stored. Each component gets its own association, so this returns a `Vector` of
+keys, one per component, in the order of `components`.
 
 Throws ArgumentError if a component is not stored in the system.
 """
@@ -2367,7 +2399,11 @@ function from_dict(
     ext = get_ext(sys)
     ext["deserialization_in_progress"] = true
     try
-        deserialize_components!(sys, raw["data"])
+        # A key reaches the JSON as its association id; resolving it back needs the
+        # store those ids were minted against.
+        IS.with_deserialization_store(IS.get_data_store(sys.data)) do
+            deserialize_components!(sys, raw["data"])
+        end
     finally
         pop!(ext, "deserialization_in_progress")
         isempty(ext) && clear_ext!(sys)
@@ -2453,6 +2489,7 @@ function deserialize_components!(sys::System, raw)
     )
     deserialize_and_add!(; include_types = [AGC])
     deserialize_and_add!(; include_types = [Bus])
+    deserialize_and_add!(; include_types = [TradingHub])
     deserialize_and_add!(;
         include_types = [Arc, Service],
         skip_types = [GroupReserve],
@@ -2679,6 +2716,13 @@ function check_attached_buses(sys::System, component::Arc)
     return
 end
 
+function check_attached_buses(sys::System, component::TradingHub)
+    for bus in get_associated_buses(component)
+        throw_if_not_attached(bus, sys)
+    end
+    return
+end
+
 """
 Throws ArgumentError if a PowerSystems rule blocks addition to the system.
 
@@ -2705,6 +2749,58 @@ function check_component_removal(sys::System, area::Area)
             throw(
                 ArgumentError(
                     "Area $(summary(area)) cannot be removed with attached AreaInterchange: $(summary(interchange))",
+                ),
+            )
+        end
+    end
+    _check_vp_settlement_removal(sys, area)
+    return
+end
+
+"""
+Throws ArgumentError if any `VirtualParticipant` settles at `topology`.
+"""
+function _check_vp_settlement_removal(sys::System, topology::Topology)
+    for vp in get_components(VirtualParticipant, sys)
+        if get_settlement_point(vp) === topology
+            throw(
+                ArgumentError(
+                    "$(summary(topology)) cannot be removed while $(summary(vp)) " *
+                    "settles there",
+                ),
+            )
+        end
+    end
+    return
+end
+
+function check_component_removal(sys::System, topology::Topology)
+    _check_vp_settlement_removal(sys, topology)
+    return
+end
+
+function check_component_removal(sys::System, bus::ACBus)
+    for hub in get_components(TradingHub, sys)
+        if bus in get_associated_buses(hub)
+            throw(
+                ArgumentError(
+                    "$(summary(bus)) cannot be removed with attached TradingHub: " *
+                    "$(summary(hub))",
+                ),
+            )
+        end
+    end
+    _check_vp_settlement_removal(sys, bus)
+    return
+end
+
+function check_component_removal(sys::System, hub::TradingHub)
+    for ptp in get_components(PointToPointBid, sys)
+        if get_from(ptp) === hub || get_to(ptp) === hub
+            throw(
+                ArgumentError(
+                    "$(summary(hub)) cannot be removed with attached PointToPointBid: " *
+                    "$(summary(ptp))",
                 ),
             )
         end
@@ -2788,6 +2884,58 @@ function check_component_addition(sys::System, bus::Bus; kwargs...)
     if !isnothing(load_zone)
         throw_if_not_attached(load_zone, sys)
     end
+end
+
+function _check_vp_location(sys::System, ::VirtualParticipant, ::Nothing, hubs)
+    for hub in hubs
+        throw_if_not_attached(hub, sys)
+    end
+    return nothing
+end
+
+function _check_vp_location(
+    sys::System,
+    vp::VirtualParticipant,
+    settlement_point::Topology,
+    hubs,
+)
+    if !isempty(hubs)
+        throw(
+            ArgumentError(
+                "$(get_name(vp)) cannot set both settlement_point " *
+                "($(get_name(settlement_point))) and trading_hubs; choose one location mode",
+            ),
+        )
+    end
+    throw_if_not_attached(settlement_point, sys)
+    return nothing
+end
+
+"""
+Throws ArgumentError if `vp` sets both `settlement_point` and `trading_hubs`, or if a set
+`settlement_point` is not attached to `sys`. Hub attachment is not checked here: hubs may be
+associated after `add_component!`, like services.
+"""
+function check_component_addition(sys::System, vp::VirtualParticipant; kwargs...)
+    _check_vp_location(sys, vp, get_settlement_point(vp), get_trading_hubs(vp))
+    return
+end
+
+"""
+Throws ArgumentError if `ptp`'s `from`/`to` terminals are not a Topology or a TradingHub, if
+they are identical, or if either is not attached to `sys`.
+"""
+function check_component_addition(sys::System, ptp::PointToPointBid; kwargs...)
+    from = get_from(ptp)
+    to = get_to(ptp)
+    _check_ptp_terminal(from)
+    _check_ptp_terminal(to)
+    if from === to
+        throw(ArgumentError("PointToPointBid $(get_name(ptp)) has identical terminals"))
+    end
+    throw_if_not_attached(from, sys)
+    throw_if_not_attached(to, sys)
+    return
 end
 
 function handle_component_addition!(sys::System, bus::Bus; kwargs...)
@@ -2893,6 +3041,13 @@ function handle_component_removal!(sys::System, service::Service)
             continue
         end
         _remove_service!(device, service)
+    end
+end
+
+function handle_component_removal!(sys::System, hub::TradingHub)
+    _handle_component_removal_common!(hub)
+    for vp in get_components(VirtualParticipant, sys)
+        _remove_trading_hub!(vp, hub)
     end
 end
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -2404,11 +2404,9 @@ function from_dict(
     ext = get_ext(sys)
     ext["deserialization_in_progress"] = true
     try
-        # A key reaches the JSON as its association id; resolving it back needs the
-        # store those ids were minted against.
-        IS.with_deserialization_store(IS.get_data_store(sys.data)) do
-            deserialize_components!(sys, raw["data"])
-        end
+        # Keys serialize as self-contained dicts (association id + element type) under
+        # the association-id world, so no scoped store is needed to resolve them back.
+        deserialize_components!(sys, raw["data"])
     finally
         pop!(ext, "deserialization_in_progress")
         isempty(ext) && clear_ext!(sys)

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -715,3 +715,19 @@ Enumeration of energy units for emissions rate denominator.
 - `GJ = 2`: Gigajoules
 - `MWH = 3`: Megawatt-hours
 """ EnergyUnit
+
+IS.@scoped_enum(
+    CurveStyles,
+    CURVE = 0,
+    FIXED = 1,
+    VARIABLE = 2,
+)
+@doc """
+Enumeration of market-bid curve-clearing styles. Corresponds to ERCOT's DAM `PriceCurve`
+`curveStyle` field (`"CURVE"` | `"FIXED"` | `"VARIABLE"`).
+
+# Values
+- `CURVE = 0`: Ordinary divisible price-setting curve (default).
+- `FIXED = 1`: The bid clears as one indivisible all-or-nothing package over its period.
+- `VARIABLE = 2`: Divisible quantity, block-priced; cannot set the settlement-point price.
+""" CurveStyles

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -19443,6 +19443,201 @@
                 }
             ],
             "supertype": "DynamicInjection"
+        },
+        {
+            "struct_name": "TradingHub",
+            "openapi_type": "TradingHub",
+            "supertype": "MarketComponent",
+            "docstring": "A market trading hub: a named set of member buses at which hub-settled bids are priced. Member buses are unweighted.",
+            "fields": [
+                {
+                    "null_value": "init",
+                    "name": "name",
+                    "comment": "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name",
+                    "exclude_setter": true,
+                    "data_type": "String"
+                },
+                {
+                    "name": "buses",
+                    "data_type": "Vector{ACBus}",
+                    "comment": "Member buses of the hub",
+                    "null_value": "ACBus[]",
+                    "default": "ACBus[]"
+                },
+                {
+                    "name": "ext",
+                    "comment": "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.",
+                    "data_type": "Dict{String, Any}",
+                    "null_value": "Dict{String, Any}()",
+                    "default": "Dict{String, Any}()"
+                },
+                {
+                    "name": "internal",
+                    "comment": "(**Do not modify.**) PowerSystems.jl internal reference",
+                    "data_type": "InfrastructureSystemsInternal",
+                    "internal_default": "InfrastructureSystemsInternal()",
+                    "exclude_setter": true
+                }
+            ]
+        },
+        {
+            "struct_name": "VirtualParticipant",
+            "openapi_type": "VirtualParticipant",
+            "supertype": "MarketTransaction",
+            "docstring": "A virtual (convergence) market participant. Supply offers map to the operating cost's incremental_offer_curves; demand bids to decremental_offer_curves. Settles either at a settlement point or at associated trading hubs (per-hub bids attach as hub-named time series). All MW values are natural units.",
+            "fields": [
+                {
+                    "null_value": "init",
+                    "name": "name",
+                    "comment": "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name",
+                    "exclude_setter": true,
+                    "data_type": "String"
+                },
+                {
+                    "null_value": "false",
+                    "name": "available",
+                    "comment": "Indicator of whether the component is available for market clearing (`true`) or not (`false`)",
+                    "data_type": "Bool"
+                },
+                {
+                    "name": "max_supply",
+                    "data_type": "Float64",
+                    "comment": "MW envelope for the incremental (supply) side (MW)",
+                    "null_value": "0.0",
+                    "valid_range": {
+                        "min": 0.0,
+                        "max": null
+                    },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "max_demand",
+                    "data_type": "Float64",
+                    "comment": "MW envelope for the decremental (demand) side (MW)",
+                    "null_value": "0.0",
+                    "valid_range": {
+                        "min": 0.0,
+                        "max": null
+                    },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "settlement_point",
+                    "openapi_name": "settlement_point_id",
+                    "data_type": "Union{Nothing, Topology}",
+                    "comment": "Settlement location (a bus, area, or load zone); `nothing` when the participant settles at trading hubs instead",
+                    "null_value": "nothing",
+                    "default": "nothing"
+                },
+                {
+                    "name": "trading_hubs",
+                    "data_type": "Vector{TradingHub}",
+                    "comment": "Trading hubs this participant settles at; mutually exclusive with `settlement_point`",
+                    "null_value": "TradingHub[]",
+                    "default": "TradingHub[]"
+                },
+                {
+                    "name": "operation_cost",
+                    "data_type": "Union{MarketBidCost, MarketBidTimeSeriesCost}",
+                    "comment": "Bid curves as an offer-curve operating cost",
+                    "null_value": "MarketBidCost(nothing)",
+                    "default": "MarketBidCost(nothing)"
+                },
+                {
+                    "name": "ext",
+                    "comment": "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.",
+                    "data_type": "Dict{String, Any}",
+                    "null_value": "Dict{String, Any}()",
+                    "default": "Dict{String, Any}()"
+                },
+                {
+                    "name": "internal",
+                    "comment": "(**Do not modify.**) PowerSystems.jl internal reference",
+                    "data_type": "InfrastructureSystemsInternal",
+                    "internal_default": "InfrastructureSystemsInternal()",
+                    "exclude_setter": true
+                }
+            ]
+        },
+        {
+            "struct_name": "PointToPointBid",
+            "openapi_type": "PointToPointBid",
+            "supertype": "MarketTransaction",
+            "docstring": "A priced point-to-point spread bid (e.g. an up-to-congestion or PTP obligation bid): a willingness-to-pay curve on the price spread between two locations. Clears as a withdrawal at `from` and an injection at `to`. Terminals are validated to be a Topology or a TradingHub. All MW values are natural units.",
+            "fields": [
+                {
+                    "null_value": "init",
+                    "name": "name",
+                    "comment": "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name",
+                    "exclude_setter": true,
+                    "data_type": "String"
+                },
+                {
+                    "null_value": "false",
+                    "name": "available",
+                    "comment": "Indicator of whether the component is available for market clearing (`true`) or not (`false`)",
+                    "data_type": "Bool"
+                },
+                {
+                    "name": "from",
+                    "openapi_name": "from_id",
+                    "data_type": "Component",
+                    "comment": "Source terminal (withdrawal side): a Topology or a TradingHub",
+                    "null_value": "ACBus(nothing)"
+                },
+                {
+                    "name": "to",
+                    "openapi_name": "to_id",
+                    "data_type": "Component",
+                    "comment": "Sink terminal (injection side): a Topology or a TradingHub; must differ from `from`",
+                    "null_value": "ACBus(nothing)"
+                },
+                {
+                    "name": "max_active_power",
+                    "data_type": "Float64",
+                    "comment": "MW envelope for the bid (MW)",
+                    "null_value": "0.0",
+                    "valid_range": {
+                        "min": 0.0,
+                        "max": null
+                    },
+                    "validation_action": "error"
+                },
+                {
+                    "name": "price_limits",
+                    "data_type": "MinMax",
+                    "comment": "Tariff bid-price bounds on the spread (\\$/MWh)",
+                    "null_value": "(min=0.0, max=0.0)"
+                },
+                {
+                    "name": "spread_bid",
+                    "data_type": "Union{MarketBidCost, MarketBidTimeSeriesCost}",
+                    "comment": "Willingness-to-pay curve on the to-minus-from price spread, as an offer-curve operating cost (incremental side only)",
+                    "null_value": "MarketBidCost(nothing)",
+                    "default": "MarketBidCost(nothing)"
+                },
+                {
+                    "name": "linked_crr",
+                    "data_type": "Union{Nothing, String}",
+                    "comment": "Identifier of a linked congestion-right instrument, when the market couples the bid to one",
+                    "null_value": "nothing",
+                    "default": "nothing"
+                },
+                {
+                    "name": "ext",
+                    "comment": "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.",
+                    "data_type": "Dict{String, Any}",
+                    "null_value": "Dict{String, Any}()",
+                    "default": "Dict{String, Any}()"
+                },
+                {
+                    "name": "internal",
+                    "comment": "(**Do not modify.**) PowerSystems.jl internal reference",
+                    "data_type": "InfrastructureSystemsInternal",
+                    "internal_default": "InfrastructureSystemsInternal()",
+                    "exclude_setter": true
+                }
+            ]
         }
     ],
     "struct_validation_descriptors": [

--- a/src/generate_structs.jl
+++ b/src/generate_structs.jl
@@ -171,9 +171,21 @@ end
 
 # `reserves` is AGC's regulated-reserve list: like `services`, it is membership, carried by
 # the document's `service_associations` rows and filled in by the association loader — never
-# an inline field on one side.
-const OPENAPI_SKIP_FIELDS =
-    Set(["ext", "internal", "services", "dynamic_injector", "reserves"])
+# an inline field on one side. `buses` and `trading_hubs` are TradingHub's and
+# VirtualParticipant's analogous membership lists, carried by `trading_hub_associations`
+# instead.
+const OPENAPI_SKIP_FIELDS = Set([
+    "ext",
+    "internal",
+    "services",
+    "dynamic_injector",
+    "reserves",
+    "buses",
+    "trading_hubs",
+])
+# Abstract reference types that are not themselves generated structs: `bare in struct_names`
+# misses them, so without this the classifier falls through to `:enum`.
+const OPENAPI_REFERENCE_TYPES = Set(["Topology", "Component"])
 const OPENAPI_SCALAR_TYPES = Set(["Float64", "Int", "Int32", "Int64", "String", "Bool"])
 const OPENAPI_COMPOUND_MEMBERS = Dict(
     "MinMax" => ("min", "max"),
@@ -251,7 +263,7 @@ function openapi_classify_field(struct_name, field, struct_names)
     if name in OPENAPI_SKIP_FIELDS
         return (:skip, field["data_type"], false)
     end
-    if name == "operation_cost"
+    if name in ("operation_cost", "spread_bid")
         return (:cost, field["data_type"], false)
     end
     bare, nullable = openapi_strip_nullable(field["data_type"])
@@ -261,7 +273,7 @@ function openapi_classify_field(struct_name, field, struct_names)
     if haskey(OPENAPI_COMPOUND_MEMBERS, bare)
         return (:compound, bare, nullable)
     end
-    if bare in struct_names
+    if bare in struct_names || bare in OPENAPI_REFERENCE_TYPES
         return (:reference, bare, nullable)
     end
     if !occursin(r"^[A-Za-z_][A-Za-z0-9_]*$", bare)
@@ -813,7 +825,8 @@ function compute_openapi_export_converter!(item, struct_names)
             continue
         end
         if kind == :cost
-            expr = "convert_cost_to_openapi(get_operation_cost(value))"
+            getter = "$(openapi_export_getter_name(field))(value)"
+            expr = "convert_cost_to_openapi($getter)"
             push!(kwargs_device, Dict("name" => name, "expr" => expr))
             push!(kwargs_natural, Dict("name" => name, "expr" => expr))
             continue

--- a/src/generate_structs.jl
+++ b/src/generate_structs.jl
@@ -123,6 +123,17 @@ function from_openapi(po::{{{openapi_po_type}}}, refs::OpenAPIRefs, ::NaturalUni
     )
 end
 
+{{#has_power_units}}
+function from_openapi(po::{{{openapi_po_type}}}, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("{{struct_name}}", po.id, po.power_units))
+end
+{{/has_power_units}}
+{{^has_power_units}}
+function from_openapi(po::{{{openapi_po_type}}}, refs::OpenAPIRefs)
+    return from_openapi(po, refs, DU)
+end
+{{/has_power_units}}
+
 function to_openapi(value::{{struct_name}}, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.{{struct_name}}(;
         {{#openapi_export_kwargs_device}}
@@ -367,6 +378,22 @@ function openapi_natural_conversion(struct_name, field)
         )
     end
     return kind
+end
+
+"""
+Whether an annotated struct has at least one field in the `:power` conversion family
+(`needs_conversion=true` with `conversion_unit` one of `:mw`/`:mvar`/`:mva` — the wire's
+`power_units` discriminator only ever governs that family, never `:ohm`/`:siemens`
+impedance/admittance fields). Determines whether the generated PO struct carries a
+`power_units` member: mechanically derived from the descriptor rather than a maintained
+list, so it can never drift from the fields that are actually emitted.
+"""
+function openapi_has_power_units(item)
+    for field in item["fields"]
+        get(field, "needs_conversion", false) || continue
+        get(field, "conversion_unit", nothing) in (":mw", ":mvar", ":mva") && return true
+    end
+    return false
 end
 
 """
@@ -886,6 +913,17 @@ function compute_openapi_export_converter!(item, struct_names)
         push!(kwargs_natural, Dict("name" => name, "expr" => natural))
     end
 
+    if get(item, "has_power_units", false)
+        push!(
+            kwargs_device,
+            Dict("name" => "power_units", "expr" => "_power_units_string(DU)"),
+        )
+        push!(
+            kwargs_natural,
+            Dict("name" => "power_units", "expr" => "_power_units_string(NU)"),
+        )
+    end
+
     item["openapi_export_kwargs_device"] = kwargs_device
     item["openapi_export_kwargs_natural"] = kwargs_natural
     return nothing
@@ -1060,6 +1098,7 @@ function generate_structs(directory, data::Vector; print_results = true)
         item["needs_positional_constructor"] = has_internal && has_non_default_values
 
         if haskey(item, "openapi_type")
+            item["has_power_units"] = openapi_has_power_units(item)
             compute_openapi_converter!(item, openapi_struct_names)
             compute_openapi_export_converter!(item, openapi_struct_names)
         end

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -171,9 +171,9 @@ function get_export_variable_cost(
         device, get_export_offer_curves(cost), start_time, len)
 end
 
-# ── START-UP / SHUT-DOWN / NO-LOAD GETTERS (time-series variants) ──────────
+# ── START-UP / SHUT-DOWN / MINIMUM-ENERGY-OFFER GETTERS (time-series variants) ──────────
 
-function get_no_load_cost(
+function get_minimum_energy_offer(
     device::StaticInjection,
     cost::MarketBidTimeSeriesCost;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
@@ -181,7 +181,7 @@ function get_no_load_cost(
 )
     isnothing(start_time) &&
         throw(ArgumentError("start_time is required for MarketBidTimeSeriesCost"))
-    return _build_static(get_no_load_cost(cost), device, start_time, len)
+    return _build_static(get_minimum_energy_offer(cost), device, start_time, len)
 end
 
 function get_shut_down(
@@ -445,7 +445,7 @@ function _replace_offer_curve(
         _retag_placeholder(get_decremental_offer_curves(cost), U)
     end
     return MarketBidCost(;
-        no_load_cost = get_no_load_cost(cost),
+        minimum_energy_offer = get_minimum_energy_offer(cost),
         start_up = get_start_up(cost),
         shut_down = get_shut_down(cost),
         incremental_offer_curves = inc,
@@ -691,4 +691,61 @@ function set_service_bid!(
     ::IS.AbstractUnitSystem,
 )
     return _reject_ts_eltype(:set_service_bid!, PiecewiseStepData, time_series_data)
+end
+
+# ── Hub Bid Setter ──────────────────────────────────────────────────────────
+
+"""
+Adds trading-hub bid time-series data to the cost.
+
+# Arguments
+- `sys::System`: PowerSystem System
+- `vp::VirtualParticipant`: Virtual participant bidding at the hub
+- `hub::TradingHub`: Trading hub the participant settles bids at
+- `time_series_data::IS.TimeSeriesData{<:PiecewiseStepData}`: TimeSeriesData whose values
+  are `PiecewiseStepData`
+"""
+function set_hub_bid!(
+    sys::System,
+    vp::VirtualParticipant,
+    hub::TradingHub,
+    time_series_data::IS.TimeSeriesData{<:PiecewiseStepData},
+    power_units::IS.AbstractUnitSystem,
+)
+    if get_name(time_series_data) != get_name(hub)
+        error(
+            "Name provided in the TimeSeries Data $(get_name(time_series_data)), doesn't match the TradingHub $(get_name(hub)).",
+        )
+    end
+    if power_units != IS.NaturalUnit()
+        throw(
+            ArgumentError(
+                "Power Unit specified for hub market bids must be NATURAL_UNITS",
+            ),
+        )
+    end
+    if !has_trading_hub(vp, hub)
+        error(
+            "$(get_name(vp)) is not associated with hub $(get_name(hub)); call add_trading_hub! first.",
+        )
+    end
+    if has_time_series(vp, typeof(time_series_data), get_name(hub))
+        error(
+            "$(get_name(vp)) already has a hub bid time series named $(get_name(hub)).",
+        )
+    end
+    add_time_series!(sys, vp, time_series_data)
+    return
+end
+
+# Hub bids must be piecewise step data; report the mismatch rather than letting the
+# narrowed signature above surface as a bare MethodError.
+function set_hub_bid!(
+    ::System,
+    ::VirtualParticipant,
+    ::TradingHub,
+    time_series_data::IS.TimeSeriesData,
+    ::IS.AbstractUnitSystem,
+)
+    return _reject_ts_eltype(:set_hub_bid!, PiecewiseStepData, time_series_data)
 end

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -31,7 +31,7 @@ end
 
 function _validate_fuel_curve(component::Component)
     op_cost = get_operation_cost(component)
-    var_cost = get_variable(op_cost)
+    var_cost = get_variable_operation_cost(op_cost)
     !(var_cost isa FuelCurve) && throw(
         ArgumentError(
             "Variable cost of type $(typeof(var_cost)) cannot represent a fuel cost, use FuelCurve instead",
@@ -641,7 +641,7 @@ function set_fuel_cost!(
             get_startup_fuel_offtake(var_cost),
             get_vom_cost(var_cost),
         )
-    set_variable!(op_cost, new_var_cost)
+    set_variable_operation_cost!(op_cost, new_var_cost)
 end
 
 # ── Service Bid Setter ──────────────────────────────────────────────────────

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -372,7 +372,7 @@ function get_services_bid(
     if IS.is_time_series_backed(offer_curves)
         ts_key = IS.get_time_series_key(get_value_curve(offer_curves))
         ts = get_time_series(
-            ts_key.time_series_type,
+            IS.get_time_series_type(ts_key),
             device,
             get_name(service);
             start_time = start_time,

--- a/src/models/cost_functions/HydroGenerationCost.jl
+++ b/src/models/cost_functions/HydroGenerationCost.jl
@@ -2,20 +2,21 @@
 $(TYPEDEF)
 $(TYPEDFIELDS)
 
-    HydroGenerationCost(variable, fixed)
-    HydroGenerationCost(; variable, fixed)
+    HydroGenerationCost(variable_operation_cost, fixed)
+    HydroGenerationCost(; variable_operation_cost, fixed)
 
 An operational cost of a hydropower generator which includes fixed and
 variable cost. Variable costs can be used to represent the cost of curtailment if negative
 values are used or the opportunity cost of water if the costs are positive. It also supports
-fuel curves to model specific water intake. 
+fuel curves to model specific water intake.
 
-The `variable` cost is a required parameter, but `zero(CostCurve)` can be used to set it to 0.
+The `variable_operation_cost` cost is a required parameter, but `zero(CostCurve)` can be used
+to set it to 0.
 """
 @kwdef mutable struct HydroGenerationCost <: OperationalCost
     "Production variable cost represented by a `FuelCurve`, where the fuel is water,
     or a `CostCurve` in currency."
-    variable::ProductionVariableCostCurve
+    variable_operation_cost::ProductionVariableCostCurve
     "(default: 0) Fixed cost of keeping the unit online. For some cost represenations this
     field can be duplicative"
     fixed::Float64
@@ -24,12 +25,13 @@ end
 # Constructor for demo purposes; non-functional.
 HydroGenerationCost(::Nothing) = HydroGenerationCost(zero(CostCurve), 0.0)
 
-"""Get [`HydroGenerationCost`](@ref) `variable`."""
-get_variable(value::HydroGenerationCost) = value.variable
+"""Get [`HydroGenerationCost`](@ref) `variable_operation_cost`."""
+get_variable_operation_cost(value::HydroGenerationCost) = value.variable_operation_cost
 """Get [`HydroGenerationCost`](@ref) `fixed`."""
 get_fixed(value::HydroGenerationCost) = value.fixed
 
-"""Set [`HydroGenerationCost`](@ref) `variable`."""
-set_variable!(value::HydroGenerationCost, val) = value.variable = val
+"""Set [`HydroGenerationCost`](@ref) `variable_operation_cost`."""
+set_variable_operation_cost!(value::HydroGenerationCost, val) =
+    value.variable_operation_cost = val
 """Set [`HydroGenerationCost`](@ref) `fixed`."""
 set_fixed!(value::HydroGenerationCost, val) = value.fixed = val

--- a/src/models/cost_functions/LoadCost.jl
+++ b/src/models/cost_functions/LoadCost.jl
@@ -2,17 +2,18 @@
 $(TYPEDEF)
 $(TYPEDFIELDS)
 
-    LoadCost(variable, fixed)
-    LoadCost(; variable, fixed)
+    LoadCost(variable_operation_cost, fixed)
+    LoadCost(; variable_operation_cost, fixed)
 
 An operational cost for controllable loads (e.g., InterruptiblePowerLoad), including
 fixed and variable cost components.
 
-The `variable` cost is a required parameter, but `zero(CostCurve)` can be used to set it to 0.
+The `variable_operation_cost` cost is a required parameter, but `zero(CostCurve)` can be used
+to set it to 0.
 """
 @kwdef mutable struct LoadCost <: OperationalCost
     "Variable cost represented as a [`CostCurve`](@ref)"
-    variable::CostCurve
+    variable_operation_cost::CostCurve
     "(default: 0) Fixed cost. For some cost represenations this field can be
     duplicative"
     fixed::Float64
@@ -21,12 +22,12 @@ end
 # Constructor for demo purposes; non-functional.
 LoadCost(::Nothing) = LoadCost(zero(CostCurve), 0.0)
 
-"""Get [`LoadCost`](@ref) `variable`."""
-get_variable(value::LoadCost) = value.variable
+"""Get [`LoadCost`](@ref) `variable_operation_cost`."""
+get_variable_operation_cost(value::LoadCost) = value.variable_operation_cost
 """Get [`LoadCost`](@ref) `fixed`."""
 get_fixed(value::LoadCost) = value.fixed
 
-"""Set [`LoadCost`](@ref) `variable`."""
-set_variable!(value::LoadCost, val) = value.variable = val
+"""Set [`LoadCost`](@ref) `variable_operation_cost`."""
+set_variable_operation_cost!(value::LoadCost, val) = value.variable_operation_cost = val
 """Set [`LoadCost`](@ref) `fixed`."""
 set_fixed!(value::LoadCost, val) = value.fixed = val

--- a/src/models/cost_functions/MarketBidCost.jl
+++ b/src/models/cost_functions/MarketBidCost.jl
@@ -2,16 +2,16 @@
 $(TYPEDEF)
 $(TYPEDFIELDS)
 
-    MarketBidCost(no_load_cost, start_up, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers)
-    MarketBidCost(; no_load_cost, start_up, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers)
-    MarketBidCost(no_load_cost, start_up::Real, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers)
+    MarketBidCost(minimum_energy_offer, start_up, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers, incremental_slope, decremental_slope, curve_style)
+    MarketBidCost(; minimum_energy_offer, start_up, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers, incremental_slope, decremental_slope, curve_style)
+    MarketBidCost(minimum_energy_offer, start_up::Real, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers, incremental_slope, decremental_slope, curve_style)
 
 An operating cost for static (non-time-varying) market bids of energy and ancillary
 services. For time-varying bids, use [`MarketBidTimeSeriesCost`](@ref).
 """
 mutable struct MarketBidCost{U <: IS.AbstractUnitSystem} <: OfferCurveCost
-    "No load cost"
-    no_load_cost::LinearCurve
+    "Minimum-energy offer: cost to operate at minimum stable level, in \$/MWh at the curve's minimum power, stored as submitted. \$/h sources convert at parse (MEO = no-load cost / P_min)."
+    minimum_energy_offer::LinearCurve
     "Start-up cost at different stages of the thermal cycle (hot, warm, cold)"
     start_up::StartUpStages
     "Shut-down cost"
@@ -22,17 +22,26 @@ mutable struct MarketBidCost{U <: IS.AbstractUnitSystem} <: OfferCurveCost
     decremental_offer_curves::CostCurve{PiecewiseIncrementalCurve, U}
     "Bids for the ancillary services"
     ancillary_service_offers::Vector{Service}
+    "Linear-interpolation flag for the corresponding offer curve; false (default) is the step interpretation. Mutually exclusive with block groups on the same curve."
+    incremental_slope::Bool
+    "Linear-interpolation flag for the corresponding offer curve; false (default) is the step interpretation. Mutually exclusive with block groups on the same curve."
+    decremental_slope::Bool
+    "Curve-clearing style for the bid ([`CurveStyles`](@ref)); CURVE (default) is ordinary divisible price-setting. A non-CURVE value is mutually exclusive with linear interpolation (`incremental_slope`/`decremental_slope`) on either offer curve."
+    curve_style::CurveStyles
 end
 
 const ZERO_OFFER_CURVE = CostCurve(PiecewiseIncrementalCurve(0.0, [0.0, 0.0], [0.0]))
 
 function MarketBidCost(;
-    no_load_cost = LinearCurve(0.0),
+    minimum_energy_offer = LinearCurve(0.0),
     start_up = (hot = 0.0, warm = 0.0, cold = 0.0),
     shut_down = LinearCurve(0.0),
     incremental_offer_curves = ZERO_OFFER_CURVE,
     decremental_offer_curves = ZERO_OFFER_CURVE,
     ancillary_service_offers = Vector{Service}(),
+    incremental_slope = false,
+    decremental_slope = false,
+    curve_style = CurveStyles.CURVE,
 )
     U_inc = typeof(get_power_units(incremental_offer_curves))
     U_dec = typeof(get_power_units(decremental_offer_curves))
@@ -41,10 +50,12 @@ function MarketBidCost(;
             "incremental_offer_curves and decremental_offer_curves must share a unit system (got $(U_inc()) vs $(U_dec()))",
         ),
     )
+    check_curve_style_exclusivity(curve_style, incremental_slope, decremental_slope)
     return MarketBidCost{U_inc}(
-        no_load_cost, start_up, shut_down,
+        minimum_energy_offer, start_up, shut_down,
         incremental_offer_curves, decremental_offer_curves,
         ancillary_service_offers,
+        incremental_slope, decremental_slope, curve_style,
     )
 end
 
@@ -60,26 +71,32 @@ Accepts a single `start_up` value to use as the `hot` value, with `warm` and `co
 `0.0`.
 """
 function MarketBidCost(
-    no_load_cost,
+    minimum_energy_offer,
     start_up::Real,
     shut_down;
     incremental_offer_curves = ZERO_OFFER_CURVE,
     decremental_offer_curves = ZERO_OFFER_CURVE,
     ancillary_service_offers = Vector{Service}(),
+    incremental_slope = false,
+    decremental_slope = false,
+    curve_style = CurveStyles.CURVE,
 )
     start_up_multi = single_start_up_to_stages(start_up)
     return MarketBidCost(;
-        no_load_cost = no_load_cost,
+        minimum_energy_offer = minimum_energy_offer,
         start_up = start_up_multi,
         shut_down = shut_down,
         incremental_offer_curves = incremental_offer_curves,
         decremental_offer_curves = decremental_offer_curves,
         ancillary_service_offers = ancillary_service_offers,
+        incremental_slope = incremental_slope,
+        decremental_slope = decremental_slope,
+        curve_style = curve_style,
     )
 end
 
-"""Get [`MarketBidCost`](@ref) `no_load_cost`."""
-get_no_load_cost(value::MarketBidCost) = value.no_load_cost
+"""Get [`MarketBidCost`](@ref) `minimum_energy_offer`."""
+get_minimum_energy_offer(value::MarketBidCost) = value.minimum_energy_offer
 """Get [`MarketBidCost`](@ref) `start_up`."""
 get_start_up(value::MarketBidCost) = value.start_up
 """Get [`MarketBidCost`](@ref) `shut_down`."""
@@ -90,9 +107,15 @@ get_incremental_offer_curves(value::MarketBidCost) = value.incremental_offer_cur
 get_decremental_offer_curves(value::MarketBidCost) = value.decremental_offer_curves
 """Get [`MarketBidCost`](@ref) `ancillary_service_offers`."""
 get_ancillary_service_offers(value::MarketBidCost) = value.ancillary_service_offers
+"""Get [`MarketBidCost`](@ref) `incremental_slope`."""
+get_incremental_slope(value::MarketBidCost) = value.incremental_slope
+"""Get [`MarketBidCost`](@ref) `decremental_slope`."""
+get_decremental_slope(value::MarketBidCost) = value.decremental_slope
+"""Get [`MarketBidCost`](@ref) `curve_style`."""
+get_curve_style(value::MarketBidCost) = value.curve_style
 
-"""Set [`MarketBidCost`](@ref) `no_load_cost`."""
-set_no_load_cost!(value::MarketBidCost, val) = value.no_load_cost = val
+"""Set [`MarketBidCost`](@ref) `minimum_energy_offer`."""
+set_minimum_energy_offer!(value::MarketBidCost, val) = value.minimum_energy_offer = val
 """Set [`MarketBidCost`](@ref) `start_up`."""
 set_start_up!(value::MarketBidCost, val) = value.start_up = val
 """Set [`MarketBidCost`](@ref) `shut_down`."""
@@ -106,6 +129,12 @@ set_decremental_offer_curves!(value::MarketBidCost, val) =
 """Set [`MarketBidCost`](@ref) `ancillary_service_offers`."""
 set_ancillary_service_offers!(value::MarketBidCost, val) =
     value.ancillary_service_offers = val
+"""Set [`MarketBidCost`](@ref) `incremental_slope`."""
+set_incremental_slope!(value::MarketBidCost, val) = value.incremental_slope = val
+"""Set [`MarketBidCost`](@ref) `decremental_slope`."""
+set_decremental_slope!(value::MarketBidCost, val) = value.decremental_slope = val
+"""Set [`MarketBidCost`](@ref) `curve_style`."""
+set_curve_style!(value::MarketBidCost, val) = value.curve_style = val
 
 """Auxiliary Method for setting up start up that are not multi-start"""
 function set_start_up!(value::MarketBidCost, val::Real)

--- a/src/models/cost_functions/MarketBidTimeSeriesCost.jl
+++ b/src/models/cost_functions/MarketBidTimeSeriesCost.jl
@@ -2,16 +2,16 @@
 $(TYPEDEF)
 $(TYPEDFIELDS)
 
-    MarketBidTimeSeriesCost(no_load_cost, start_up, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers)
-    MarketBidTimeSeriesCost(; no_load_cost, start_up, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers)
+    MarketBidTimeSeriesCost(minimum_energy_offer, start_up, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers, incremental_slope, decremental_slope, curve_style)
+    MarketBidTimeSeriesCost(; minimum_energy_offer, start_up, shut_down, incremental_offer_curves, decremental_offer_curves, ancillary_service_offers, incremental_slope, decremental_slope, curve_style)
 
 An operating cost for time-varying market bids of energy and ancillary services.
 All cost curve fields are backed by time series data via IS.jl's time-series ValueCurve types.
 For static (non-time-varying) bids, use [`MarketBidCost`](@ref).
 """
 mutable struct MarketBidTimeSeriesCost{U <: IS.AbstractUnitSystem} <: OfferCurveCost
-    "No load cost (time series)"
-    no_load_cost::TimeSeriesLinearCurve
+    "Minimum-energy offer: cost to operate at minimum stable level, in \$/MWh at the curve's minimum power, stored as submitted. \$/h sources convert at parse (MEO = no-load cost / P_min)."
+    minimum_energy_offer::TimeSeriesLinearCurve
     "Key of a time series of `NTuple{3, Float64}` start-up cost stages, resolved to a
     `StartUpStages` at a chosen timestep by `get_start_up(device, cost; start_time)`"
     start_up::IS.ConcreteTimeSeriesKey
@@ -23,15 +23,24 @@ mutable struct MarketBidTimeSeriesCost{U <: IS.AbstractUnitSystem} <: OfferCurve
     decremental_offer_curves::CostCurve{TimeSeriesPiecewiseIncrementalCurve, U}
     "Bids for the ancillary services"
     ancillary_service_offers::Vector{Service}
+    "Linear-interpolation flag for the corresponding offer curve; false (default) is the step interpretation. Mutually exclusive with block groups on the same curve."
+    incremental_slope::Bool
+    "Linear-interpolation flag for the corresponding offer curve; false (default) is the step interpretation. Mutually exclusive with block groups on the same curve."
+    decremental_slope::Bool
+    "Curve-clearing style for the bid ([`CurveStyles`](@ref)); CURVE (default) is ordinary divisible price-setting. A non-CURVE value is mutually exclusive with linear interpolation (`incremental_slope`/`decremental_slope`) on either offer curve."
+    curve_style::CurveStyles
 end
 
 function MarketBidTimeSeriesCost(;
-    no_load_cost,
+    minimum_energy_offer,
     start_up,
     shut_down,
     incremental_offer_curves,
     decremental_offer_curves,
     ancillary_service_offers = Vector{Service}(),
+    incremental_slope = false,
+    decremental_slope = false,
+    curve_style = CurveStyles.CURVE,
 )
     U_inc = typeof(get_power_units(incremental_offer_curves))
     U_dec = typeof(get_power_units(decremental_offer_curves))
@@ -40,15 +49,17 @@ function MarketBidTimeSeriesCost(;
             "incremental_offer_curves and decremental_offer_curves must share a unit system (got $(U_inc()) vs $(U_dec()))",
         ),
     )
+    check_curve_style_exclusivity(curve_style, incremental_slope, decremental_slope)
     return MarketBidTimeSeriesCost{U_inc}(
-        no_load_cost, start_up, shut_down,
+        minimum_energy_offer, start_up, shut_down,
         incremental_offer_curves, decremental_offer_curves,
         ancillary_service_offers,
+        incremental_slope, decremental_slope, curve_style,
     )
 end
 
-"""Get [`MarketBidTimeSeriesCost`](@ref) `no_load_cost`."""
-get_no_load_cost(value::MarketBidTimeSeriesCost) = value.no_load_cost
+"""Get [`MarketBidTimeSeriesCost`](@ref) `minimum_energy_offer`."""
+get_minimum_energy_offer(value::MarketBidTimeSeriesCost) = value.minimum_energy_offer
 """Get [`MarketBidTimeSeriesCost`](@ref) `start_up`."""
 get_start_up(value::MarketBidTimeSeriesCost) = value.start_up
 """Get [`MarketBidTimeSeriesCost`](@ref) `shut_down`."""
@@ -62,9 +73,16 @@ get_decremental_offer_curves(value::MarketBidTimeSeriesCost) =
 """Get [`MarketBidTimeSeriesCost`](@ref) `ancillary_service_offers`."""
 get_ancillary_service_offers(value::MarketBidTimeSeriesCost) =
     value.ancillary_service_offers
+"""Get [`MarketBidTimeSeriesCost`](@ref) `incremental_slope`."""
+get_incremental_slope(value::MarketBidTimeSeriesCost) = value.incremental_slope
+"""Get [`MarketBidTimeSeriesCost`](@ref) `decremental_slope`."""
+get_decremental_slope(value::MarketBidTimeSeriesCost) = value.decremental_slope
+"""Get [`MarketBidTimeSeriesCost`](@ref) `curve_style`."""
+get_curve_style(value::MarketBidTimeSeriesCost) = value.curve_style
 
-"""Set [`MarketBidTimeSeriesCost`](@ref) `no_load_cost`."""
-set_no_load_cost!(value::MarketBidTimeSeriesCost, val) = value.no_load_cost = val
+"""Set [`MarketBidTimeSeriesCost`](@ref) `minimum_energy_offer`."""
+set_minimum_energy_offer!(value::MarketBidTimeSeriesCost, val) =
+    value.minimum_energy_offer = val
 """Set [`MarketBidTimeSeriesCost`](@ref) `start_up`."""
 set_start_up!(value::MarketBidTimeSeriesCost, val) = value.start_up = val
 """Set [`MarketBidTimeSeriesCost`](@ref) `shut_down`."""
@@ -78,6 +96,15 @@ set_decremental_offer_curves!(value::MarketBidTimeSeriesCost, val) =
 """Set [`MarketBidTimeSeriesCost`](@ref) `ancillary_service_offers`."""
 set_ancillary_service_offers!(value::MarketBidTimeSeriesCost, val) =
     value.ancillary_service_offers = val
+"""Set [`MarketBidTimeSeriesCost`](@ref) `incremental_slope`."""
+set_incremental_slope!(value::MarketBidTimeSeriesCost, val) =
+    value.incremental_slope = val
+"""Set [`MarketBidTimeSeriesCost`](@ref) `decremental_slope`."""
+set_decremental_slope!(value::MarketBidTimeSeriesCost, val) =
+    value.decremental_slope = val
+"""Set [`MarketBidTimeSeriesCost`](@ref) `curve_style`."""
+set_curve_style!(value::MarketBidTimeSeriesCost, val) =
+    value.curve_style = val
 
 """
 Make a time-series-backed `CostCurve{TimeSeriesPiecewiseIncrementalCurve}` from

--- a/src/models/cost_functions/OfferCurveCost.jl
+++ b/src/models/cost_functions/OfferCurveCost.jl
@@ -11,3 +11,23 @@ All concrete subtypes must implement the required interface methods for cost cal
 and curve evaluation in power system market operations.
 """
 abstract type OfferCurveCost <: OperationalCost end
+
+"""
+Throws ArgumentError if a non-`CURVE` `curve_style` is combined with linear interpolation on
+either offer curve. Shared by the [`MarketBidCost`](@ref) and
+[`MarketBidTimeSeriesCost`](@ref) constructors.
+"""
+function check_curve_style_exclusivity(
+    curve_style::CurveStyles,
+    incremental_slope::Bool,
+    decremental_slope::Bool,
+)
+    if curve_style != CurveStyles.CURVE && (incremental_slope || decremental_slope)
+        throw(
+            ArgumentError(
+                "curve_style is mutually exclusive with incremental_slope/decremental_slope: an interpolated curve cannot clear as a block",
+            ),
+        )
+    end
+    return nothing
+end

--- a/src/models/cost_functions/RenewableGenerationCost.jl
+++ b/src/models/cost_functions/RenewableGenerationCost.jl
@@ -2,38 +2,41 @@
 $(TYPEDEF)
 $(TYPEDFIELDS)
 
-    RenewableGenerationCost(variable, curtailment_cost, fixed)
-    RenewableGenerationCost(; variable, curtailment_cost, fixed)
+    RenewableGenerationCost(variable_operation_cost, curtailment_cost, fixed)
+    RenewableGenerationCost(; variable_operation_cost, curtailment_cost, fixed)
 
 An operational cost of renewable generators which includes the variable cost of energy
 (like a [PPA](@ref P)), the cost of curtailing power, and a fixed cost of keeping the unit online.
 For example, curtailment costs can be used to represent the loss of tax incentives.
 
-The `variable` cost is a required parameter, but `zero(CostCurve)` can be used to set it to 0.
+The `variable_operation_cost` cost is a required parameter, but `zero(CostCurve)` can be used
+to set it to 0.
 """
 @kwdef mutable struct RenewableGenerationCost <: OperationalCost
     "Variable cost represented as a [`CostCurve`](@ref)"
-    variable::CostCurve
+    variable_operation_cost::CostCurve
     "(default of 0) Cost of curtailing power represented as a [`CostCurve`](@ref)"
     curtailment_cost::CostCurve = zero(CostCurve)
     "Fixed cost of keeping the unit online. For some cost representations this field can be duplicative with respect to the data in the VOM field."
     fixed::Float64 = 0.0
 end
 
-RenewableGenerationCost(variable) = RenewableGenerationCost(; variable)
+RenewableGenerationCost(variable_operation_cost) =
+    RenewableGenerationCost(; variable_operation_cost)
 
 # Constructor for demo purposes; non-functional.
 RenewableGenerationCost(::Nothing) = RenewableGenerationCost(zero(CostCurve))
 
-"""Get [`RenewableGenerationCost`](@ref) `variable`."""
-get_variable(value::RenewableGenerationCost) = value.variable
+"""Get [`RenewableGenerationCost`](@ref) `variable_operation_cost`."""
+get_variable_operation_cost(value::RenewableGenerationCost) = value.variable_operation_cost
 """Get [`RenewableGenerationCost`](@ref) `curtailment_cost`."""
 get_curtailment_cost(value::RenewableGenerationCost) = value.curtailment_cost
 """Get [`RenewableGenerationCost`](@ref) `fixed`."""
 get_fixed(value::RenewableGenerationCost) = value.fixed
 
-"""Set [`RenewableGenerationCost`](@ref) `variable`."""
-set_variable!(value::RenewableGenerationCost, val) = value.variable = val
+"""Set [`RenewableGenerationCost`](@ref) `variable_operation_cost`."""
+set_variable_operation_cost!(value::RenewableGenerationCost, val) =
+    value.variable_operation_cost = val
 """Set [`RenewableGenerationCost`](@ref) `curtailment_cost`."""
 set_curtailment_cost!(value::RenewableGenerationCost, val) = value.curtailment_cost = val
 """Set [`RenewableGenerationCost`](@ref) `fixed`."""

--- a/src/models/cost_functions/ThermalGenerationCost.jl
+++ b/src/models/cost_functions/ThermalGenerationCost.jl
@@ -2,15 +2,15 @@
 $(TYPEDEF)
 $(TYPEDFIELDS)
 
-    ThermalGenerationCost(variable, fixed, start_up, shut_down)
-    ThermalGenerationCost(; variable, fixed, start_up, shut_down)
+    ThermalGenerationCost(variable_operation_cost, fixed, start_up, shut_down)
+    ThermalGenerationCost(; variable_operation_cost, fixed, start_up, shut_down)
 
 An operational cost for thermal generators which includes fixed cost, variable cost, shut-down
 cost, and  multiple options for start up costs.
 """
 @kwdef mutable struct ThermalGenerationCost <: OperationalCost
     "Variable production cost. Can take a [`CostCurve`](@ref) or [`FuelCurve`](@ref)"
-    variable::ProductionVariableCostCurve
+    variable_operation_cost::ProductionVariableCostCurve
     "Fixed cost of keeping the unit online. For some cost represenations this field can be
     duplicative"
     fixed::Float64
@@ -20,21 +20,23 @@ cost, and  multiple options for start up costs.
     shut_down::Float64
 end
 
-ThermalGenerationCost(variable, fixed, start_up::Integer, shut_down) =
-    ThermalGenerationCost(variable, fixed, convert(Float64, start_up), shut_down)
+ThermalGenerationCost(variable_operation_cost, fixed, start_up::Integer, shut_down) =
+    ThermalGenerationCost(
+        variable_operation_cost, fixed, convert(Float64, start_up), shut_down,
+    )
 
 # Constructor for demo purposes; non-functional.
 function ThermalGenerationCost(::Nothing)
     ThermalGenerationCost(;
-        variable = zero(CostCurve),
+        variable_operation_cost = zero(CostCurve),
         fixed = 0.0,
         start_up = 0.0,
         shut_down = 0.0,
     )
 end
 
-"""Get [`ThermalGenerationCost`](@ref) `variable`."""
-get_variable(value::ThermalGenerationCost) = value.variable
+"""Get [`ThermalGenerationCost`](@ref) `variable_operation_cost`."""
+get_variable_operation_cost(value::ThermalGenerationCost) = value.variable_operation_cost
 """Get [`ThermalGenerationCost`](@ref) `fixed`."""
 get_fixed(value::ThermalGenerationCost) = value.fixed
 """Get [`ThermalGenerationCost`](@ref) `start_up`."""
@@ -42,8 +44,9 @@ get_start_up(value::ThermalGenerationCost) = value.start_up
 """Get [`ThermalGenerationCost`](@ref) `shut_down`."""
 get_shut_down(value::ThermalGenerationCost) = value.shut_down
 
-"""Set [`ThermalGenerationCost`](@ref) `variable`."""
-set_variable!(value::ThermalGenerationCost, val) = value.variable = val
+"""Set [`ThermalGenerationCost`](@ref) `variable_operation_cost`."""
+set_variable_operation_cost!(value::ThermalGenerationCost, val) =
+    value.variable_operation_cost = val
 """Set [`ThermalGenerationCost`](@ref) `fixed`."""
 set_fixed!(value::ThermalGenerationCost, val) = value.fixed = val
 """Set [`ThermalGenerationCost`](@ref) `start_up`."""

--- a/src/models/generated/ACBus.jl
+++ b/src/models/generated/ACBus.jl
@@ -181,6 +181,10 @@ function from_openapi(po::PO.ACBus, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.ACBus, refs::OpenAPIRefs)
+    return from_openapi(po, refs, DU)
+end
+
 function to_openapi(value::ACBus, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.ACBus(;
         id = component_id(refs, value),

--- a/src/models/generated/AGC.jl
+++ b/src/models/generated/AGC.jl
@@ -165,6 +165,10 @@ function from_openapi(po::PO.AGC, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.AGC, refs::OpenAPIRefs)
+    return from_openapi(po, refs, DU)
+end
+
 function to_openapi(value::AGC, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.AGC(;
         id = component_id(refs, value),

--- a/src/models/generated/AreaInterchange.jl
+++ b/src/models/generated/AreaInterchange.jl
@@ -147,6 +147,10 @@ function from_openapi(po::PO.AreaInterchange, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.AreaInterchange, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("AreaInterchange", po.id, po.power_units))
+end
+
 function to_openapi(value::AreaInterchange, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.AreaInterchange(;
         id = component_id(refs, value),
@@ -157,6 +161,7 @@ function to_openapi(value::AreaInterchange, refs::OpenAPIRefs, ::DeviceBaseUnit)
         to_area = component_id(refs, get_to_area(value)),
         flow_limits = _fromto_tofrom_po(get_flow_limits(value, SU)),
         base_power = get_base_power(refs),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -170,5 +175,6 @@ function to_openapi(value::AreaInterchange, refs::OpenAPIRefs, ::NaturalUnit)
         to_area = component_id(refs, get_to_area(value)),
         flow_limits = _fromto_tofrom_po_scaled(get_flow_limits(value, SU), get_base_power(refs)),
         base_power = get_base_power(refs),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/DCBus.jl
+++ b/src/models/generated/DCBus.jl
@@ -143,6 +143,10 @@ function from_openapi(po::PO.DCBus, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.DCBus, refs::OpenAPIRefs)
+    return from_openapi(po, refs, DU)
+end
+
 function to_openapi(value::DCBus, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.DCBus(;
         id = component_id(refs, value),

--- a/src/models/generated/ExponentialLoad.jl
+++ b/src/models/generated/ExponentialLoad.jl
@@ -208,6 +208,10 @@ function from_openapi(po::PO.ExponentialLoad, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.ExponentialLoad, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("ExponentialLoad", po.id, po.power_units))
+end
+
 function to_openapi(value::ExponentialLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.ExponentialLoad(;
         id = component_id(refs, value),
@@ -222,6 +226,7 @@ function to_openapi(value::ExponentialLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
         max_active_power = get_max_active_power(value, DU),
         max_reactive_power = get_max_reactive_power(value, DU),
         conformity = string(get_conformity(value)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -239,5 +244,6 @@ function to_openapi(value::ExponentialLoad, refs::OpenAPIRefs, ::NaturalUnit)
         max_active_power = get_max_active_power(value, DU) * _get_base_power(value),
         max_reactive_power = get_max_reactive_power(value, DU) * _get_base_power(value),
         conformity = string(get_conformity(value)),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/HydroDispatch.jl
+++ b/src/models/generated/HydroDispatch.jl
@@ -260,6 +260,10 @@ function from_openapi(po::PO.HydroDispatch, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.HydroDispatch, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("HydroDispatch", po.id, po.power_units))
+end
+
 function to_openapi(value::HydroDispatch, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.HydroDispatch(;
         id = component_id(refs, value),
@@ -278,6 +282,7 @@ function to_openapi(value::HydroDispatch, refs::OpenAPIRefs, ::DeviceBaseUnit)
         status = get_status(value),
         time_at_status = get_time_at_status(value),
         operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -299,5 +304,6 @@ function to_openapi(value::HydroDispatch, refs::OpenAPIRefs, ::NaturalUnit)
         status = get_status(value),
         time_at_status = get_time_at_status(value),
         operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/HydroPumpTurbine.jl
+++ b/src/models/generated/HydroPumpTurbine.jl
@@ -376,6 +376,10 @@ function from_openapi(po::PO.HydroPumpTurbine, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.HydroPumpTurbine, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("HydroPumpTurbine", po.id, po.power_units))
+end
+
 function to_openapi(value::HydroPumpTurbine, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.HydroPumpTurbine(;
         id = component_id(refs, value),
@@ -404,6 +408,7 @@ function to_openapi(value::HydroPumpTurbine, refs::OpenAPIRefs, ::DeviceBaseUnit
         conversion_factor = get_conversion_factor(value),
         must_run = get_must_run(value),
         prime_mover_type = string(get_prime_mover_type(value)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -435,5 +440,6 @@ function to_openapi(value::HydroPumpTurbine, refs::OpenAPIRefs, ::NaturalUnit)
         conversion_factor = get_conversion_factor(value),
         must_run = get_must_run(value),
         prime_mover_type = string(get_prime_mover_type(value)),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/HydroTurbine.jl
+++ b/src/models/generated/HydroTurbine.jl
@@ -302,6 +302,10 @@ function from_openapi(po::PO.HydroTurbine, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.HydroTurbine, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("HydroTurbine", po.id, po.power_units))
+end
+
 function to_openapi(value::HydroTurbine, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.HydroTurbine(;
         id = component_id(refs, value),
@@ -324,6 +328,7 @@ function to_openapi(value::HydroTurbine, refs::OpenAPIRefs, ::DeviceBaseUnit)
         conversion_factor = get_conversion_factor(value),
         prime_mover_type = string(get_prime_mover_type(value)),
         travel_time = get_travel_time(value),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -349,5 +354,6 @@ function to_openapi(value::HydroTurbine, refs::OpenAPIRefs, ::NaturalUnit)
         conversion_factor = get_conversion_factor(value),
         prime_mover_type = string(get_prime_mover_type(value)),
         travel_time = get_travel_time(value),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/InterruptiblePowerLoad.jl
+++ b/src/models/generated/InterruptiblePowerLoad.jl
@@ -197,6 +197,10 @@ function from_openapi(po::PO.InterruptiblePowerLoad, refs::OpenAPIRefs, ::Natura
     )
 end
 
+function from_openapi(po::PO.InterruptiblePowerLoad, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("InterruptiblePowerLoad", po.id, po.power_units))
+end
+
 function to_openapi(value::InterruptiblePowerLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.InterruptiblePowerLoad(;
         id = component_id(refs, value),
@@ -210,6 +214,7 @@ function to_openapi(value::InterruptiblePowerLoad, refs::OpenAPIRefs, ::DeviceBa
         base_power = _get_base_power(value),
         operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
         conformity = string(get_conformity(value)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -226,5 +231,6 @@ function to_openapi(value::InterruptiblePowerLoad, refs::OpenAPIRefs, ::NaturalU
         base_power = _get_base_power(value),
         operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
         conformity = string(get_conformity(value)),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/InterruptibleStandardLoad.jl
+++ b/src/models/generated/InterruptibleStandardLoad.jl
@@ -319,6 +319,10 @@ function from_openapi(po::PO.InterruptibleStandardLoad, refs::OpenAPIRefs, ::Nat
     )
 end
 
+function from_openapi(po::PO.InterruptibleStandardLoad, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("InterruptibleStandardLoad", po.id, po.power_units))
+end
+
 function to_openapi(value::InterruptibleStandardLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.InterruptibleStandardLoad(;
         id = component_id(refs, value),
@@ -340,6 +344,7 @@ function to_openapi(value::InterruptibleStandardLoad, refs::OpenAPIRefs, ::Devic
         max_impedance_reactive_power = get_max_impedance_reactive_power(value, DU),
         max_current_active_power = get_max_current_active_power(value, DU),
         max_current_reactive_power = get_max_current_reactive_power(value, DU),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -364,5 +369,6 @@ function to_openapi(value::InterruptibleStandardLoad, refs::OpenAPIRefs, ::Natur
         max_impedance_reactive_power = get_max_impedance_reactive_power(value, DU) * _get_base_power(value),
         max_current_active_power = get_max_current_active_power(value, DU) * _get_base_power(value),
         max_current_reactive_power = get_max_current_reactive_power(value, DU) * _get_base_power(value),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/MotorLoad.jl
+++ b/src/models/generated/MotorLoad.jl
@@ -201,6 +201,10 @@ function from_openapi(po::PO.MotorLoad, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.MotorLoad, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("MotorLoad", po.id, po.power_units))
+end
+
 function to_openapi(value::MotorLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.MotorLoad(;
         id = component_id(refs, value),
@@ -214,6 +218,7 @@ function to_openapi(value::MotorLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
         max_active_power = get_max_active_power(value, DU),
         reactive_power_limits = _minmax_po_optional(get_reactive_power_limits(value, DU)),
         motor_technology = string(get_motor_technology(value)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -230,5 +235,6 @@ function to_openapi(value::MotorLoad, refs::OpenAPIRefs, ::NaturalUnit)
         max_active_power = get_max_active_power(value, DU) * _get_base_power(value),
         reactive_power_limits = _minmax_po_scaled_optional(get_reactive_power_limits(value, DU), _get_base_power(value)),
         motor_technology = string(get_motor_technology(value)),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/PointToPointBid.jl
+++ b/src/models/generated/PointToPointBid.jl
@@ -1,0 +1,172 @@
+#=
+This file is auto-generated. Do not edit.
+=#
+
+#! format: off
+
+"""
+    mutable struct PointToPointBid <: MarketTransaction
+        name::String
+        available::Bool
+        from::Component
+        to::Component
+        max_active_power::Float64
+        price_limits::MinMax
+        spread_bid::Union{MarketBidCost, MarketBidTimeSeriesCost}
+        linked_crr::Union{Nothing, String}
+        ext::Dict{String, Any}
+        internal::InfrastructureSystemsInternal
+    end
+
+A priced point-to-point spread bid (e.g. an up-to-congestion or PTP obligation bid): a willingness-to-pay curve on the price spread between two locations. Clears as a withdrawal at `from` and an injection at `to`. Terminals are validated to be a Topology or a TradingHub. All MW values are natural units.
+
+# Arguments
+- `name::String`: Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name
+- `available::Bool`: Indicator of whether the component is available for market clearing (`true`) or not (`false`)
+- `from::Component`: Source terminal (withdrawal side): a Topology or a TradingHub
+- `to::Component`: Sink terminal (injection side): a Topology or a TradingHub; must differ from `from`
+- `max_active_power::Float64`: MW envelope for the bid (MW), validation range: `(0.0, nothing)`
+- `price_limits::MinMax`: Tariff bid-price bounds on the spread (\$/MWh)
+- `spread_bid::Union{MarketBidCost, MarketBidTimeSeriesCost}`: (default: `MarketBidCost(nothing)`) Willingness-to-pay curve on the to-minus-from price spread, as an offer-curve operating cost (incremental side only)
+- `linked_crr::Union{Nothing, String}`: (default: `nothing`) Identifier of a linked congestion-right instrument, when the market couples the bid to one
+- `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
+- `internal::InfrastructureSystemsInternal`: (**Do not modify.**) PowerSystems.jl internal reference
+"""
+mutable struct PointToPointBid <: MarketTransaction
+    "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name"
+    name::String
+    "Indicator of whether the component is available for market clearing (`true`) or not (`false`)"
+    available::Bool
+    "Source terminal (withdrawal side): a Topology or a TradingHub"
+    from::Component
+    "Sink terminal (injection side): a Topology or a TradingHub; must differ from `from`"
+    to::Component
+    "MW envelope for the bid (MW)"
+    max_active_power::Float64
+    "Tariff bid-price bounds on the spread (\$/MWh)"
+    price_limits::MinMax
+    "Willingness-to-pay curve on the to-minus-from price spread, as an offer-curve operating cost (incremental side only)"
+    spread_bid::Union{MarketBidCost, MarketBidTimeSeriesCost}
+    "Identifier of a linked congestion-right instrument, when the market couples the bid to one"
+    linked_crr::Union{Nothing, String}
+    "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation."
+    ext::Dict{String, Any}
+    "(**Do not modify.**) PowerSystems.jl internal reference"
+    internal::InfrastructureSystemsInternal
+end
+
+function PointToPointBid(name, available, from, to, max_active_power, price_limits, spread_bid=MarketBidCost(nothing), linked_crr=nothing, ext=Dict{String, Any}(), )
+    PointToPointBid(name, available, from, to, max_active_power, price_limits, spread_bid, linked_crr, ext, InfrastructureSystemsInternal(), )
+end
+
+function PointToPointBid(; name, available, from, to, max_active_power, price_limits, spread_bid=MarketBidCost(nothing), linked_crr=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    PointToPointBid(name, available, from, to, max_active_power, price_limits, spread_bid, linked_crr, ext, internal, )
+end
+
+# Constructor for demo purposes; non-functional.
+function PointToPointBid(::Nothing)
+    PointToPointBid(;
+        name="init",
+        available=false,
+        from=ACBus(nothing),
+        to=ACBus(nothing),
+        max_active_power=0.0,
+        price_limits=(min=0.0, max=0.0),
+        spread_bid=MarketBidCost(nothing),
+        linked_crr=nothing,
+        ext=Dict{String, Any}(),
+    )
+end
+
+"""Get [`PointToPointBid`](@ref) `name`."""
+get_name(value::PointToPointBid) = value.name
+"""Get [`PointToPointBid`](@ref) `available`."""
+get_available(value::PointToPointBid) = value.available
+"""Get [`PointToPointBid`](@ref) `from`."""
+get_from(value::PointToPointBid) = value.from
+"""Get [`PointToPointBid`](@ref) `to`."""
+get_to(value::PointToPointBid) = value.to
+"""Get [`PointToPointBid`](@ref) `max_active_power`."""
+get_max_active_power(value::PointToPointBid) = value.max_active_power
+"""Get [`PointToPointBid`](@ref) `price_limits`."""
+get_price_limits(value::PointToPointBid) = value.price_limits
+"""Get [`PointToPointBid`](@ref) `spread_bid`."""
+get_spread_bid(value::PointToPointBid) = value.spread_bid
+"""Get [`PointToPointBid`](@ref) `linked_crr`."""
+get_linked_crr(value::PointToPointBid) = value.linked_crr
+"""Get [`PointToPointBid`](@ref) `ext`."""
+get_ext(value::PointToPointBid) = value.ext
+"""Get [`PointToPointBid`](@ref) `internal`."""
+get_internal(value::PointToPointBid) = value.internal
+
+"""Set [`PointToPointBid`](@ref) `available`."""
+set_available!(value::PointToPointBid, val) = value.available = val
+"""Set [`PointToPointBid`](@ref) `from`."""
+set_from!(value::PointToPointBid, val) = value.from = val
+"""Set [`PointToPointBid`](@ref) `to`."""
+set_to!(value::PointToPointBid, val) = value.to = val
+"""Set [`PointToPointBid`](@ref) `max_active_power`."""
+set_max_active_power!(value::PointToPointBid, val) = value.max_active_power = val
+"""Set [`PointToPointBid`](@ref) `price_limits`."""
+set_price_limits!(value::PointToPointBid, val) = value.price_limits = val
+"""Set [`PointToPointBid`](@ref) `spread_bid`."""
+set_spread_bid!(value::PointToPointBid, val) = value.spread_bid = val
+"""Set [`PointToPointBid`](@ref) `linked_crr`."""
+set_linked_crr!(value::PointToPointBid, val) = value.linked_crr = val
+"""Set [`PointToPointBid`](@ref) `ext`."""
+set_ext!(value::PointToPointBid, val) = value.ext = val
+
+
+function from_openapi(po::PO.PointToPointBid, refs::OpenAPIRefs, ::DeviceBaseUnit)
+    return PointToPointBid(;
+        name = po.name,
+        available = po.available,
+        from = resolve_ref(refs, po.from_id, Component),
+        to = resolve_ref(refs, po.to_id, Component),
+        max_active_power = po.max_active_power,
+        price_limits = _minmax_from_po(po.price_limits),
+        spread_bid = convert_cost(po.spread_bid)::Union{MarketBidCost, MarketBidTimeSeriesCost},
+        linked_crr = po.linked_crr,
+    )
+end
+
+function from_openapi(po::PO.PointToPointBid, refs::OpenAPIRefs, ::NaturalUnit)
+    return PointToPointBid(;
+        name = po.name,
+        available = po.available,
+        from = resolve_ref(refs, po.from_id, Component),
+        to = resolve_ref(refs, po.to_id, Component),
+        max_active_power = po.max_active_power,
+        price_limits = _minmax_from_po(po.price_limits),
+        spread_bid = convert_cost(po.spread_bid)::Union{MarketBidCost, MarketBidTimeSeriesCost},
+        linked_crr = po.linked_crr,
+    )
+end
+
+function to_openapi(value::PointToPointBid, refs::OpenAPIRefs, ::DeviceBaseUnit)
+    return PO.PointToPointBid(;
+        id = component_id(refs, value),
+        name = get_name(value),
+        available = get_available(value),
+        from_id = component_id(refs, get_from(value)),
+        to_id = component_id(refs, get_to(value)),
+        max_active_power = get_max_active_power(value),
+        price_limits = _minmax_po(get_price_limits(value)),
+        spread_bid = convert_cost_to_openapi(get_spread_bid(value)),
+        linked_crr = get_linked_crr(value),
+    )
+end
+
+function to_openapi(value::PointToPointBid, refs::OpenAPIRefs, ::NaturalUnit)
+    return PO.PointToPointBid(;
+        id = component_id(refs, value),
+        name = get_name(value),
+        available = get_available(value),
+        from_id = component_id(refs, get_from(value)),
+        to_id = component_id(refs, get_to(value)),
+        max_active_power = get_max_active_power(value),
+        price_limits = _minmax_po(get_price_limits(value)),
+        spread_bid = convert_cost_to_openapi(get_spread_bid(value)),
+        linked_crr = get_linked_crr(value),
+    )
+end

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -186,6 +186,10 @@ function from_openapi(po::PO.PowerLoad, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.PowerLoad, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("PowerLoad", po.id, po.power_units))
+end
+
 function to_openapi(value::PowerLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.PowerLoad(;
         id = component_id(refs, value),
@@ -198,6 +202,7 @@ function to_openapi(value::PowerLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
         max_active_power = get_max_active_power(value, DU),
         max_reactive_power = get_max_reactive_power(value, DU),
         conformity = string(get_conformity(value)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -213,5 +218,6 @@ function to_openapi(value::PowerLoad, refs::OpenAPIRefs, ::NaturalUnit)
         max_active_power = get_max_active_power(value, DU) * _get_base_power(value),
         max_reactive_power = get_max_reactive_power(value, DU) * _get_base_power(value),
         conformity = string(get_conformity(value)),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/RenewableDispatch.jl
+++ b/src/models/generated/RenewableDispatch.jl
@@ -210,6 +210,10 @@ function from_openapi(po::PO.RenewableDispatch, refs::OpenAPIRefs, ::NaturalUnit
     )
 end
 
+function from_openapi(po::PO.RenewableDispatch, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("RenewableDispatch", po.id, po.power_units))
+end
+
 function to_openapi(value::RenewableDispatch, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.RenewableDispatch(;
         id = component_id(refs, value),
@@ -224,6 +228,7 @@ function to_openapi(value::RenewableDispatch, refs::OpenAPIRefs, ::DeviceBaseUni
         power_factor = get_power_factor(value),
         operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
         base_power = _get_base_power(value),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -241,5 +246,6 @@ function to_openapi(value::RenewableDispatch, refs::OpenAPIRefs, ::NaturalUnit)
         power_factor = get_power_factor(value),
         operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
         base_power = _get_base_power(value),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/RenewableNonDispatch.jl
+++ b/src/models/generated/RenewableNonDispatch.jl
@@ -184,6 +184,10 @@ function from_openapi(po::PO.RenewableNonDispatch, refs::OpenAPIRefs, ::NaturalU
     )
 end
 
+function from_openapi(po::PO.RenewableNonDispatch, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("RenewableNonDispatch", po.id, po.power_units))
+end
+
 function to_openapi(value::RenewableNonDispatch, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.RenewableNonDispatch(;
         id = component_id(refs, value),
@@ -196,6 +200,7 @@ function to_openapi(value::RenewableNonDispatch, refs::OpenAPIRefs, ::DeviceBase
         prime_mover_type = string(get_prime_mover_type(value)),
         power_factor = get_power_factor(value),
         base_power = _get_base_power(value),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -211,5 +216,6 @@ function to_openapi(value::RenewableNonDispatch, refs::OpenAPIRefs, ::NaturalUni
         prime_mover_type = string(get_prime_mover_type(value)),
         power_factor = get_power_factor(value),
         base_power = _get_base_power(value),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/ShiftablePowerLoad.jl
+++ b/src/models/generated/ShiftablePowerLoad.jl
@@ -212,6 +212,10 @@ function from_openapi(po::PO.ShiftablePowerLoad, refs::OpenAPIRefs, ::NaturalUni
     )
 end
 
+function from_openapi(po::PO.ShiftablePowerLoad, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("ShiftablePowerLoad", po.id, po.power_units))
+end
+
 function to_openapi(value::ShiftablePowerLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.ShiftablePowerLoad(;
         id = component_id(refs, value),
@@ -226,6 +230,7 @@ function to_openapi(value::ShiftablePowerLoad, refs::OpenAPIRefs, ::DeviceBaseUn
         base_power = _get_base_power(value),
         load_balance_time_horizon = get_load_balance_time_horizon(value),
         operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -243,5 +248,6 @@ function to_openapi(value::ShiftablePowerLoad, refs::OpenAPIRefs, ::NaturalUnit)
         base_power = _get_base_power(value),
         load_balance_time_horizon = get_load_balance_time_horizon(value),
         operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/StandardLoad.jl
+++ b/src/models/generated/StandardLoad.jl
@@ -308,6 +308,10 @@ function from_openapi(po::PO.StandardLoad, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.StandardLoad, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("StandardLoad", po.id, po.power_units))
+end
+
 function to_openapi(value::StandardLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.StandardLoad(;
         id = component_id(refs, value),
@@ -328,6 +332,7 @@ function to_openapi(value::StandardLoad, refs::OpenAPIRefs, ::DeviceBaseUnit)
         max_current_active_power = get_max_current_active_power(value, DU),
         max_current_reactive_power = get_max_current_reactive_power(value, DU),
         conformity = string(get_conformity(value)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -351,5 +356,6 @@ function to_openapi(value::StandardLoad, refs::OpenAPIRefs, ::NaturalUnit)
         max_current_active_power = get_max_current_active_power(value, DU) * _get_base_power(value),
         max_current_reactive_power = get_max_current_reactive_power(value, DU) * _get_base_power(value),
         conformity = string(get_conformity(value)),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/SynchronousCondenser.jl
+++ b/src/models/generated/SynchronousCondenser.jl
@@ -173,6 +173,10 @@ function from_openapi(po::PO.SynchronousCondenser, refs::OpenAPIRefs, ::NaturalU
     )
 end
 
+function from_openapi(po::PO.SynchronousCondenser, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("SynchronousCondenser", po.id, po.power_units))
+end
+
 function to_openapi(value::SynchronousCondenser, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.SynchronousCondenser(;
         id = component_id(refs, value),
@@ -184,6 +188,7 @@ function to_openapi(value::SynchronousCondenser, refs::OpenAPIRefs, ::DeviceBase
         reactive_power_limits = _minmax_po_optional(get_reactive_power_limits(value, DU)),
         base_power = _get_base_power(value),
         active_power_losses = get_active_power_losses(value, DU),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -198,5 +203,6 @@ function to_openapi(value::SynchronousCondenser, refs::OpenAPIRefs, ::NaturalUni
         reactive_power_limits = _minmax_po_scaled_optional(get_reactive_power_limits(value, DU), _get_base_power(value)),
         base_power = _get_base_power(value),
         active_power_losses = get_active_power_losses(value, DU) * _get_base_power(value),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/ThermalMultiStart.jl
+++ b/src/models/generated/ThermalMultiStart.jl
@@ -318,6 +318,10 @@ function from_openapi(po::PO.ThermalMultiStart, refs::OpenAPIRefs, ::NaturalUnit
     )
 end
 
+function from_openapi(po::PO.ThermalMultiStart, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("ThermalMultiStart", po.id, po.power_units))
+end
+
 function to_openapi(value::ThermalMultiStart, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.ThermalMultiStart(;
         id = component_id(refs, value),
@@ -341,6 +345,7 @@ function to_openapi(value::ThermalMultiStart, refs::OpenAPIRefs, ::DeviceBaseUni
         base_power = _get_base_power(value),
         time_at_status = get_time_at_status(value),
         must_run = get_must_run(value),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -367,5 +372,6 @@ function to_openapi(value::ThermalMultiStart, refs::OpenAPIRefs, ::NaturalUnit)
         base_power = _get_base_power(value),
         time_at_status = get_time_at_status(value),
         must_run = get_must_run(value),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/ThermalStandard.jl
+++ b/src/models/generated/ThermalStandard.jl
@@ -282,6 +282,10 @@ function from_openapi(po::PO.ThermalStandard, refs::OpenAPIRefs, ::NaturalUnit)
     )
 end
 
+function from_openapi(po::PO.ThermalStandard, refs::OpenAPIRefs)
+    return from_openapi(po, refs, _power_units_marker("ThermalStandard", po.id, po.power_units))
+end
+
 function to_openapi(value::ThermalStandard, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.ThermalStandard(;
         id = component_id(refs, value),
@@ -302,6 +306,7 @@ function to_openapi(value::ThermalStandard, refs::OpenAPIRefs, ::DeviceBaseUnit)
         prime_mover_type = string(get_prime_mover_type(value)),
         fuel = string(get_fuel(value)),
         time_at_status = get_time_at_status(value),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -325,5 +330,6 @@ function to_openapi(value::ThermalStandard, refs::OpenAPIRefs, ::NaturalUnit)
         prime_mover_type = string(get_prime_mover_type(value)),
         fuel = string(get_fuel(value)),
         time_at_status = get_time_at_status(value),
+        power_units = _power_units_string(NU),
     )
 end

--- a/src/models/generated/TradingHub.jl
+++ b/src/models/generated/TradingHub.jl
@@ -1,0 +1,90 @@
+#=
+This file is auto-generated. Do not edit.
+=#
+
+#! format: off
+
+"""
+    mutable struct TradingHub <: MarketComponent
+        name::String
+        buses::Vector{ACBus}
+        ext::Dict{String, Any}
+        internal::InfrastructureSystemsInternal
+    end
+
+A market trading hub: a named set of member buses at which hub-settled bids are priced. Member buses are unweighted.
+
+# Arguments
+- `name::String`: Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name
+- `buses::Vector{ACBus}`: (default: `ACBus[]`) Member buses of the hub
+- `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
+- `internal::InfrastructureSystemsInternal`: (**Do not modify.**) PowerSystems.jl internal reference
+"""
+mutable struct TradingHub <: MarketComponent
+    "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name"
+    name::String
+    "Member buses of the hub"
+    buses::Vector{ACBus}
+    "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation."
+    ext::Dict{String, Any}
+    "(**Do not modify.**) PowerSystems.jl internal reference"
+    internal::InfrastructureSystemsInternal
+end
+
+function TradingHub(name, buses=ACBus[], ext=Dict{String, Any}(), )
+    TradingHub(name, buses, ext, InfrastructureSystemsInternal(), )
+end
+
+function TradingHub(; name, buses=ACBus[], ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    TradingHub(name, buses, ext, internal, )
+end
+
+# Constructor for demo purposes; non-functional.
+function TradingHub(::Nothing)
+    TradingHub(;
+        name="init",
+        buses=ACBus[],
+        ext=Dict{String, Any}(),
+    )
+end
+
+"""Get [`TradingHub`](@ref) `name`."""
+get_name(value::TradingHub) = value.name
+"""Get [`TradingHub`](@ref) `buses`."""
+get_buses(value::TradingHub) = value.buses
+"""Get [`TradingHub`](@ref) `ext`."""
+get_ext(value::TradingHub) = value.ext
+"""Get [`TradingHub`](@ref) `internal`."""
+get_internal(value::TradingHub) = value.internal
+
+"""Set [`TradingHub`](@ref) `buses`."""
+set_buses!(value::TradingHub, val) = value.buses = val
+"""Set [`TradingHub`](@ref) `ext`."""
+set_ext!(value::TradingHub, val) = value.ext = val
+
+
+function from_openapi(po::PO.TradingHub, refs::OpenAPIRefs, ::DeviceBaseUnit)
+    return TradingHub(;
+        name = po.name,
+    )
+end
+
+function from_openapi(po::PO.TradingHub, refs::OpenAPIRefs, ::NaturalUnit)
+    return TradingHub(;
+        name = po.name,
+    )
+end
+
+function to_openapi(value::TradingHub, refs::OpenAPIRefs, ::DeviceBaseUnit)
+    return PO.TradingHub(;
+        id = component_id(refs, value),
+        name = get_name(value),
+    )
+end
+
+function to_openapi(value::TradingHub, refs::OpenAPIRefs, ::NaturalUnit)
+    return PO.TradingHub(;
+        id = component_id(refs, value),
+        name = get_name(value),
+    )
+end

--- a/src/models/generated/VirtualParticipant.jl
+++ b/src/models/generated/VirtualParticipant.jl
@@ -1,0 +1,155 @@
+#=
+This file is auto-generated. Do not edit.
+=#
+
+#! format: off
+
+"""
+    mutable struct VirtualParticipant <: MarketTransaction
+        name::String
+        available::Bool
+        max_supply::Float64
+        max_demand::Float64
+        settlement_point::Union{Nothing, Topology}
+        trading_hubs::Vector{TradingHub}
+        operation_cost::Union{MarketBidCost, MarketBidTimeSeriesCost}
+        ext::Dict{String, Any}
+        internal::InfrastructureSystemsInternal
+    end
+
+A virtual (convergence) market participant. Supply offers map to the operating cost's incremental_offer_curves; demand bids to decremental_offer_curves. Settles either at a settlement point or at associated trading hubs (per-hub bids attach as hub-named time series). All MW values are natural units.
+
+# Arguments
+- `name::String`: Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name
+- `available::Bool`: Indicator of whether the component is available for market clearing (`true`) or not (`false`)
+- `max_supply::Float64`: MW envelope for the incremental (supply) side (MW), validation range: `(0.0, nothing)`
+- `max_demand::Float64`: MW envelope for the decremental (demand) side (MW), validation range: `(0.0, nothing)`
+- `settlement_point::Union{Nothing, Topology}`: (default: `nothing`) Settlement location (a bus, area, or load zone); `nothing` when the participant settles at trading hubs instead
+- `trading_hubs::Vector{TradingHub}`: (default: `TradingHub[]`) Trading hubs this participant settles at; mutually exclusive with `settlement_point`
+- `operation_cost::Union{MarketBidCost, MarketBidTimeSeriesCost}`: (default: `MarketBidCost(nothing)`) Bid curves as an offer-curve operating cost
+- `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
+- `internal::InfrastructureSystemsInternal`: (**Do not modify.**) PowerSystems.jl internal reference
+"""
+mutable struct VirtualParticipant <: MarketTransaction
+    "Name of the component. Components of the same type (e.g., `PowerLoad`) must have unique names, but components of different types (e.g., `PowerLoad` and `ACBus`) can have the same name"
+    name::String
+    "Indicator of whether the component is available for market clearing (`true`) or not (`false`)"
+    available::Bool
+    "MW envelope for the incremental (supply) side (MW)"
+    max_supply::Float64
+    "MW envelope for the decremental (demand) side (MW)"
+    max_demand::Float64
+    "Settlement location (a bus, area, or load zone); `nothing` when the participant settles at trading hubs instead"
+    settlement_point::Union{Nothing, Topology}
+    "Trading hubs this participant settles at; mutually exclusive with `settlement_point`"
+    trading_hubs::Vector{TradingHub}
+    "Bid curves as an offer-curve operating cost"
+    operation_cost::Union{MarketBidCost, MarketBidTimeSeriesCost}
+    "An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation."
+    ext::Dict{String, Any}
+    "(**Do not modify.**) PowerSystems.jl internal reference"
+    internal::InfrastructureSystemsInternal
+end
+
+function VirtualParticipant(name, available, max_supply, max_demand, settlement_point=nothing, trading_hubs=TradingHub[], operation_cost=MarketBidCost(nothing), ext=Dict{String, Any}(), )
+    VirtualParticipant(name, available, max_supply, max_demand, settlement_point, trading_hubs, operation_cost, ext, InfrastructureSystemsInternal(), )
+end
+
+function VirtualParticipant(; name, available, max_supply, max_demand, settlement_point=nothing, trading_hubs=TradingHub[], operation_cost=MarketBidCost(nothing), ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    VirtualParticipant(name, available, max_supply, max_demand, settlement_point, trading_hubs, operation_cost, ext, internal, )
+end
+
+# Constructor for demo purposes; non-functional.
+function VirtualParticipant(::Nothing)
+    VirtualParticipant(;
+        name="init",
+        available=false,
+        max_supply=0.0,
+        max_demand=0.0,
+        settlement_point=nothing,
+        trading_hubs=TradingHub[],
+        operation_cost=MarketBidCost(nothing),
+        ext=Dict{String, Any}(),
+    )
+end
+
+"""Get [`VirtualParticipant`](@ref) `name`."""
+get_name(value::VirtualParticipant) = value.name
+"""Get [`VirtualParticipant`](@ref) `available`."""
+get_available(value::VirtualParticipant) = value.available
+"""Get [`VirtualParticipant`](@ref) `max_supply`."""
+get_max_supply(value::VirtualParticipant) = value.max_supply
+"""Get [`VirtualParticipant`](@ref) `max_demand`."""
+get_max_demand(value::VirtualParticipant) = value.max_demand
+"""Get [`VirtualParticipant`](@ref) `settlement_point`."""
+get_settlement_point(value::VirtualParticipant) = value.settlement_point
+"""Get [`VirtualParticipant`](@ref) `trading_hubs`."""
+get_trading_hubs(value::VirtualParticipant) = value.trading_hubs
+"""Get [`VirtualParticipant`](@ref) `operation_cost`."""
+get_operation_cost(value::VirtualParticipant) = value.operation_cost
+"""Get [`VirtualParticipant`](@ref) `ext`."""
+get_ext(value::VirtualParticipant) = value.ext
+"""Get [`VirtualParticipant`](@ref) `internal`."""
+get_internal(value::VirtualParticipant) = value.internal
+
+"""Set [`VirtualParticipant`](@ref) `available`."""
+set_available!(value::VirtualParticipant, val) = value.available = val
+"""Set [`VirtualParticipant`](@ref) `max_supply`."""
+set_max_supply!(value::VirtualParticipant, val) = value.max_supply = val
+"""Set [`VirtualParticipant`](@ref) `max_demand`."""
+set_max_demand!(value::VirtualParticipant, val) = value.max_demand = val
+"""Set [`VirtualParticipant`](@ref) `settlement_point`."""
+set_settlement_point!(value::VirtualParticipant, val) = value.settlement_point = val
+"""Set [`VirtualParticipant`](@ref) `trading_hubs`."""
+set_trading_hubs!(value::VirtualParticipant, val) = value.trading_hubs = val
+"""Set [`VirtualParticipant`](@ref) `operation_cost`."""
+set_operation_cost!(value::VirtualParticipant, val) = value.operation_cost = val
+"""Set [`VirtualParticipant`](@ref) `ext`."""
+set_ext!(value::VirtualParticipant, val) = value.ext = val
+
+
+function from_openapi(po::PO.VirtualParticipant, refs::OpenAPIRefs, ::DeviceBaseUnit)
+    return VirtualParticipant(;
+        name = po.name,
+        available = po.available,
+        max_supply = po.max_supply,
+        max_demand = po.max_demand,
+        settlement_point = resolve_ref(refs, po.settlement_point_id, Topology),
+        operation_cost = convert_cost(po.operation_cost)::Union{MarketBidCost, MarketBidTimeSeriesCost},
+    )
+end
+
+function from_openapi(po::PO.VirtualParticipant, refs::OpenAPIRefs, ::NaturalUnit)
+    return VirtualParticipant(;
+        name = po.name,
+        available = po.available,
+        max_supply = po.max_supply,
+        max_demand = po.max_demand,
+        settlement_point = resolve_ref(refs, po.settlement_point_id, Topology),
+        operation_cost = convert_cost(po.operation_cost)::Union{MarketBidCost, MarketBidTimeSeriesCost},
+    )
+end
+
+function to_openapi(value::VirtualParticipant, refs::OpenAPIRefs, ::DeviceBaseUnit)
+    return PO.VirtualParticipant(;
+        id = component_id(refs, value),
+        name = get_name(value),
+        available = get_available(value),
+        max_supply = get_max_supply(value),
+        max_demand = get_max_demand(value),
+        settlement_point_id = _component_id_optional(refs, get_settlement_point(value)),
+        operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
+    )
+end
+
+function to_openapi(value::VirtualParticipant, refs::OpenAPIRefs, ::NaturalUnit)
+    return PO.VirtualParticipant(;
+        id = component_id(refs, value),
+        name = get_name(value),
+        available = get_available(value),
+        max_supply = get_max_supply(value),
+        max_demand = get_max_demand(value),
+        settlement_point_id = _component_id_optional(refs, get_settlement_point(value)),
+        operation_cost = convert_cost_to_openapi(get_operation_cost(value)),
+    )
+end

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -131,6 +131,9 @@ include("AggregateDistributedGenerationA.jl")
 include("Source.jl")
 include("PeriodicVariableSource.jl")
 include("GenericDER.jl")
+include("TradingHub.jl")
+include("VirtualParticipant.jl")
+include("PointToPointBid.jl")
 
 export get_A
 export get_A1
@@ -520,6 +523,7 @@ export get_branch_id_control
 export get_branch_status
 export get_bus
 export get_bus_control
+export get_buses
 export get_bustype
 export get_c
 export get_c_dc
@@ -659,6 +663,7 @@ export get_level_data_type
 export get_level_targets
 export get_lf
 export get_lg
+export get_linked_crr
 export get_load_balance_time_horizon
 export get_load_response
 export get_load_zone
@@ -682,6 +687,7 @@ export get_max_dc_current
 export get_max_dc_current_from
 export get_max_dc_current_to
 export get_max_dc_current_unitful
+export get_max_demand
 export get_max_flow
 export get_max_flow_unitful
 export get_max_impedance_active_power
@@ -692,6 +698,7 @@ export get_max_reactive_power
 export get_max_reactive_power_unitful
 export get_max_shunt_current
 export get_max_shunt_current_unitful
+export get_max_supply
 export get_min_compounding_voltage
 export get_minimum_time
 export get_motor_technology
@@ -720,6 +727,7 @@ export get_power_mode
 export get_power_trajectory
 export get_power_trajectory_unitful
 export get_powerhouse_elevation
+export get_price_limits
 export get_primary_circuit
 export get_prime_mover_type
 export get_q_nl
@@ -797,10 +805,12 @@ export get_scheduled_dc_voltage
 export get_secondary_circuit
 export get_self_discharge
 export get_services
+export get_settlement_point
 export get_shunt_control_type
 export get_shunt_location
 export get_speed_error_signal
 export get_spillage_limits
+export get_spread_bid
 export get_standing_loss
 export get_standing_loss_unitful
 export get_star_bus
@@ -829,6 +839,7 @@ export get_time_limits
 export get_to
 export get_to_area
 export get_to_branch_control
+export get_trading_hubs
 export get_transfer_setpoint
 export get_transition_time
 export get_travel_time
@@ -1251,6 +1262,7 @@ export set_branch_id_control!
 export set_branch_status!
 export set_bus!
 export set_bus_control!
+export set_buses!
 export set_bustype!
 export set_c!
 export set_c_dc!
@@ -1379,6 +1391,7 @@ export set_level_data_type!
 export set_level_targets!
 export set_lf!
 export set_lg!
+export set_linked_crr!
 export set_load_balance_time_horizon!
 export set_load_response!
 export set_load_zone!
@@ -1395,11 +1408,13 @@ export set_max_current_reactive_power!
 export set_max_dc_current!
 export set_max_dc_current_from!
 export set_max_dc_current_to!
+export set_max_demand!
 export set_max_flow!
 export set_max_impedance_active_power!
 export set_max_impedance_reactive_power!
 export set_max_reactive_power!
 export set_max_shunt_current!
+export set_max_supply!
 export set_min_compounding_voltage!
 export set_minimum_time!
 export set_motor_technology!
@@ -1424,6 +1439,7 @@ export set_power_gate_openings!
 export set_power_mode!
 export set_power_trajectory!
 export set_powerhouse_elevation!
+export set_price_limits!
 export set_primary_circuit!
 export set_prime_mover_type!
 export set_q_nl!
@@ -1484,10 +1500,12 @@ export set_scheduled_dc_voltage!
 export set_secondary_circuit!
 export set_self_discharge!
 export set_services!
+export set_settlement_point!
 export set_shunt_control_type!
 export set_shunt_location!
 export set_speed_error_signal!
 export set_spillage_limits!
+export set_spread_bid!
 export set_standing_loss!
 export set_star_bus!
 export set_start_time_limits!
@@ -1514,6 +1532,7 @@ export set_time_limits!
 export set_to!
 export set_to_area!
 export set_to_branch_control!
+export set_trading_hubs!
 export set_transfer_setpoint!
 export set_transition_time!
 export set_travel_time!

--- a/src/models/market_components.jl
+++ b/src/models/market_components.jl
@@ -1,0 +1,13 @@
+"""
+Supertype of market constructs: instruments whose cleared award enters the network balance of at
+least one clearing stage, and the hubs they settle at. Peers of `Device`, `Service`, `Topology`.
+"""
+abstract type MarketComponent <: Component end
+
+"""
+Supertype of market instruments (virtual bids, point-to-point spread bids). Bilateral trades are
+settlement-ledger records in the schemas layer, not components.
+"""
+abstract type MarketTransaction <: MarketComponent end
+
+supports_time_series(::MarketComponent) = true

--- a/src/models/point_to_point_bid.jl
+++ b/src/models/point_to_point_bid.jl
@@ -1,0 +1,13 @@
+"""
+Throws ArgumentError unless the terminal is a Topology or a TradingHub.
+"""
+_check_ptp_terminal(::Topology) = nothing
+_check_ptp_terminal(::TradingHub) = nothing
+
+function _check_ptp_terminal(c::Component)
+    throw(
+        ArgumentError(
+            "PointToPointBid terminals must be a Topology or a TradingHub; got $(typeof(c)) $(get_name(c))",
+        ),
+    )
+end

--- a/src/models/serialization.jl
+++ b/src/models/serialization.jl
@@ -3,13 +3,17 @@ const _ENCODE_AS_ID = (
     Area,
     Bus,
     LoadZone,
+    Topology,
     DynamicInjection,
     StaticInjection,
     HydroReservoir,
+    Component,
     Vector{Service},
     Vector{Reserve},
     Vector{HydroUnit},
     Vector{Device},
+    Vector{ACBus},
+    Vector{TradingHub},
 )
 
 should_encode_as_id(val) = any(x -> val isa x, _ENCODE_AS_ID)

--- a/src/models/trading_hub.jl
+++ b/src/models/trading_hub.jl
@@ -1,0 +1,31 @@
+"""Return the member buses of `hub`."""
+function get_associated_buses(hub::TradingHub)
+    return get_buses(hub)
+end
+
+"""
+Return true if `bus` is a member of `hub`.
+"""
+function has_hub_bus(hub::TradingHub, bus::ACBus)
+    for _bus in get_associated_buses(hub)
+        if IS.get_id(_bus) == IS.get_id(bus)
+            return true
+        end
+    end
+    return false
+end
+
+"""
+Add `bus` to `hub`'s member buses without checking that both are attached to the same system.
+"""
+function add_hub_bus_internal!(hub::TradingHub, bus::ACBus)
+    if has_hub_bus(hub, bus)
+        throw(
+            ArgumentError(
+                "bus $(get_name(bus)) is already associated with $(get_name(hub))",
+            ),
+        )
+    end
+    push!(get_buses(hub), bus)
+    return nothing
+end

--- a/src/models/virtual_participant.jl
+++ b/src/models/virtual_participant.jl
@@ -1,0 +1,62 @@
+"""
+Add `hub` to `vp` without checking that both are attached to the same system.
+"""
+function add_trading_hub_internal!(vp::VirtualParticipant, hub::TradingHub)
+    if has_trading_hub(vp, hub)
+        error("Hub $(get_name(hub)) is already associated with $(get_name(vp))")
+    end
+    push!(get_trading_hubs(vp), hub)
+    return nothing
+end
+
+"""
+Return true if `hub` is associated with `vp`.
+"""
+function has_trading_hub(vp::VirtualParticipant, hub::TradingHub)
+    for _hub in get_trading_hubs(vp)
+        if IS.get_id(_hub) == IS.get_id(hub)
+            return true
+        end
+    end
+    return false
+end
+
+"""
+Remove `hub` from `vp` if it is associated; return whether it was removed.
+"""
+function _remove_trading_hub!(vp::VirtualParticipant, hub::TradingHub)
+    removed = false
+    hubs = get_trading_hubs(vp)
+    for (i, _hub) in enumerate(hubs)
+        if IS.get_id(_hub) == IS.get_id(hub)
+            deleteat!(hubs, i)
+            removed = true
+            break
+        end
+    end
+    return removed
+end
+
+"""
+Remove `hub` from `vp`.
+
+Throws ArgumentError if the hub is not associated with `vp`.
+"""
+function remove_trading_hub!(vp::VirtualParticipant, hub::TradingHub)
+    if !_remove_trading_hub!(vp, hub)
+        throw(
+            ArgumentError(
+                "hub $(get_name(hub)) was not associated with $(get_name(vp))",
+            ),
+        )
+    end
+    return
+end
+
+"""
+Remove all trading hubs associated with `vp`.
+"""
+function clear_trading_hubs!(vp::VirtualParticipant)
+    empty!(get_trading_hubs(vp))
+    return
+end

--- a/src/openapi/cost_conversion.jl
+++ b/src/openapi/cost_conversion.jl
@@ -149,6 +149,21 @@ convert_cost(fd::PC.TimeSeriesPiecewiseStepData) = convert_cost(fd, _current_imp
 _resolve_optional_key(::Any, ::Nothing) = nothing
 _resolve_optional_key(store, id::Integer) = IS.get_time_series_key(store, id)
 
+"""Wire representation of [`CurveStyles`](@ref): a plain integer (0/1/2), deliberately not
+the string-enum convention used elsewhere in the schemas — see `curve_style` on
+`MarketBidCost`/`MarketBidTimeSeriesCost`."""
+function _curve_style_from_wire(id::Integer)
+    if id ∉ (0, 1, 2)
+        throw(
+            ArgumentError(
+                "convert_cost: curve_style $id is not a valid CurveStyles value; " *
+                "expected 0 (CURVE), 1 (FIXED), or 2 (VARIABLE)",
+            ),
+        )
+    end
+    return CurveStyles(Int(id))
+end
+
 convert_cost(vc::PC.TimeSeriesInputOutputCurve, store) =
     TimeSeriesInputOutputCurve(convert_cost(vc.function_data, store), vc.input_at_zero)
 convert_cost(vc::PC.TimeSeriesInputOutputCurve) = convert_cost(vc, _current_import_store())
@@ -322,8 +337,8 @@ objects only after every service is imported, so this conversion leaves the vect
 """
 function convert_cost(po::PC.MarketBidCost)
     return MarketBidCost(;
-        no_load_cost = convert_cost(
-            _require(po.no_load_cost, "MarketBidCost.no_load_cost"),
+        minimum_energy_offer = convert_cost(
+            _require(po.minimum_energy_offer, "MarketBidCost.minimum_energy_offer"),
         ),
         start_up = convert_cost(_require(po.start_up, "MarketBidCost.start_up")),
         shut_down = convert_cost(_require(po.shut_down, "MarketBidCost.shut_down")),
@@ -332,6 +347,17 @@ function convert_cost(po::PC.MarketBidCost)
         ),
         decremental_offer_curves = convert_cost(
             _require(po.decremental_offer_curves, "MarketBidCost.decremental_offer_curves"),
+        ),
+        incremental_slope = _require(
+            po.incremental_slope,
+            "MarketBidCost.incremental_slope",
+        ),
+        decremental_slope = _require(
+            po.decremental_slope,
+            "MarketBidCost.decremental_slope",
+        ),
+        curve_style = _curve_style_from_wire(
+            _require(po.curve_style, "MarketBidCost.curve_style"),
         ),
     )
 end
@@ -371,8 +397,11 @@ offer curves.
 """
 function convert_cost(po::PC.MarketBidTimeSeriesCost, store)
     return MarketBidTimeSeriesCost(;
-        no_load_cost = convert_cost(
-            _require(po.no_load_cost, "MarketBidTimeSeriesCost.no_load_cost"), store,
+        minimum_energy_offer = convert_cost(
+            _require(
+                po.minimum_energy_offer,
+                "MarketBidTimeSeriesCost.minimum_energy_offer",
+            ), store,
         ),
         start_up = IS.get_time_series_key(
             store,
@@ -399,6 +428,15 @@ function convert_cost(po::PC.MarketBidTimeSeriesCost, store)
                 "MarketBidTimeSeriesCost.decremental_offer_curves",
             ),
             store,
+        ),
+        incremental_slope = _require(
+            po.incremental_slope, "MarketBidTimeSeriesCost.incremental_slope",
+        ),
+        decremental_slope = _require(
+            po.decremental_slope, "MarketBidTimeSeriesCost.decremental_slope",
+        ),
+        curve_style = _curve_style_from_wire(
+            _require(po.curve_style, "MarketBidTimeSeriesCost.curve_style"),
         ),
     )
 end

--- a/src/openapi/cost_conversion.jl
+++ b/src/openapi/cost_conversion.jl
@@ -290,7 +290,12 @@ convert_cost(s::PC.StorageCostStartUpOneOf) = (charge = s.charge, discharge = s.
 
 function convert_cost(po::PC.ThermalGenerationCost)
     return ThermalGenerationCost(;
-        variable = convert_cost(_require(po.variable, "ThermalGenerationCost.variable")),
+        variable_operation_cost = convert_cost(
+            _require(
+                po.variable_operation_cost,
+                "ThermalGenerationCost.variable_operation_cost",
+            ),
+        ),
         fixed = po.fixed,
         start_up = convert_cost(_require(po.start_up, "ThermalGenerationCost.start_up")),
         shut_down = po.shut_down,
@@ -299,7 +304,12 @@ end
 
 function convert_cost(po::PC.RenewableGenerationCost)
     return RenewableGenerationCost(;
-        variable = convert_cost(_require(po.variable, "RenewableGenerationCost.variable")),
+        variable_operation_cost = convert_cost(
+            _require(
+                po.variable_operation_cost,
+                "RenewableGenerationCost.variable_operation_cost",
+            ),
+        ),
         curtailment_cost = _optional_cost_curve(po.curtailment_cost),
         fixed = po.fixed,
     )
@@ -307,14 +317,21 @@ end
 
 function convert_cost(po::PC.HydroGenerationCost)
     return HydroGenerationCost(;
-        variable = convert_cost(_require(po.variable, "HydroGenerationCost.variable")),
+        variable_operation_cost = convert_cost(
+            _require(
+                po.variable_operation_cost,
+                "HydroGenerationCost.variable_operation_cost",
+            ),
+        ),
         fixed = po.fixed,
     )
 end
 
 function convert_cost(po::PC.LoadCost)
     return LoadCost(;
-        variable = convert_cost(_require(po.variable, "LoadCost.variable")),
+        variable_operation_cost = convert_cost(
+            _require(po.variable_operation_cost, "LoadCost.variable_operation_cost"),
+        ),
         fixed = po.fixed,
     )
 end

--- a/src/openapi/cost_conversion.jl
+++ b/src/openapi/cost_conversion.jl
@@ -76,16 +76,16 @@ end
 
 # ── FunctionData ────────────────────────────────────────────────────────────────
 
-convert_cost(fd::PC.LinearFunctionData) =
+convert_cost(fd::IC.LinearFunctionData) =
     LinearFunctionData(fd.proportional_term, fd.constant_term)
-convert_cost(fd::PC.QuadraticFunctionData) =
+convert_cost(fd::IC.QuadraticFunctionData) =
     QuadraticFunctionData(fd.quadratic_term, fd.proportional_term, fd.constant_term)
 # `points` is generated as a bare `Vector`, so converting once restores inference for the loop.
-function convert_cost(fd::PC.PiecewiseLinearData)
-    points = convert(Vector{PC.XYCoords}, fd.points)
+function convert_cost(fd::IC.PiecewiseLinearData)
+    points = convert(Vector{IC.XYCoords}, fd.points)
     return PiecewiseLinearData([(x = p.x, y = p.y) for p in points])
 end
-convert_cost(fd::PC.PiecewiseStepData) = PiecewiseStepData(fd.x_coords, fd.y_coords)
+convert_cost(fd::IC.PiecewiseStepData) = PiecewiseStepData(fd.x_coords, fd.y_coords)
 # Catch-all for every PO type, not just FunctionData: a PO cost type with no converter
 # lands here, so the message must not claim to know what kind of variant it got.
 convert_cost(fd) = error("convert_cost: unmapped variant $(typeof(fd))")
@@ -122,32 +122,32 @@ wire type for the error a missing id raises."""
 _function_data_key(fd, store, what::AbstractString) =
     IS.get_time_series_key(store, _require(fd.association_id, "$what.association_id"))
 
-convert_cost(fd::PC.TimeSeriesLinearFunctionData, store) =
+convert_cost(fd::IC.TimeSeriesLinearFunctionData, store) =
     TimeSeriesFunctionData{LinearFunctionData}(
         _function_data_key(fd, store, "TimeSeriesLinearFunctionData"),
     )
-convert_cost(fd::PC.TimeSeriesLinearFunctionData) =
+convert_cost(fd::IC.TimeSeriesLinearFunctionData) =
     convert_cost(fd, _current_import_store())
 
-convert_cost(fd::PC.TimeSeriesQuadraticFunctionData, store) =
+convert_cost(fd::IC.TimeSeriesQuadraticFunctionData, store) =
     TimeSeriesFunctionData{QuadraticFunctionData}(
         _function_data_key(fd, store, "TimeSeriesQuadraticFunctionData"),
     )
-convert_cost(fd::PC.TimeSeriesQuadraticFunctionData) =
+convert_cost(fd::IC.TimeSeriesQuadraticFunctionData) =
     convert_cost(fd, _current_import_store())
 
-convert_cost(fd::PC.TimeSeriesPiecewiseLinearData, store) =
+convert_cost(fd::IC.TimeSeriesPiecewiseLinearData, store) =
     TimeSeriesFunctionData{PiecewiseLinearData}(
         _function_data_key(fd, store, "TimeSeriesPiecewiseLinearData"),
     )
-convert_cost(fd::PC.TimeSeriesPiecewiseLinearData) =
+convert_cost(fd::IC.TimeSeriesPiecewiseLinearData) =
     convert_cost(fd, _current_import_store())
 
-convert_cost(fd::PC.TimeSeriesPiecewiseStepData, store) =
+convert_cost(fd::IC.TimeSeriesPiecewiseStepData, store) =
     TimeSeriesFunctionData{PiecewiseStepData}(
         _function_data_key(fd, store, "TimeSeriesPiecewiseStepData"),
     )
-convert_cost(fd::PC.TimeSeriesPiecewiseStepData) = convert_cost(fd, _current_import_store())
+convert_cost(fd::IC.TimeSeriesPiecewiseStepData) = convert_cost(fd, _current_import_store())
 
 """`nothing` stays `nothing`; a wire association id resolves against `store`."""
 _resolve_optional_key(::Any, ::Nothing) = nothing

--- a/src/openapi/export_cost_conversion.jl
+++ b/src/openapi/export_cost_conversion.jl
@@ -141,6 +141,10 @@ _key_association_id(::Nothing) = nothing
 _key_association_id(key::IS.ConcreteTimeSeriesKey) =
     _record_emitted_association_id(IS.get_association_id(key))
 
+"""Wire representation of [`CurveStyles`](@ref): a plain integer (0/1/2) — see
+`cost_conversion.jl`'s `_curve_style_from_wire` for the import-direction counterpart."""
+_curve_style_to_wire(style::CurveStyles) = style.value
+
 function convert_cost_to_openapi(curve::TimeSeriesInputOutputCurve)
     return PC.TimeSeriesInputOutputCurve(;
         function_data = PC.FunctionData(convert_cost_to_openapi(get_function_data(curve))),
@@ -260,7 +264,7 @@ stores component ids, and this converter has no id registry, so it exports the l
 function convert_cost_to_openapi(cost::MarketBidCost)
     start_up = get_start_up(cost)
     return PC.MarketBidCost(;
-        no_load_cost = convert_cost_to_openapi(get_no_load_cost(cost)),
+        minimum_energy_offer = convert_cost_to_openapi(get_minimum_energy_offer(cost)),
         start_up = PC.StartUpStages(;
             hot = start_up.hot,
             warm = start_up.warm,
@@ -274,6 +278,9 @@ function convert_cost_to_openapi(cost::MarketBidCost)
             get_decremental_offer_curves(cost),
         ),
         ancillary_service_offers = Int64[],
+        incremental_slope = get_incremental_slope(cost),
+        decremental_slope = get_decremental_slope(cost),
+        curve_style = _curve_style_to_wire(get_curve_style(cost)),
     )
 end
 
@@ -334,7 +341,7 @@ function convert_cost_to_openapi(cost::MarketBidTimeSeriesCost)
         )
     end
     return PC.MarketBidTimeSeriesCost(;
-        no_load_cost = convert_cost_to_openapi(get_no_load_cost(cost)),
+        minimum_energy_offer = convert_cost_to_openapi(get_minimum_energy_offer(cost)),
         start_up_association_id = _key_association_id(get_start_up(cost)),
         shut_down = convert_cost_to_openapi(get_shut_down(cost)),
         incremental_offer_curves = convert_cost_to_openapi(
@@ -344,6 +351,9 @@ function convert_cost_to_openapi(cost::MarketBidTimeSeriesCost)
             get_decremental_offer_curves(cost),
         ),
         ancillary_service_offers = Int64[],
+        incremental_slope = get_incremental_slope(cost),
+        decremental_slope = get_decremental_slope(cost),
+        curve_style = _curve_style_to_wire(get_curve_style(cost)),
     )
 end
 

--- a/src/openapi/export_cost_conversion.jl
+++ b/src/openapi/export_cost_conversion.jl
@@ -5,7 +5,7 @@
 # Dispatch mirrors the PSY type hierarchy directly (abstract `ValueCurve`/`FunctionData`
 # supertypes, `AbstractReserve`) rather than an enumerated `isa`/`Union` chain — the same style
 # already used throughout this package. PO structs are built with kwargs; oneOf wrappers
-# (`PC.ValueCurve`, `PC.FunctionData`, `PC.ProductionVariableCostCurve`, ...) take their concrete
+# (`PC.ValueCurve`, `IC.FunctionData`, `PC.ProductionVariableCostCurve`, ...) take their concrete
 # value positionally, matching how `PowerOperationsOpenAPIModels`/`PowerCoreOpenAPIModels`
 # generate them.
 
@@ -31,14 +31,14 @@ end
 # ── FunctionData ────────────────────────────────────────────────────────────────
 
 function convert_cost_to_openapi(fd::LinearFunctionData)
-    return PC.LinearFunctionData(;
+    return IC.LinearFunctionData(;
         proportional_term = get_proportional_term(fd),
         constant_term = get_constant_term(fd),
     )
 end
 
 function convert_cost_to_openapi(fd::QuadraticFunctionData)
-    return PC.QuadraticFunctionData(;
+    return IC.QuadraticFunctionData(;
         quadratic_term = get_quadratic_term(fd),
         proportional_term = get_proportional_term(fd),
         constant_term = get_constant_term(fd),
@@ -46,13 +46,13 @@ function convert_cost_to_openapi(fd::QuadraticFunctionData)
 end
 
 function convert_cost_to_openapi(fd::PiecewiseLinearData)
-    return PC.PiecewiseLinearData(;
-        points = [PC.XYCoords(; x = p.x, y = p.y) for p in get_points(fd)],
+    return IC.PiecewiseLinearData(;
+        points = [IC.XYCoords(; x = p.x, y = p.y) for p in get_points(fd)],
     )
 end
 
 function convert_cost_to_openapi(fd::PiecewiseStepData)
-    return PC.PiecewiseStepData(; x_coords = get_x_coords(fd), y_coords = get_y_coords(fd))
+    return IC.PiecewiseStepData(; x_coords = get_x_coords(fd), y_coords = get_y_coords(fd))
 end
 
 # ── ValueCurve ──────────────────────────────────────────────────────────────────
@@ -103,11 +103,11 @@ end
 # ── Time-series FunctionData/ValueCurve — export reads association ids straight off the
 # PSY key, needs no store ──────────────────────────────────────────────────────
 
-_ts_function_data_wire_type(::Type{LinearFunctionData}) = PC.TimeSeriesLinearFunctionData
+_ts_function_data_wire_type(::Type{LinearFunctionData}) = IC.TimeSeriesLinearFunctionData
 _ts_function_data_wire_type(::Type{QuadraticFunctionData}) =
-    PC.TimeSeriesQuadraticFunctionData
-_ts_function_data_wire_type(::Type{PiecewiseLinearData}) = PC.TimeSeriesPiecewiseLinearData
-_ts_function_data_wire_type(::Type{PiecewiseStepData}) = PC.TimeSeriesPiecewiseStepData
+    IC.TimeSeriesQuadraticFunctionData
+_ts_function_data_wire_type(::Type{PiecewiseLinearData}) = IC.TimeSeriesPiecewiseLinearData
+_ts_function_data_wire_type(::Type{PiecewiseStepData}) = IC.TimeSeriesPiecewiseStepData
 
 function convert_cost_to_openapi(fd::TimeSeriesFunctionData{T}) where {T}
     WireType = _ts_function_data_wire_type(T)
@@ -147,14 +147,14 @@ _curve_style_to_wire(style::CurveStyles) = style.value
 
 function convert_cost_to_openapi(curve::TimeSeriesInputOutputCurve)
     return PC.TimeSeriesInputOutputCurve(;
-        function_data = PC.FunctionData(convert_cost_to_openapi(get_function_data(curve))),
+        function_data = IC.FunctionData(convert_cost_to_openapi(get_function_data(curve))),
         input_at_zero = get_input_at_zero(curve),
     )
 end
 
 function convert_cost_to_openapi(curve::TimeSeriesIncrementalCurve)
     return PC.TimeSeriesIncrementalCurve(;
-        function_data = PC.FunctionData(convert_cost_to_openapi(get_function_data(curve))),
+        function_data = IC.FunctionData(convert_cost_to_openapi(get_function_data(curve))),
         initial_input_association_id = _key_association_id(get_initial_input(curve)),
         input_at_zero_association_id = _key_association_id(get_input_at_zero(curve)),
     )
@@ -162,7 +162,7 @@ end
 
 function convert_cost_to_openapi(curve::TimeSeriesAverageRateCurve)
     return PC.TimeSeriesAverageRateCurve(;
-        function_data = PC.FunctionData(convert_cost_to_openapi(get_function_data(curve))),
+        function_data = IC.FunctionData(convert_cost_to_openapi(get_function_data(curve))),
         initial_input_association_id = _key_association_id(get_initial_input(curve)),
         input_at_zero_association_id = _key_association_id(get_input_at_zero(curve)),
     )

--- a/src/openapi/export_cost_conversion.jl
+++ b/src/openapi/export_cost_conversion.jl
@@ -222,15 +222,17 @@ function convert_cost_to_openapi(cost::ThermalGenerationCost)
         fixed = get_fixed(cost),
         shut_down = get_shut_down(cost),
         start_up = _thermal_start_up_to_openapi(get_start_up(cost)),
-        variable = PC.ProductionVariableCostCurve(
-            convert_cost_to_openapi(get_variable(cost)),
+        variable_operation_cost = PC.ProductionVariableCostCurve(
+            convert_cost_to_openapi(get_variable_operation_cost(cost)),
         ),
     )
 end
 
 function convert_cost_to_openapi(cost::RenewableGenerationCost)
     return PC.RenewableGenerationCost(;
-        variable = convert_cost_to_openapi(get_variable(cost)),
+        variable_operation_cost = convert_cost_to_openapi(
+            get_variable_operation_cost(cost),
+        ),
         curtailment_cost = _optional_cost_curve_to_openapi(get_curtailment_cost(cost)),
         fixed = get_fixed(cost),
     )
@@ -239,15 +241,17 @@ end
 function convert_cost_to_openapi(cost::HydroGenerationCost)
     return PC.HydroGenerationCost(;
         fixed = get_fixed(cost),
-        variable = PC.ProductionVariableCostCurve(
-            convert_cost_to_openapi(get_variable(cost)),
+        variable_operation_cost = PC.ProductionVariableCostCurve(
+            convert_cost_to_openapi(get_variable_operation_cost(cost)),
         ),
     )
 end
 
 function convert_cost_to_openapi(cost::LoadCost)
     return PC.LoadCost(;
-        variable = convert_cost_to_openapi(get_variable(cost)),
+        variable_operation_cost = convert_cost_to_openapi(
+            get_variable_operation_cost(cost),
+        ),
         fixed = get_fixed(cost),
     )
 end

--- a/src/openapi/export_document.jl
+++ b/src/openapi/export_document.jl
@@ -501,7 +501,7 @@ before `to_openapi(attr, refs)` reads that id back. The store's rows already arr
 """
 function _export_supplemental_attributes(refs::OpenAPIRefs, sys::System)
     attribute_rows = OpenAPI.APIModel[]
-    association_rows = PC.SupplementalAttributeAssociation[]
+    association_rows = IC.SupplementalAttributeAssociation[]
     plant_association_rows = PO.PlantAssociation[]
     combined_cycle_association_rows = PO.CombinedCycleAssociation[]
     attributes_by_id = Dict{Int, SupplementalAttribute}(

--- a/src/openapi/export_document.jl
+++ b/src/openapi/export_document.jl
@@ -324,6 +324,35 @@ function _export_service_associations(refs::OpenAPIRefs, sys::System)
     return rows
 end
 
+# ── trading hub membership (reverse of the trading-hub-membership branch in
+# load_supplemental_attribute_associations!) ──────────────────────────────────────
+function _export_trading_hub_associations(refs::OpenAPIRefs, sys::System)
+    rows = PO.TradingHubAssociation[]
+    for hub in get_components(TradingHub, sys)
+        for bus in get_associated_buses(hub)
+            push!(
+                rows,
+                PO.TradingHubAssociation(;
+                    trading_hub_id = component_id(refs, hub),
+                    entity_id = component_id(refs, bus),
+                ),
+            )
+        end
+    end
+    for vp in get_components(VirtualParticipant, sys)
+        for hub in get_trading_hubs(vp)
+            push!(
+                rows,
+                PO.TradingHubAssociation(;
+                    trading_hub_id = component_id(refs, hub),
+                    entity_id = component_id(refs, vp),
+                ),
+            )
+        end
+    end
+    return rows
+end
+
 # ── supplemental attributes (reverse of _attach_supplemental_attribute_associations!) ──
 
 # A plant-family attribute (`ThermalPowerPlant`, `HydroPowerPlant`, `RenewablePowerPlant`,
@@ -683,6 +712,10 @@ function to_openapi(
         append!(doc.plant_associations, plant_associations)
         append!(doc.combined_cycle_associations, combined_cycle_associations)
         append!(doc.service_associations, _export_service_associations(refs, sys))
+        append!(
+            doc.trading_hub_associations,
+            _export_trading_hub_associations(refs, sys),
+        )
         append!(
             doc.time_series_associations,
             _export_all_time_series(sys, refs, time_series_storage_path),

--- a/src/openapi/export_document.jl
+++ b/src/openapi/export_document.jl
@@ -165,21 +165,20 @@ function warn_unexportable_components(sys::System)
     return nothing
 end
 
-# ── unit_system resolution ──────────────────────────────────────────────────────
+# ── power_units resolution ───────────────────────────────────────────────────────
 
-"""Resolve the `unit_system` kwarg to the document's `unit_system` string.
-
-The caller states the convention outright: a `System` records no unit system of its own — every
-getter takes one explicitly — so there is nothing to infer from `sys`."""
-function _resolve_export_unit_system(unit_system::Symbol)
-    if unit_system === :device_base
-        return "COMPONENT_BASE"
-    elseif unit_system === :natural_units
-        return "NATURAL_UNITS"
+"""Resolve the `power_units` kwarg to the `DU`/`NU` marker every exported component blob is
+stamped with — a uniform stamp per export, since PSY does not record a per-component creation
+basis."""
+function _resolve_export_power_units(power_units::Symbol)
+    if power_units === :component_base
+        return DU
+    elseif power_units === :natural_units
+        return NU
     else
         error(
-            "to_openapi(sys; unit_system=$unit_system): unmapped — expected " *
-            ":device_base or :natural_units",
+            "to_openapi(sys; power_units=$power_units): unmapped — expected " *
+            ":component_base or :natural_units",
         )
     end
 end
@@ -227,8 +226,8 @@ id — but it is still registered in [`OpenAPIRefs`](@ref), and must be skipped 
 _has_own_id(::Any) = true
 _has_own_id(::TransformerCircuit) = false
 
-function _build_export_refs(sys::System, unit_system_string::AbstractString)
-    refs = OpenAPIRefs(unit_system_string, get_base_power(sys))
+function _build_export_refs(sys::System)
+    refs = OpenAPIRefs(get_base_power(sys))
     # Components and supplemental attributes share one id stream, so a fresh
     # `TransformerCircuit` id must clear the highest of both kinds.
     highest = 0
@@ -636,9 +635,11 @@ Returns the typed container, not JSON: writing it to disk belongs to
 — components and supplemental attributes alike — comes from the document's single counter, since
 consumers key a row by id without its type.
 
-`unit_system`: `:device_base` (default) writes each component's values on its own base, the
-convention PSY stores natively, so no conversion happens; `:natural_units` converts to physical
-units on the way out. Any `System` is exportable either way, however it was built.
+`power_units`: `:component_base` (default) stamps every exported component blob "COMPONENT_BASE"
+and writes each component's values on its own base, the convention PSY stores natively, so no
+conversion happens; `:natural_units` stamps "NATURAL_UNITS" and converts to physical units on
+the way out. The stamp is uniform across the whole export — PSY does not record a
+per-component creation basis. Any `System` is exportable either way, however it was built.
 
 Walks components in [`DOCUMENT_PLAN`](@ref) order (symmetry with import, not a resolution
 requirement — every id already exists or is assigned fresh before it is ever read). Emits
@@ -650,17 +651,14 @@ dropping data: a time series with no `time_series_storage_path` given.
 """
 function to_openapi(
     sys::System;
-    unit_system::Symbol = :device_base,
+    power_units::Symbol = :component_base,
     time_series_storage_path = nothing,
 )
     warn_unexportable_components(sys)
-    unit_system_string = _resolve_export_unit_system(unit_system)
-    refs = _build_export_refs(sys, unit_system_string)
-    val = _unit_val(unit_system_string)
+    val = _resolve_export_power_units(power_units)
+    refs = _build_export_refs(sys)
 
-    doc = PD.SystemDocument(
-        get_base_power(sys);
-        unit_system = unit_system_string,
+    doc = PD.SystemDocument(;
         name = get_name(sys),
         description = get_description(sys),
         frequency = sys.frequency,

--- a/src/openapi/export_document.jl
+++ b/src/openapi/export_document.jl
@@ -635,11 +635,23 @@ Returns the typed container, not JSON: writing it to disk belongs to
 — components and supplemental attributes alike — comes from the document's single counter, since
 consumers key a row by id without its type.
 
-`power_units`: `:component_base` (default) stamps every exported component blob "COMPONENT_BASE"
-and writes each component's values on its own base, the convention PSY stores natively, so no
-conversion happens; `:natural_units` stamps "NATURAL_UNITS" and converts to physical units on
-the way out. The stamp is uniform across the whole export — PSY does not record a
-per-component creation basis. Any `System` is exportable either way, however it was built.
+`power_units` selects the basis every value is written on, and the stamp each blob carries:
+
+  - `:component_base` (default) stamps every power-bearing blob `"COMPONENT_BASE"` and writes
+    each component's values on its own `base_power` — what PSY stores natively, so no
+    conversion runs and the numbers on disk are the numbers in memory.
+  - `:natural_units` stamps `"NATURAL_UNITS"` and converts to physical units (MW, MVAr, MVA).
+
+Anything else errors: the mapping to the internal `DU`/`NU` markers is explicit, so an
+unrecognized symbol is refused rather than defaulted.
+
+The stamp is uniform across an export because PSY records no per-component creation basis.
+Reading is not uniform: `from_openapi` honors the `power_units` on each individual blob, so a
+document written elsewhere with a mixed basis loads correctly, and a blob that omits the field
+is an error — `OpenAPI.from_json` does not enforce the schema's `required`, so the check is
+made explicitly rather than defaulting to a basis and silently rescaling the value.
+
+Any `System` is exportable either way, however it was built.
 
 Walks components in [`DOCUMENT_PLAN`](@ref) order (symmetry with import, not a resolution
 requirement — every id already exists or is assigned fresh before it is ever read). Emits

--- a/src/openapi/export_generated_types.jl
+++ b/src/openapi/export_generated_types.jl
@@ -3,17 +3,17 @@
 
 # ── Compound-field helpers (device-base pu) ──
 
-_minmax_po(nt) = PC.MinMax(; min = nt.min, max = nt.max)
+_minmax_po(nt) = IC.MinMax(; min = nt.min, max = nt.max)
 _minmax_po_optional(::Nothing) = nothing
 _minmax_po_optional(nt) = _minmax_po(nt)
-_minmax_po_scaled(nt, base) = PC.MinMax(; min = nt.min * base, max = nt.max * base)
+_minmax_po_scaled(nt, base) = IC.MinMax(; min = nt.min * base, max = nt.max * base)
 _minmax_po_scaled_optional(::Nothing, base) = nothing
 _minmax_po_scaled_optional(nt, base) = _minmax_po_scaled(nt, base)
 
 _updown_po_optional(::Nothing) = nothing
-_updown_po_optional(nt) = PC.UpDown(; up = nt.up, down = nt.down)
+_updown_po_optional(nt) = IC.UpDown(; up = nt.up, down = nt.down)
 _updown_po_scaled_optional(::Nothing, base) = nothing
-_updown_po_scaled_optional(nt, base) = PC.UpDown(; up = nt.up * base, down = nt.down * base)
+_updown_po_scaled_optional(nt, base) = IC.UpDown(; up = nt.up * base, down = nt.down * base)
 
 _startup_shutdown_po_optional(::Nothing) = nothing
 _startup_shutdown_po_optional(nt) =
@@ -28,15 +28,15 @@ _startup_stages_po_optional(nt) =
 
 _turbinepump_po(nt) = PC.TurbinePump(; turbine = nt.turbine, pump = nt.pump)
 
-_fromto_po(nt) = PC.FromTo(; from = nt.from, to = nt.to)
-_fromto_tofrom_po(nt) = PC.FromToToFrom(; from_to = nt.from_to, to_from = nt.to_from)
+_fromto_po(nt) = IC.FromTo(; from = nt.from, to = nt.to)
+_fromto_tofrom_po(nt) = IC.FromToToFrom(; from_to = nt.from_to, to_from = nt.to_from)
 _fromto_tofrom_po_scaled(nt, base) =
-    PC.FromToToFrom(; from_to = nt.from_to * base, to_from = nt.to_from * base)
-_inout_po(nt) = PC.InOut(; in = nt.in, out = nt.out)
+    IC.FromToToFrom(; from_to = nt.from_to * base, to_from = nt.to_from * base)
+_inout_po(nt) = IC.InOut(; in = nt.in, out = nt.out)
 _inout_po_optional(::Nothing) = nothing
 _inout_po_optional(nt) = _inout_po(nt)
 # Inverse of the import side's `_complex_number` (import_handwritten.jl).
-_complex_number_po(c) = PC.ComplexNumber(; real = real(c), imag = imag(c))
+_complex_number_po(c) = IC.ComplexNumber(; real = real(c), imag = imag(c))
 
 _scale_optional_po(::Nothing, base) = nothing
 _scale_optional_po(v, base) = v * base

--- a/src/openapi/export_handwritten.jl
+++ b/src/openapi/export_handwritten.jl
@@ -1170,7 +1170,7 @@ function to_openapi(res::HydroReservoir, refs::OpenAPIRefs, ::DeviceBaseUnit)
         outflow = get_outflow(res),
         level_targets = _level_absolute(get_level_targets(res), limits.max),
         intake_elevation = get_intake_elevation(res),
-        head_to_volume_factor = PC.FunctionData(
+        head_to_volume_factor = IC.FunctionData(
             convert_cost_to_openapi(get_head_to_volume_factor(res)),
         ),
         upstream_turbines = _hydro_unit_ids(refs, get_upstream_turbines(res)),

--- a/src/openapi/export_handwritten.jl
+++ b/src/openapi/export_handwritten.jl
@@ -303,6 +303,7 @@ function to_openapi(line::TModelHVDCLine, refs::OpenAPIRefs, ::DeviceBaseUnit)
         c = get_c(line),
         active_power_limits_from = _minmax_po(get_active_power_limits_from(line, SU)),
         active_power_limits_to = _minmax_po(get_active_power_limits_to(line, SU)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -325,6 +326,7 @@ function to_openapi(line::TModelHVDCLine, refs::OpenAPIRefs, ::NaturalUnit)
         active_power_limits_to = _minmax_po_scaled(
             get_active_power_limits_to(line, SU), sbp,
         ),
+        power_units = _power_units_string(NU),
     )
 end
 

--- a/src/openapi/export_handwritten.jl
+++ b/src/openapi/export_handwritten.jl
@@ -23,12 +23,24 @@ function to_openapi(arc::Arc, refs::OpenAPIRefs, ::NaturalUnit)
 end
 
 # ── Area / LoadZone ─────────────────────────────────────────────────────────────
-# peak_active_power/peak_reactive_power are fixed-natural (x-unit MW/MVAr) regardless of
-# document unit_system (mirrors import — see import_handwritten.jl's header on this
-# exact point) — multiply by `get_base_power(refs)` in BOTH methods. `load_response` has no
-# `conversion_unit` and passes through unconverted in both.
+# peak_active_power/peak_reactive_power are discriminated by `power_units` like every other
+# power-family field: COMPONENT_BASE writes the pu value as-is, NATURAL_UNITS multiplies by
+# `get_base_power(refs)`. `load_response` has no `conversion_unit` and passes through
+# unconverted in both.
 
 function to_openapi(area::Area, refs::OpenAPIRefs, ::DeviceBaseUnit)
+    return PO.Area(;
+        id = component_id(refs, area),
+        name = get_name(area),
+        peak_active_power = get_peak_active_power(area, SU),
+        peak_reactive_power = get_peak_reactive_power(area, SU),
+        load_response = get_load_response(area),
+        base_power = get_base_power(refs),
+        power_units = _power_units_string(DU),
+    )
+end
+
+function to_openapi(area::Area, refs::OpenAPIRefs, ::NaturalUnit)
     return PO.Area(;
         id = component_id(refs, area),
         name = get_name(area),
@@ -36,34 +48,51 @@ function to_openapi(area::Area, refs::OpenAPIRefs, ::DeviceBaseUnit)
         peak_reactive_power = get_peak_reactive_power(area, SU) * get_base_power(refs),
         load_response = get_load_response(area),
         base_power = get_base_power(refs),
+        power_units = _power_units_string(NU),
     )
-end
-
-function to_openapi(area::Area, refs::OpenAPIRefs, ::NaturalUnit)
-    return to_openapi(area, refs, DU)
 end
 
 function to_openapi(lz::LoadZone, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.LoadZone(;
         id = component_id(refs, lz),
         name = get_name(lz),
-        peak_active_power = get_peak_active_power(lz, SU) * get_base_power(refs),
-        peak_reactive_power = get_peak_reactive_power(lz, SU) * get_base_power(refs),
+        peak_active_power = get_peak_active_power(lz, SU),
+        peak_reactive_power = get_peak_reactive_power(lz, SU),
         base_power = get_base_power(refs),
+        power_units = _power_units_string(DU),
     )
 end
 
 function to_openapi(lz::LoadZone, refs::OpenAPIRefs, ::NaturalUnit)
-    return to_openapi(lz, refs, DU)
+    return PO.LoadZone(;
+        id = component_id(refs, lz),
+        name = get_name(lz),
+        peak_active_power = get_peak_active_power(lz, SU) * get_base_power(refs),
+        peak_reactive_power = get_peak_reactive_power(lz, SU) * get_base_power(refs),
+        base_power = get_base_power(refs),
+        power_units = _power_units_string(NU),
+    )
 end
 
 # ── TransmissionInterface ───────────────────────────────────────────────────────
-# `active_power_flow_limits` is fixed-natural (x-unit MW) regardless of document
-# unit_system (mirrors import) — multiply by `get_base_power(refs)` in BOTH methods.
-# `violation_penalty`/`direction_mapping` have no `conversion_unit` and pass through
-# unconverted in both.
+# `active_power_flow_limits` is discriminated by `power_units` like every other power-family
+# field, mirroring Area/LoadZone above. `violation_penalty`/`direction_mapping` have no
+# `conversion_unit` and pass through unconverted in both.
 
 function to_openapi(tx::TransmissionInterface, refs::OpenAPIRefs, ::DeviceBaseUnit)
+    return PO.TransmissionInterface(;
+        id = component_id(refs, tx),
+        name = get_name(tx),
+        available = get_available(tx),
+        active_power_flow_limits = _minmax_po(get_active_power_flow_limits(tx, SU)),
+        violation_penalty = get_violation_penalty(tx),
+        direction_mapping = get_direction_mapping(tx),
+        base_power = get_base_power(refs),
+        power_units = _power_units_string(DU),
+    )
+end
+
+function to_openapi(tx::TransmissionInterface, refs::OpenAPIRefs, ::NaturalUnit)
     return PO.TransmissionInterface(;
         id = component_id(refs, tx),
         name = get_name(tx),
@@ -75,11 +104,8 @@ function to_openapi(tx::TransmissionInterface, refs::OpenAPIRefs, ::DeviceBaseUn
         violation_penalty = get_violation_penalty(tx),
         direction_mapping = get_direction_mapping(tx),
         base_power = get_base_power(refs),
+        power_units = _power_units_string(NU),
     )
-end
-
-function to_openapi(tx::TransmissionInterface, refs::OpenAPIRefs, ::NaturalUnit)
-    return to_openapi(tx, refs, DU)
 end
 
 # ── Line ────────────────────────────────────────────────────────────────────────
@@ -105,6 +131,7 @@ function to_openapi(line::Line, refs::OpenAPIRefs, ::DeviceBaseUnit)
         rating_c = get_rating_c(line, SU),
         angle_limits = _minmax_po(get_angle_limits(line)),
         g = _fromto_po(get_g(line, SU)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -126,6 +153,7 @@ function to_openapi(line::Line, refs::OpenAPIRefs, ::NaturalUnit)
         rating_c = _scale_optional_po(get_rating_c(line, SU), sbp),
         angle_limits = _minmax_po(get_angle_limits(line)),
         g = _fromto_po(get_g(line, SU)),
+        power_units = _power_units_string(NU),
     )
 end
 
@@ -163,6 +191,7 @@ function to_openapi(hyb::HybridSystem, refs::OpenAPIRefs, ::DeviceBaseUnit)
         interconnection_efficiency = _inout_po_optional(
             get_interconnection_efficiency(hyb),
         ),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -200,6 +229,7 @@ function to_openapi(hyb::HybridSystem, refs::OpenAPIRefs, ::NaturalUnit)
         interconnection_efficiency = _inout_po_optional(
             get_interconnection_efficiency(hyb),
         ),
+        power_units = _power_units_string(NU),
     )
 end
 
@@ -225,6 +255,7 @@ function to_openapi(src::Source, refs::OpenAPIRefs, ::DeviceBaseUnit)
         base_voltage = get_base_voltage(src),
         base_power = _get_base_power(src),
         operation_cost = convert_cost_to_openapi(get_operation_cost(src)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -249,6 +280,7 @@ function to_openapi(src::Source, refs::OpenAPIRefs, ::NaturalUnit)
         base_voltage = get_base_voltage(src),
         base_power = dbp,
         operation_cost = convert_cost_to_openapi(get_operation_cost(src)),
+        power_units = _power_units_string(NU),
     )
 end
 
@@ -325,6 +357,7 @@ function to_openapi(conv::InterconnectingConverter, refs::OpenAPIRefs, ::DeviceB
         rmpct = get_rmpct(conv),
         power_factor_weighting_fraction = get_power_factor_weighting_fraction(conv),
         voltage_limits = _minmax_po(get_voltage_limits(conv)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -356,6 +389,7 @@ function to_openapi(conv::InterconnectingConverter, refs::OpenAPIRefs, ::Natural
         rmpct = get_rmpct(conv),
         power_factor_weighting_fraction = get_power_factor_weighting_fraction(conv),
         voltage_limits = _minmax_po(get_voltage_limits(conv)),
+        power_units = _power_units_string(NU),
     )
 end
 
@@ -380,6 +414,7 @@ function to_openapi(line::MonitoredLine, refs::OpenAPIRefs, ::DeviceBaseUnit)
         rating_c = get_rating_c(line, SU),
         angle_limits = _minmax_po(get_angle_limits(line)),
         g = _fromto_po(get_g(line, SU)),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -402,6 +437,7 @@ function to_openapi(line::MonitoredLine, refs::OpenAPIRefs, ::NaturalUnit)
         rating_c = _scale_optional_po(get_rating_c(line, SU), sbp),
         angle_limits = _minmax_po(get_angle_limits(line)),
         g = _fromto_po(get_g(line, SU)),
+        power_units = _power_units_string(NU),
     )
 end
 
@@ -422,6 +458,7 @@ function to_openapi(branch::GenericArcImpedance, refs::OpenAPIRefs, ::DeviceBase
         parameter_units = "COMPONENT_BASE",
         r = get_r(branch, SU),
         x = get_x(branch, SU),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -439,14 +476,15 @@ function to_openapi(branch::GenericArcImpedance, refs::OpenAPIRefs, ::NaturalUni
         parameter_units = "COMPONENT_BASE",
         r = get_r(branch, SU),
         x = get_x(branch, SU),
+        power_units = _power_units_string(NU),
     )
 end
 
 # ── DiscreteControlledACBranch ───────────────────────────────────────────────────
 # `active_power_flow`/`reactive_power_flow`/`r`/`x` are declared `SU` (system base), `rating`
-# is declared `DU` — numerically identical for this type since its `base_power` always equals
-# the document system base (see the import-side comment), but the identity accessor for each
-# field must still match its own declared tier.
+# is declared `DU` — numerically identical for this type since `add_component!` keeps its
+# `base_power` synced to the System's, but the identity accessor for each field must still
+# match its own declared tier.
 
 function to_openapi(branch::DiscreteControlledACBranch, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return PO.DiscreteControlledACBranch(;
@@ -467,6 +505,7 @@ function to_openapi(branch::DiscreteControlledACBranch, refs::OpenAPIRefs, ::Dev
         normal_branch_status = string(get_normal_branch_status(
             branch,
         )),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -490,14 +529,15 @@ function to_openapi(branch::DiscreteControlledACBranch, refs::OpenAPIRefs, ::Nat
         normal_branch_status = string(get_normal_branch_status(
             branch,
         )),
+        power_units = _power_units_string(NU),
     )
 end
 
 # ── TransformerCircuit ──────────────────────────────────────────────────────────
-# `r`/`x` are pu on the circuit's own `base_power` and identity in BOTH document unit systems
-# (mirrors import — parameter_units is always emitted as "COMPONENT_BASE", the only basis this
-# pass implements on either side). `rating`/`rating_b`/`rating_c`/`active_power_flow`/
-# `reactive_power_flow` scale by the circuit's own `base_power` under NATURAL_UNITS only.
+# `r`/`x` are pu on the circuit's own `base_power` and identity in both marker methods
+# (`parameter_units` is always emitted as "COMPONENT_BASE", the only basis this pass implements
+# on either side). `rating`/`rating_b`/`rating_c`/`active_power_flow`/`reactive_power_flow`
+# scale by the circuit's own `base_power` under NATURAL_UNITS only.
 # Reached only via its owning `TwoWindingTransformer`'s `to_openapi` — never a standalone
 # System component (no `addable` entry of its own), so this method is called directly on the
 # `TransformerCircuit` object the document walk already resolved to an id.
@@ -527,6 +567,7 @@ function to_openapi(circuit::TransformerCircuit, refs::OpenAPIRefs, ::DeviceBase
         base_power = get_base_power(circuit),
         base_voltage_primary = get_base_voltage_primary(circuit),
         base_voltage_secondary = get_base_voltage_secondary(circuit),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -556,6 +597,7 @@ function to_openapi(circuit::TransformerCircuit, refs::OpenAPIRefs, ::NaturalUni
         base_power = dbp,
         base_voltage_primary = get_base_voltage_primary(circuit),
         base_voltage_secondary = get_base_voltage_secondary(circuit),
+        power_units = _power_units_string(NU),
     )
 end
 
@@ -625,9 +667,8 @@ end
 # `Y` is stored in PSY as pu on the system base, but the wire enum has no system-base
 # member: `ShuntAdmittanceUnitBasis` is `NATURAL_UNITS`/`COMPONENT_MVAR` only, because a shunt
 # has no device MVA rating of its own. Export therefore states `COMPONENT_MVAR` (MVAr at unity
-# voltage) and multiplies by the document-level system base, exactly inverting the
-# `COMPONENT_MVAR` division in `_fixed_admittance_pu`. Independent of what basis the document was
-# originally imported from, mirroring TwoWindingTransformer's always-"COMPONENT_BASE" export.
+# voltage) and multiplies by `get_base_power(refs)`, exactly inverting the `COMPONENT_MVAR`
+# division in `_fixed_admittance_pu`, in both methods.
 
 function to_openapi(shunt::FixedAdmittance, refs::OpenAPIRefs, ::DeviceBaseUnit)
     y = get_Y(shunt) * get_base_power(refs)
@@ -638,10 +679,9 @@ function to_openapi(shunt::FixedAdmittance, refs::OpenAPIRefs, ::DeviceBaseUnit)
         bus = component_id(refs, get_bus(shunt)),
         admittance_units = "COMPONENT_MVAR",
         Y = _complex_number_po(y),
-        # FixedAdmittance's base_power_kind is SystemBasePower (components.jl): the field
-        # is kept in sync by add_component!, not authoritative on its own, so read the
-        # document-level anchor (per openapi_export_base_source in generate_structs.jl),
-        # same as `y` above.
+        # FixedAdmittance's base_power_kind is SystemBasePower (components.jl): the field is
+        # kept in sync by add_component!, not authoritative on its own, so read `refs`'s
+        # anchor (per `openapi_export_base_source` in generate_structs.jl), same as `y` above.
         base_power = get_base_power(refs),
     )
 end
@@ -651,8 +691,8 @@ function to_openapi(shunt::FixedAdmittance, refs::OpenAPIRefs, ::NaturalUnit)
 end
 
 # ── SwitchedAdmittance ────────────────────────────────────────────────────────────
-# Mirrors `FixedAdmittance`: `Y`/`Y_increase` are fixed-natural COMPONENT_MVAR-on-system-base,
-# independent of the document's unit system, so `NaturalUnit` delegates to `DeviceBaseUnit`.
+# Mirrors `FixedAdmittance`: `Y`/`Y_increase` are fixed-natural COMPONENT_MVAR-on-system-base
+# in both methods, so `NaturalUnit` delegates to `DeviceBaseUnit`.
 
 function to_openapi(shunt::SwitchedAdmittance, refs::OpenAPIRefs, ::DeviceBaseUnit)
     base_power = get_base_power(refs)
@@ -680,13 +720,39 @@ function to_openapi(shunt::SwitchedAdmittance, refs::OpenAPIRefs, ::NaturalUnit)
 end
 
 # ── FACTSControlDevice ────────────────────────────────────────────────────────────
-# Mirrors import: `max_shunt_current`/`max_reactive_power` are `SU`-identity, divided/
-# multiplied by the document system base; `voltage_setpoint` is always exported as
-# "COMPONENT_BASE" (the only basis import implements), matching TwoWindingTransformer's
-# always-"COMPONENT_BASE" export posture for a similarly fixed-representation field.
+# `max_shunt_current`/`max_reactive_power` are discriminated by `power_units` like every other
+# power-family field: COMPONENT_BASE writes the pu value as-is, NATURAL_UNITS multiplies by the
+# device's own `base_power`. `voltage_setpoint` is always exported as "COMPONENT_BASE" (the only
+# basis import implements).
 
 function to_openapi(device::FACTSControlDevice, refs::OpenAPIRefs, ::DeviceBaseUnit)
-    base_power = get_base_power(refs)
+    control_mode = get_control_mode(device)
+    return PO.FACTSControlDevice(;
+        id = component_id(refs, device),
+        name = get_name(device),
+        available = get_available(device),
+        bus = component_id(refs, get_bus(device)),
+        control_mode = if isnothing(control_mode)
+            nothing
+        else
+            string(control_mode)
+        end,
+        voltage_setpoint_units = "COMPONENT_BASE",
+        voltage_setpoint = get_voltage_setpoint(device),
+        max_shunt_current = get_max_shunt_current(device, SU),
+        reactive_power_required = get_reactive_power_required(device),
+        max_reactive_power = get_max_reactive_power(device, SU),
+        shunt_control_type = string(get_shunt_control_type(
+            device,
+        )),
+        regulated_bus_number = get_regulated_bus_number(device),
+        base_power = _get_base_power(device),
+        power_units = _power_units_string(DU),
+    )
+end
+
+function to_openapi(device::FACTSControlDevice, refs::OpenAPIRefs, ::NaturalUnit)
+    base_power = _get_base_power(device)
     control_mode = get_control_mode(device)
     return PO.FACTSControlDevice(;
         id = component_id(refs, device),
@@ -707,11 +773,9 @@ function to_openapi(device::FACTSControlDevice, refs::OpenAPIRefs, ::DeviceBaseU
             device,
         )),
         regulated_bus_number = get_regulated_bus_number(device),
+        base_power = base_power,
+        power_units = _power_units_string(NU),
     )
-end
-
-function to_openapi(device::FACTSControlDevice, refs::OpenAPIRefs, ::NaturalUnit)
-    return to_openapi(device, refs, DU)
 end
 
 # ── TwoTerminalGenericHVDCLine ──────────────────────────────────────────────────
@@ -742,6 +806,7 @@ function to_openapi(
         reactive_power_limits_to = _minmax_po(get_reactive_power_limits_to(hvdc, SU)),
         loss = _hvdc_loss_to_openapi(get_loss(hvdc)),
         base_power = get_base_power(refs),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -773,19 +838,20 @@ function to_openapi(
         ),
         loss = _hvdc_loss_to_openapi(get_loss(hvdc)),
         base_power = sbp,
+        power_units = _power_units_string(NU),
     )
 end
 
 # ── TwoTerminalLCCLine ────────────────────────────────────────────────────────────
-# Mirrors import: always exports "NATURAL_UNITS" for `parameter_units`/`dc_voltage_units` (the
-# only basis implemented), so `r`/`rectifier_rc`/`rectifier_xc`/`rectifier_capacitor_reactance`/
+# Always exports "NATURAL_UNITS" for `parameter_units`/`dc_voltage_units` (the only basis
+# implemented), so `r`/`rectifier_rc`/`rectifier_xc`/`rectifier_capacitor_reactance`/
 # `inverter_rc`/`inverter_xc`/`inverter_capacitor_reactance`/`compounding_resistance` convert
 # pu → ohms in BOTH methods identically — the PROVISIONAL `scheduled_dc_voltage`-based Zbase for
 # `r`/`compounding_resistance` (see import_handwritten.jl's header on this exact point) applies
 # here too. Only `active_power_flow`/`active_power_limits_*`/`reactive_power_limits_*`/
-# `transfer_setpoint` (when `power_mode`) differ, multiplying by the document system base under
-# `NaturalUnit`. Voltage/angle/ratio/tap/bridge fields have no unit-aware getter on the PSY
-# side (plain field access) and pass through unconverted.
+# `transfer_setpoint` (when `power_mode`) are discriminated by `power_units`, multiplying by
+# `base_power` under `NaturalUnit`. Voltage/angle/ratio/tap/bridge fields have no unit-aware
+# getter on the PSY side (plain field access) and pass through unconverted.
 
 _lcc_pu_to_ohm(pu, base_voltage, base_power) = pu * (base_voltage^2 / base_power)
 
@@ -852,6 +918,7 @@ function to_openapi(lcc::TwoTerminalLCCLine, refs::OpenAPIRefs, ::DeviceBaseUnit
         reactive_power_limits_to = _minmax_po(get_reactive_power_limits_to(lcc, SU)),
         loss = _hvdc_loss_to_openapi(get_loss(lcc)),
         base_power = base_power,
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -927,14 +994,15 @@ function to_openapi(lcc::TwoTerminalLCCLine, refs::OpenAPIRefs, ::NaturalUnit)
         ),
         loss = _hvdc_loss_to_openapi(get_loss(lcc)),
         base_power = base_power,
+        power_units = _power_units_string(NU),
     )
 end
 
 # ── TwoTerminalVSCLine ──────────────────────────────────────────────────────────
-# Mirrors import: always exports "NATURAL_UNITS" for `admittance_units`/`voltage_units` (the
-# only basis implemented), so `g` converts pu → siemens in BOTH methods. Only the
-# document-unit-system-governed power
-# fields and `dc_setpoint_*`'s `DC_POWER` branch multiply by the system base under `NaturalUnit`.
+# Always exports "NATURAL_UNITS" for `admittance_units`/`voltage_units` (the only basis
+# implemented), so `g` converts pu → siemens in BOTH methods. Only the power-family fields and
+# `dc_setpoint_*`'s `DC_POWER` branch are discriminated by `power_units`, multiplying by
+# `base_power` under `NaturalUnit`.
 # `voltage_limits_*`, `dc_voltage_droop_*`, the current fields, `rmpct_*`, the weighting
 # fractions, and `rated_dc_voltage`/`rated_ac_voltage_from`/`rated_ac_voltage_to` pass through —
 # see import_handwritten.jl's header for why each one is left alone. The voltage-regulating
@@ -1060,6 +1128,7 @@ function _two_terminal_vsc_line_to_openapi(vsc::TwoTerminalVSCLine, refs::OpenAP
         rmpct_from = get_rmpct_from(vsc),
         rmpct_to = get_rmpct_to(vsc),
         base_power = base_power,
+        power_units = _power_units_string(unit),
     )
 end
 
@@ -1166,6 +1235,7 @@ function to_openapi(storage::EnergyReservoirStorage, refs::OpenAPIRefs, ::Device
         ramp_limits = _updown_po_optional(get_ramp_limits(storage, DU)),
         self_discharge = get_self_discharge(storage),
         standing_loss = get_standing_loss(storage, DU),
+        power_units = _power_units_string(DU),
     )
 end
 
@@ -1206,16 +1276,18 @@ function to_openapi(
         ramp_limits = _updown_po_scaled_optional(get_ramp_limits(storage, DU), base),
         self_discharge = get_self_discharge(storage),
         standing_loss = get_standing_loss(storage, DU) * base,
+        power_units = _power_units_string(NU),
     )
 end
 
 # ── Reserves: OnlineReserve, OfflineReserve, GroupReserve ───────────────────────
 # `reserve_direction` resolves from the `T` type parameter through a literal table (the
-# reverse of `RESERVE_DIRECTION`; direction is not a codegen case). `requirement` divides by /
-# multiplies by the document-level `get_base_power(refs)` — a reserve has no device base of its
-# own, same fallback `TwoTerminalGenericHVDCLine` uses. `variable` (the Operating Reserve
-# Demand Curve) goes through `convert_reserve_variable_to_openapi` (already handles the
-# `ZERO_OFFER_CURVE` → `nothing` default).
+# reverse of `RESERVE_DIRECTION`; direction is not a codegen case). `requirement`'s schema
+# declares x-unit "MW" outright (see import_handwritten.jl's header on this exact point), so it
+# multiplies by `get_base_power(refs)` in both methods — a reserve has no base of its own.
+# `variable` (the Operating Reserve Demand Curve) goes through
+# `convert_reserve_variable_to_openapi` (already handles the `ZERO_OFFER_CURVE` → `nothing`
+# default).
 
 const RESERVE_DIRECTION_TO_STRING = _invert(RESERVE_DIRECTION)
 
@@ -1229,7 +1301,7 @@ function to_openapi(
         name = get_name(reserve),
         available = get_available(reserve),
         time_frame = get_time_frame(reserve),
-        requirement = get_requirement(reserve, SU),
+        requirement = get_requirement(reserve, SU) * get_base_power(refs),
         variable = convert_reserve_variable_to_openapi(reserve),
         sustained_time = get_sustained_time(reserve),
         max_output_fraction = get_max_output_fraction(reserve),
@@ -1244,19 +1316,7 @@ function to_openapi(
     refs::OpenAPIRefs,
     ::NaturalUnit,
 ) where {T <: ReserveDirection, U}
-    return PO.OnlineReserve(;
-        id = component_id(refs, reserve),
-        name = get_name(reserve),
-        available = get_available(reserve),
-        time_frame = get_time_frame(reserve),
-        requirement = get_requirement(reserve, SU) * get_base_power(refs),
-        variable = convert_reserve_variable_to_openapi(reserve),
-        sustained_time = get_sustained_time(reserve),
-        max_output_fraction = get_max_output_fraction(reserve),
-        max_participation_factor = get_max_participation_factor(reserve),
-        deployed_fraction = get_deployed_fraction(reserve),
-        reserve_direction = RESERVE_DIRECTION_TO_STRING[T],
-    )
+    return to_openapi(reserve, refs, DU)
 end
 
 function to_openapi(
@@ -1269,7 +1329,7 @@ function to_openapi(
         name = get_name(reserve),
         available = get_available(reserve),
         time_frame = get_time_frame(reserve),
-        requirement = get_requirement(reserve, SU),
+        requirement = get_requirement(reserve, SU) * get_base_power(refs),
         variable = convert_reserve_variable_to_openapi(reserve),
         sustained_time = get_sustained_time(reserve),
         max_output_fraction = get_max_output_fraction(reserve),
@@ -1283,18 +1343,7 @@ function to_openapi(
     refs::OpenAPIRefs,
     ::NaturalUnit,
 ) where {U}
-    return PO.OfflineReserve(;
-        id = component_id(refs, reserve),
-        name = get_name(reserve),
-        available = get_available(reserve),
-        time_frame = get_time_frame(reserve),
-        requirement = get_requirement(reserve, SU) * get_base_power(refs),
-        variable = convert_reserve_variable_to_openapi(reserve),
-        sustained_time = get_sustained_time(reserve),
-        max_output_fraction = get_max_output_fraction(reserve),
-        max_participation_factor = get_max_participation_factor(reserve),
-        deployed_fraction = get_deployed_fraction(reserve),
-    )
+    return to_openapi(reserve, refs, DU)
 end
 
 function to_openapi(
@@ -1306,7 +1355,7 @@ function to_openapi(
         id = component_id(refs, reserve),
         name = get_name(reserve),
         available = get_available(reserve),
-        requirement = get_requirement(reserve, SU),
+        requirement = get_requirement(reserve, SU) * get_base_power(refs),
         reserve_direction = RESERVE_DIRECTION_TO_STRING[T],
     )
 end
@@ -1316,11 +1365,5 @@ function to_openapi(
     refs::OpenAPIRefs,
     ::NaturalUnit,
 ) where {T <: ReserveDirection}
-    return PO.GroupReserve(;
-        id = component_id(refs, reserve),
-        name = get_name(reserve),
-        available = get_available(reserve),
-        requirement = get_requirement(reserve, SU) * get_base_power(refs),
-        reserve_direction = RESERVE_DIRECTION_TO_STRING[T],
-    )
+    return to_openapi(reserve, refs, DU)
 end

--- a/src/openapi/file_io.jl
+++ b/src/openapi/file_io.jl
@@ -48,9 +48,26 @@ $(TYPEDSIGNATURES)
 
 Write `sys` to `dir` as a `system.json` + `time_series.h5` bundle.
 
-`power_units` is passed through to [`to_openapi`](@ref): `:component_base` (default) writes each
-component's values on its own base, PSY's native convention, and `:natural_units` converts to
-physical units instead.
+# The `power_units` keyword
+
+`power_units` is passed through to [`to_openapi`](@ref) and chooses the basis every value in
+the document is written on:
+
+  - `:component_base` (default) writes each component's values on its own `base_power`, the
+    convention PSY stores natively. Nothing is converted, so the numbers on disk are the
+    numbers in memory and the round trip is exact.
+  - `:natural_units` converts on the way out to physical units — MW, MVAr, MVA — which is
+    what a reader outside Sienna generally wants.
+
+Both are complete: any `System` exports either way, whatever it was built from.
+
+Note the asymmetry between writing and reading. **A write is uniform**: PSY does not track a
+per-component basis, so the choice made here stamps every power-bearing blob in the document
+with the same value. **A read is per component**: each blob is converted according to the
+`power_units` it carries, so a document written by another client with a mixed basis is read
+back correctly, and a blob missing the field is an error rather than a guess (see
+`from_openapi`). Writing then reading therefore returns what you exported regardless of which
+basis you chose.
 
 The sidecar is written only when `sys` actually carries time series; otherwise the document's
 `time_series_storage_file` is null and no HDF5 file is created.

--- a/src/openapi/file_io.jl
+++ b/src/openapi/file_io.jl
@@ -48,7 +48,7 @@ $(TYPEDSIGNATURES)
 
 Write `sys` to `dir` as a `system.json` + `time_series.h5` bundle.
 
-`unit_system` is passed through to [`to_openapi`](@ref): `:device_base` (default) writes each
+`power_units` is passed through to [`to_openapi`](@ref): `:component_base` (default) writes each
 component's values on its own base, PSY's native convention, and `:natural_units` converts to
 physical units instead.
 
@@ -58,14 +58,14 @@ The sidecar is written only when `sys` actually carries time series; otherwise t
 function to_file(
     sys::System,
     dir::AbstractString;
-    unit_system::Symbol = :device_base,
+    power_units::Symbol = :component_base,
     force::Bool = false,
     pretty::Bool = false,
 )
     _prepare_bundle_dir(dir, force)
     storage_path = _sidecar_path_for_write(sys, dir)
     doc =
-        to_openapi(sys; unit_system = unit_system, time_series_storage_path = storage_path)
+        to_openapi(sys; power_units = power_units, time_series_storage_path = storage_path)
     PD.write_document(
         doc,
         joinpath(dir, SYSTEM_DOCUMENT_FILE);

--- a/src/openapi/import_document.jl
+++ b/src/openapi/import_document.jl
@@ -234,15 +234,6 @@ for (_po_type, psy_type, _key, _addable) in DOCUMENT_PLAN
     @eval is_document_exportable(::$psy_type) = true
 end
 
-function _unit_val(unit_system::AbstractString)
-    unit_system == "NATURAL_UNITS" && return NU
-    unit_system == "COMPONENT_BASE" && return DU
-    error(
-        "from_openapi(System, doc): unmapped unit_system \"$unit_system\" — expected " *
-        "NATURAL_UNITS or COMPONENT_BASE",
-    )
-end
-
 """Error, naming every offending type, when the document declares a component type with
 no registered `from_openapi` converter — psy6 forbids silently skipping unconverted
 types."""
@@ -325,8 +316,9 @@ end
 # through `SupplementalAttributeAssociation.attribute_type` and its type registry, so the
 # type is known here and Julia's dispatch replaces what used to be a parallel string table
 # in this file. None of these embed unit-converted fields, so unlike the per-component
-# converters they take no `Val{unit_system}`. Every method takes `refs` so the attribute
-# walk (`load_supplemental_attribute_associations!` in sqlite_load.jl) can call one
+# converters they take no `::DeviceBaseUnit`/`::NaturalUnit` marker argument. Every method
+# takes `refs` so the attribute walk (`load_supplemental_attribute_associations!` in
+# sqlite_load.jl) can call one
 # signature uniformly; only the three `Outage` types read it, to resolve document-id
 # `monitored_components` into the UUIDs PSY stores.
 
@@ -399,7 +391,7 @@ function from_openapi(po::PO.CombinedCycleFractional, ::OpenAPIRefs)
 end
 
 # `GeographicInfo` and `DataSource` are InfrastructureSystems types and their converters live
-# there, taking no `OpenAPIRefs` — that registry carries the document's `unit_system` and
+# there, taking no `OpenAPIRefs` — that registry carries the System's computational
 # `base_power`, which IS has no notion of. These two methods only reconcile the arity the
 # attribute walk calls with, so IS stays the single owner of the field mapping.
 from_openapi(po::PC.GeographicInfo, ::OpenAPIRefs) = from_openapi(po)
@@ -487,9 +479,9 @@ _apply_metadata_field!(setter, sys::System, value) = setter(sys, value)
 """
 Carry the document's system-level metadata onto `sys`.
 
-`base_power` and `unit_system` are consumed by the caller when constructing the `System`, so
-only `name` and `description` are applied here. `frequency` is deliberately not applied:
-`System`'s own default stands, and a document that omits it must not silently reset it.
+Only `name` and `description` are applied here (`base_power` is a `from_openapi` kwarg, not a
+document field). `frequency` is deliberately not applied: `System`'s own default stands, and a
+document that omits it must not silently reset it.
 """
 function _apply_document_metadata!(sys::System, doc::PD.SystemDocument)
     _apply_metadata_field!(set_name!, sys, PD.get_name(doc))
@@ -526,6 +518,10 @@ type, scaling-factor multiplier, or supplemental `attribute_type` (see
 [`load_supplemental_attribute_associations!`](@ref)), a document that declares time series
 but supplies no `time_series_storage_path`, and any drift this validation catches.
 
+`base_power` is the `System`'s own computational base (MVA); every component blob is
+self-interpretable via its own `power_units`/`base_power`. It defaults to the same `100.0`
+`System`'s own constructor defaults to.
+
 `system_kwargs` pass straight through to the fresh `System(base_power; system_kwargs...)`
 this builds (e.g. `time_series_in_memory`, `time_series_directory`, `time_series_read_only`,
 `runchecks` — `System`'s own `SYSTEM_KWARGS`); an unsupported key still errors, from
@@ -534,13 +530,10 @@ this builds (e.g. `time_series_in_memory`, `time_series_directory`, `time_series
 function from_openapi(
     ::Type{System},
     doc::PD.SystemDocument;
+    base_power::Float64 = 100.0,
     time_series_storage_path = nothing,
     system_kwargs...,
 )
-    base_power = PD.get_base_power(doc)
-    unit_system = PD.get_unit_system(doc)
-    unit_val = _unit_val(unit_system)
-
     _check_no_unconverted_component_types(doc.components)
 
     sys = _system_with_sidecar(base_power, doc, time_series_storage_path; system_kwargs...)
@@ -551,7 +544,7 @@ function from_openapi(
     else
         sys.data.time_series_manager.data_store
     end
-    refs = OpenAPIRefs(unit_system, base_power; store = store)
+    refs = OpenAPIRefs(base_power; store = store)
 
     # Bound for the whole component pass: a `MarketBidTimeSeriesCost`/time-series-backed
     # `FuelCurve` reaches `convert_cost` several frames below a GENERATED per-device
@@ -564,7 +557,7 @@ function from_openapi(
     _with_import_store(store) do
         for (_po_type, psy_type, key, addable) in DOCUMENT_PLAN
             for po in PD.get_components(doc, key)
-                component = from_openapi(po, refs, unit_val)
+                component = from_openapi(po, refs)
                 extras = get(doc.ext, Int(po.id), nothing)
                 isnothing(extras) || _merge_doc_ext!(component, extras)
                 if addable

--- a/src/openapi/import_document.jl
+++ b/src/openapi/import_document.jl
@@ -179,6 +179,21 @@ const DOCUMENT_PLAN = [
     ),
     # After the reserves it regulates; membership arrives as service_associations rows.
     (po_type = PO.AGC, psy_type = AGC, key = "AGC", addable = true),
+    # Hub membership (member buses) arrives as trading_hub_associations rows, the same
+    # shape as service membership above.
+    (po_type = PO.TradingHub, psy_type = TradingHub, key = "TradingHub", addable = true),
+    # After every settlement-point candidate (Area, LoadZone, ACBus) and TradingHub: a
+    # VirtualParticipant's `settlement_point` and hub membership both resolve by reference.
+    (
+        po_type = PO.VirtualParticipant, psy_type = VirtualParticipant,
+        key = "VirtualParticipant", addable = true,
+    ),
+    # After every Topology candidate (Area, LoadZone, ACBus, DCBus, Arc) and TradingHub: a
+    # PointToPointBid's `from`/`to` terminals resolve by reference to either.
+    (
+        po_type = PO.PointToPointBid, psy_type = PointToPointBid,
+        key = "PointToPointBid", addable = true,
+    ),
 ]
 
 """
@@ -308,6 +323,35 @@ function _attach_service_membership!(entity, service, ::System)
     error(
         "from_openapi(System, doc): unmapped service membership pair — entity=" *
         "$(typeof(entity)) service=$(typeof(service))",
+    )
+end
+
+# ── trading hub membership dispatch ─────────────────────────────────────────────
+# Hub membership arrives as rows in the document's own `trading_hub_associations` table
+# rather than an inline array on `TradingHub`, so each `entity_id` is attached by type here.
+
+"""Attach a member bus to `hub`."""
+function _attach_trading_hub_membership!(entity::ACBus, hub::TradingHub, sys::System)
+    throw_if_not_attached(entity, sys)
+    throw_if_not_attached(hub, sys)
+    add_hub_bus_internal!(hub, entity)
+    return nothing
+end
+
+"""Record `entity` as settling at `hub`."""
+function _attach_trading_hub_membership!(
+    entity::VirtualParticipant,
+    hub::TradingHub,
+    ::System,
+)
+    add_trading_hub_internal!(entity, hub)
+    return nothing
+end
+
+function _attach_trading_hub_membership!(entity, hub, ::System)
+    error(
+        "from_openapi(System, doc): unmapped trading hub membership pair — entity=" *
+        "$(typeof(entity)) hub=$(typeof(hub))",
     )
 end
 

--- a/src/openapi/import_document.jl
+++ b/src/openapi/import_document.jl
@@ -438,8 +438,8 @@ end
 # there, taking no `OpenAPIRefs` — that registry carries the System's computational
 # `base_power`, which IS has no notion of. These two methods only reconcile the arity the
 # attribute walk calls with, so IS stays the single owner of the field mapping.
-from_openapi(po::PC.GeographicInfo, ::OpenAPIRefs) = from_openapi(po)
-from_openapi(po::PC.DataSource, ::OpenAPIRefs) = from_openapi(po)
+from_openapi(po::IC.GeographicInfo, ::OpenAPIRefs) = from_openapi(po)
+from_openapi(po::IC.DataSource, ::OpenAPIRefs) = from_openapi(po)
 
 """`table_number`/`transformer_winding`/`transformer_control_mode` carry no unit-bearing
 fields — a row number and two enum discriminators. `impedance_correction_curve` reuses
@@ -779,7 +779,7 @@ _ts_row_identity(row) = (
 _ts_feature_values(::Nothing) = nothing
 _ts_feature_values(features::AbstractDict) =
     Dict{String, Any}(String(k) => _ts_feature_value(v) for (k, v) in features)
-_ts_feature_value(v::PowerTimeSeriesOpenAPIModels.TimeSeriesFeatureValue) = v.value
+_ts_feature_value(v::InfrastructureTimeSeriesOpenAPIModels.TimeSeriesFeatureValue) = v.value
 _ts_feature_value(v) = v
 
 """Human-readable label for a time series association identity, for error messages."""

--- a/src/openapi/import_document.jl
+++ b/src/openapi/import_document.jl
@@ -771,13 +771,23 @@ end
 
 """The `(owner_id, owner_category, time_series_type, name, resolution, interval, features)`
 named tuple a time series association row is matched by — the same identity the store's own
-uniqueness index keys on. See [`_validate_time_series_associations!`](@ref)."""
+uniqueness index keys on. See [`_validate_time_series_associations!`](@ref).
+
+Features are compared by value: the wire type wraps each value in a mutable
+`TimeSeriesFeatureValue`, which compares by object identity, so a document row and its store
+counterpart would never match on the wrappers themselves."""
 _ts_row_identity(row) = (
     owner_id = row.owner_id, owner_category = row.owner_category,
     time_series_type = row.time_series_type, name = row.name,
     resolution = _ts_field(row, :resolution), interval = _ts_field(row, :interval),
-    features = row.features,
+    features = _ts_feature_values(row.features),
 )
+
+_ts_feature_values(::Nothing) = nothing
+_ts_feature_values(features::AbstractDict) =
+    Dict{String, Any}(String(k) => _ts_feature_value(v) for (k, v) in features)
+_ts_feature_value(v::PowerTimeSeriesOpenAPIModels.TimeSeriesFeatureValue) = v.value
+_ts_feature_value(v) = v
 
 """Human-readable label for a time series association identity, for error messages."""
 function _ts_row_label(identity)

--- a/src/openapi/import_generated_types.jl
+++ b/src/openapi/import_generated_types.jl
@@ -19,39 +19,39 @@
 # last bits of every converted value.
 
 """Rebuild a `MinMax` from its PO struct; `nothing` in means `nothing` out."""
-@inline _minmax_from_po(x::PC.MinMax) = (min = x.min, max = x.max)
+@inline _minmax_from_po(x::IC.MinMax) = (min = x.min, max = x.max)
 @inline _minmax_from_po(::Nothing) = nothing
-@inline _minmax_from_po(x::PC.MinMax, op::F, base) where {F} =
+@inline _minmax_from_po(x::IC.MinMax, op::F, base) where {F} =
     (min = op(x.min, base), max = op(x.max, base))
 @inline _minmax_from_po(::Nothing, ::Any, ::Any) = nothing
 
 """Rebuild an `UpDown` from its PO struct; `nothing` in means `nothing` out."""
-@inline _updown_from_po(x::PC.UpDown) = (up = x.up, down = x.down)
+@inline _updown_from_po(x::IC.UpDown) = (up = x.up, down = x.down)
 @inline _updown_from_po(::Nothing) = nothing
-@inline _updown_from_po(x::PC.UpDown, op::F, base) where {F} =
+@inline _updown_from_po(x::IC.UpDown, op::F, base) where {F} =
     (up = op(x.up, base), down = op(x.down, base))
 @inline _updown_from_po(::Nothing, ::Any, ::Any) = nothing
 
 """Rebuild a `FromTo` from its PO struct; `nothing` in means `nothing` out."""
-@inline _fromto_from_po(x::PC.FromTo) = (from = x.from, to = x.to)
+@inline _fromto_from_po(x::IC.FromTo) = (from = x.from, to = x.to)
 @inline _fromto_from_po(::Nothing) = nothing
-@inline _fromto_from_po(x::PC.FromTo, op::F, base) where {F} =
+@inline _fromto_from_po(x::IC.FromTo, op::F, base) where {F} =
     (from = op(x.from, base), to = op(x.to, base))
 @inline _fromto_from_po(::Nothing, ::Any, ::Any) = nothing
 
 """Rebuild an `InOut` from its PO struct; `nothing` in means `nothing` out."""
-@inline _inout_from_po(x::PC.InOut) = (in = x.in, out = x.out)
+@inline _inout_from_po(x::IC.InOut) = (in = x.in, out = x.out)
 @inline _inout_from_po(::Nothing) = nothing
-@inline _inout_from_po(x::PC.InOut, op::F, base) where {F} =
+@inline _inout_from_po(x::IC.InOut, op::F, base) where {F} =
     (in = op(x.in, base), out = op(x.out, base))
 @inline _inout_from_po(::Nothing, ::Any, ::Any) = nothing
 
-"""Rebuild a `FromTo_ToFrom` from its PO struct (`PC.FromToToFrom` — the schema drops the
+"""Rebuild a `FromTo_ToFrom` from its PO struct (`IC.FromToToFrom` — the schema drops the
 underscore PSY's alias keeps); `nothing` in means `nothing` out."""
-@inline _fromto_tofrom_from_po(x::PC.FromToToFrom) =
+@inline _fromto_tofrom_from_po(x::IC.FromToToFrom) =
     (from_to = x.from_to, to_from = x.to_from)
 @inline _fromto_tofrom_from_po(::Nothing) = nothing
-@inline _fromto_tofrom_from_po(x::PC.FromToToFrom, op::F, base) where {F} =
+@inline _fromto_tofrom_from_po(x::IC.FromToToFrom, op::F, base) where {F} =
     (from_to = op(x.from_to, base), to_from = op(x.to_from, base))
 @inline _fromto_tofrom_from_po(::Nothing, ::Any, ::Any) = nothing
 

--- a/src/openapi/import_handwritten.jl
+++ b/src/openapi/import_handwritten.jl
@@ -928,7 +928,7 @@ end
 _unwrap_oneof(x::OpenAPI.OneOfAPIModel) = _unwrap_oneof(x.value)
 _unwrap_oneof(x) = x
 
-_linear_curve_from_function_data(fd::PC.LinearFunctionData) =
+_linear_curve_from_function_data(fd::IC.LinearFunctionData) =
     LinearCurve(fd.proportional_term, fd.constant_term)
 _linear_curve_from_function_data(fd) =
     error("unmapped TwoTerminalLoss FunctionData variant: $(typeof(fd))")

--- a/src/openapi/import_handwritten.jl
+++ b/src/openapi/import_handwritten.jl
@@ -22,7 +22,7 @@ for T in (
     :Area, :LoadZone, :TransmissionInterface, :Line, :MonitoredLine, :GenericArcImpedance,
     :DiscreteControlledACBranch, :TransformerCircuit, :EnergyReservoirStorage,
     :TwoTerminalGenericHVDCLine, :TwoTerminalLCCLine, :TwoTerminalVSCLine, :Source,
-    :InterconnectingConverter, :HybridSystem, :FACTSControlDevice,
+    :InterconnectingConverter, :HybridSystem, :FACTSControlDevice, :TModelHVDCLine,
 )
     @eval function from_openapi(po::PO.$T, refs::OpenAPIRefs)
         return from_openapi(
@@ -35,7 +35,7 @@ end
 
 for T in (
     :Arc, :TwoWindingTransformer, :ThreeWindingTransformer, :FixedAdmittance,
-    :SwitchedAdmittance, :HydroReservoir, :TModelHVDCLine, :OnlineReserve, :OfflineReserve,
+    :SwitchedAdmittance, :HydroReservoir, :OnlineReserve, :OfflineReserve,
     :GroupReserve,
 )
     @eval from_openapi(po::PO.$T, refs::OpenAPIRefs) = from_openapi(po, refs, DU)

--- a/src/openapi/import_handwritten.jl
+++ b/src/openapi/import_handwritten.jl
@@ -2,7 +2,7 @@
 # through the generator first; what blocks each one:
 #
 #   Arc                          abstract `Bus` field type; PO names `from_id`/`to_id` differ
-#   Area, LoadZone               peak power is schema-fixed-natural, not unit-system-dependent
+#   Area, LoadZone               no `openapi_type` annotation in the descriptor
 #   TransmissionInterface        `direction_mapping::Dict{String, Int}` unclassifiable
 #   Line                         `r`/`x`/`b`/`g` need a `base_voltage` the struct does not carry
 #   TwoTerminalGenericHVDCLine   `loss` is a Union of two curve types, not `Union{Nothing, X}`
@@ -13,6 +13,33 @@
 #   HydroReservoir               `Vector{HydroUnit}`/`Vector{Device}` fields; fraction conversion
 #   EnergyReservoirStorage       `efficiency` spelled out instead of the `InOut` alias
 #   Online/Offline/GroupReserve  parametric structs, which the generator rejects outright
+#
+# A hand-written type with a `power_units` member joins the first loop below; every other
+# hand-written type joins the second. The generated types get the analogous 2-arg selector
+# from the generator itself (`compute_openapi_converter!` in generate_structs.jl).
+
+for T in (
+    :Area, :LoadZone, :TransmissionInterface, :Line, :MonitoredLine, :GenericArcImpedance,
+    :DiscreteControlledACBranch, :TransformerCircuit, :EnergyReservoirStorage,
+    :TwoTerminalGenericHVDCLine, :TwoTerminalLCCLine, :TwoTerminalVSCLine, :Source,
+    :InterconnectingConverter, :HybridSystem, :FACTSControlDevice,
+)
+    @eval function from_openapi(po::PO.$T, refs::OpenAPIRefs)
+        return from_openapi(
+            po,
+            refs,
+            _power_units_marker($(string(T)), po.id, po.power_units),
+        )
+    end
+end
+
+for T in (
+    :Arc, :TwoWindingTransformer, :ThreeWindingTransformer, :FixedAdmittance,
+    :SwitchedAdmittance, :HydroReservoir, :TModelHVDCLine, :OnlineReserve, :OfflineReserve,
+    :GroupReserve,
+)
+    @eval from_openapi(po::PO.$T, refs::OpenAPIRefs) = from_openapi(po, refs, DU)
+end
 
 """Named tuple of `(min, max)` from a PO `MinMax`-shaped struct."""
 _minmax(m) = (min = Float64(m.min), max = Float64(m.max))
@@ -42,15 +69,6 @@ _opt_updown(m) = (up = Float64(m.up), down = Float64(m.down))
 """`v` divided by `base`, or `nothing` when absent."""
 _scale_optional(::Nothing, base) = nothing
 _scale_optional(v, base) = Float64(v) / base
-
-"""Resolve a component's own per-unitization `base_power` from the document, falling back to
-the document-level system base when the producer omits it. `Area`/`LoadZone`/
-`TransmissionInterface`/`Line`/`TwoTerminalGenericHVDCLine` each carry their own `base_power`
-and it is schema-`required` going forward, but a producer may still omit it; for these five
-types the system base is numerically identical by construction. Do not weaken this to a
-general nothing-skip guard elsewhere."""
-_resolve_base_power(refs::OpenAPIRefs, ::Nothing) = get_base_power(refs)
-_resolve_base_power(::OpenAPIRefs, base_power) = Float64(base_power)
 
 """Reservoir level fields arrive absolute (per `level_data_type`'s units); PSY wants them
 as a fraction of `storage_level_limits.max`. Semantic, not a unit conversion — same in
@@ -122,54 +140,60 @@ function from_openapi(po::PO.Arc, refs::OpenAPIRefs, ::NaturalUnit)
 end
 
 # ── Area / LoadZone ─────────────────────────────────────────────────────────────
-# SiennaSchemas Operations/Topology/{Area,LoadZone}.json declare `peak_active_power`
-# (x-unit MW) / `peak_reactive_power` (x-unit MVAr) as FIXED natural units — the document
-# carries them in MW/MVAr regardless of its declared unit_system, exactly like a reserve's
-# `requirement` (x-unit MW). PSY's descriptor marks both `needs_conversion: true,
-# conversion_unit: ":mva"`, so the divisor is `get_base_power(refs)` (the document-level
-# system base) in BOTH unit-system methods — the schema unit is fixed, not document-unit-
-# system-dependent, which is what still keeps this hand-written: a generated converter would
-# divide only under `NATURAL_UNITS`, not both. `Area.load_response` (x-unit MW/Hz) has no
-# `conversion_unit` in the PSY descriptor and passes through unconverted in both methods.
-# The new `base_power` kwarg reads the document's own field via `_resolve_base_power`,
-# falling back to `get_base_power(refs)` when a producer omits it — same fallback the
-# pre-existing conversion arithmetic already used.
+# `peak_active_power`/`peak_reactive_power` are discriminated by the blob's own `power_units`,
+# like every other power-family field: COMPONENT_BASE passes through pu, NATURAL_UNITS divides
+# by the blob's own (required) `base_power` — `_require_base_power` errors naming the type/id
+# when a blob omits it. `Area.load_response` (x-unit MW/Hz) has no `conversion_unit` in the PSY
+# descriptor and passes through unconverted in both methods. `direction_mapping::Dict{String,
+# Int}` (TransmissionInterface, below) is unclassifiable to the generator, which is what keeps
+# these hand-written rather than generated.
 
 function from_openapi(po::PO.Area, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return Area(;
         name = po.name,
-        peak_active_power = po.peak_active_power / get_base_power(refs),
-        peak_reactive_power = po.peak_reactive_power / get_base_power(refs),
+        peak_active_power = po.peak_active_power,
+        peak_reactive_power = po.peak_reactive_power,
         load_response = po.load_response,
-        base_power = _resolve_base_power(refs, po.base_power),
+        base_power = _require_base_power("Area", po.id, po.base_power),
     )
 end
 
 function from_openapi(po::PO.Area, refs::OpenAPIRefs, ::NaturalUnit)
-    return from_openapi(po, refs, DU)
+    bp = _require_base_power("Area", po.id, po.base_power)
+    return Area(;
+        name = po.name,
+        peak_active_power = po.peak_active_power / bp,
+        peak_reactive_power = po.peak_reactive_power / bp,
+        load_response = po.load_response,
+        base_power = bp,
+    )
 end
 
 function from_openapi(po::PO.LoadZone, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return LoadZone(;
         name = po.name,
-        peak_active_power = po.peak_active_power / get_base_power(refs),
-        peak_reactive_power = po.peak_reactive_power / get_base_power(refs),
-        base_power = _resolve_base_power(refs, po.base_power),
+        peak_active_power = po.peak_active_power,
+        peak_reactive_power = po.peak_reactive_power,
+        base_power = _require_base_power("LoadZone", po.id, po.base_power),
     )
 end
 
 function from_openapi(po::PO.LoadZone, refs::OpenAPIRefs, ::NaturalUnit)
-    return from_openapi(po, refs, DU)
+    bp = _require_base_power("LoadZone", po.id, po.base_power)
+    return LoadZone(;
+        name = po.name,
+        peak_active_power = po.peak_active_power / bp,
+        peak_reactive_power = po.peak_reactive_power / bp,
+        base_power = bp,
+    )
 end
 
 # ── TransmissionInterface ───────────────────────────────────────────────────────
-# SiennaSchemas Operations/Service/TransmissionInterface.json declares
-# `active_power_flow_limits` (x-unit MW) as FIXED natural units — same shape as Area/
-# LoadZone's peak fields above, divided by `get_base_power(refs)` in BOTH unit-system
-# methods. `direction_mapping::Dict{String, Int}` is unclassifiable to the generator
-# (not scalar/compound/reference/enum), which is what keeps this hand-written.
-# `violation_penalty` has no `conversion_unit` and passes through unconverted in both.
-# The new `base_power` kwarg mirrors Area/LoadZone's `_resolve_base_power` fallback.
+# `active_power_flow_limits` (x-unit MW) is discriminated by `power_units` like every other
+# power-family field, mirroring Area/LoadZone's peak fields above. `direction_mapping::
+# Dict{String, Int}` is unclassifiable to the generator (not scalar/compound/reference/enum),
+# which is what keeps this hand-written. `violation_penalty` has no `conversion_unit` and
+# passes through unconverted in both methods.
 
 function from_openapi(
     po::PO.TransmissionInterface,
@@ -179,13 +203,10 @@ function from_openapi(
     return TransmissionInterface(;
         name = po.name,
         available = po.available,
-        active_power_flow_limits = _minmax_du(
-            po.active_power_flow_limits,
-            get_base_power(refs),
-        ),
+        active_power_flow_limits = _minmax(po.active_power_flow_limits),
         violation_penalty = po.violation_penalty,
         direction_mapping = po.direction_mapping,
-        base_power = _resolve_base_power(refs, po.base_power),
+        base_power = _require_base_power("TransmissionInterface", po.id, po.base_power),
     )
 end
 
@@ -194,18 +215,25 @@ function from_openapi(
     refs::OpenAPIRefs,
     ::NaturalUnit,
 )
-    return from_openapi(po, refs, DU)
+    bp = _require_base_power("TransmissionInterface", po.id, po.base_power)
+    return TransmissionInterface(;
+        name = po.name,
+        available = po.available,
+        active_power_flow_limits = _minmax_du(po.active_power_flow_limits, bp),
+        violation_penalty = po.violation_penalty,
+        direction_mapping = po.direction_mapping,
+        base_power = bp,
+    )
 end
 
 # ── Line ────────────────────────────────────────────────────────────────────────
 # `r`/`x`/`b`/`g` are pu on system base in the document already (identity in both methods,
 # matching every other schema-declared-pu field) — they need `base_voltage` for an
 # impedance/admittance conversion, which `Line` does not carry (`TransformerCircuit` is the
-# pattern for a device that does), and that is what keeps this hand-written now.
+# pattern for a device that does), and that is what keeps this hand-written.
 # `rating`/`rating_b`/`rating_c`/`active_power_flow`/`reactive_power_flow` are natural MVA/MW
-# divided by the line's own `base_power`, now a real PSY field — only under `NaturalUnit`;
-# `_resolve_base_power` falls back to `get_base_power(refs)` when a producer omits the field,
-# same as Area/LoadZone/TransmissionInterface above.
+# divided by the line's own (required) `base_power` only under `NaturalUnit`; `_require_base_power`
+# errors, naming the type/id, when a blob omits it.
 
 function from_openapi(po::PO.Line, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return Line(;
@@ -222,12 +250,12 @@ function from_openapi(po::PO.Line, refs::OpenAPIRefs, ::DeviceBaseUnit)
         rating_b = po.rating_b,
         rating_c = po.rating_c,
         g = _fromto(po.g),
-        base_power = _resolve_base_power(refs, po.base_power),
+        base_power = _require_base_power("Line", po.id, po.base_power),
     )
 end
 
 function from_openapi(po::PO.Line, refs::OpenAPIRefs, ::NaturalUnit)
-    sbp = _resolve_base_power(refs, po.base_power)
+    sbp = _require_base_power("Line", po.id, po.base_power)
     return Line(;
         name = po.name,
         available = po.available,
@@ -249,9 +277,9 @@ end
 # ── MonitoredLine ───────────────────────────────────────────────────────────────
 # Same posture as `Line` directly above, field for field, plus `flow_limits`: `r`/`x`/`b`/`g`
 # are already pu on the line's base and pass through in both methods (no `base_voltage` to
-# build Zbase from), the MVA/MW fields divide by `_resolve_base_power`, and `angle_limits` is
-# radians with no conversion. `flow_limits` is the one field `Line` does not have — a
-# `FromTo_ToFrom` of natural MVA, so it scales with the same base as `rating`.
+# build Zbase from), the MVA/MW fields divide by `_require_base_power`'s result, and
+# `angle_limits` is radians with no conversion. `flow_limits` is the one field `Line` does not
+# have — a `FromTo_ToFrom` of natural MVA, so it scales with the same base as `rating`.
 
 _fromto_toframe(m) = (from_to = Float64(m.from_to), to_from = Float64(m.to_from))
 _fromto_toframe_du(m, base) =
@@ -273,12 +301,12 @@ function from_openapi(po::PO.MonitoredLine, refs::OpenAPIRefs, ::DeviceBaseUnit)
         rating_b = po.rating_b,
         rating_c = po.rating_c,
         g = _fromto(po.g),
-        base_power = _resolve_base_power(refs, po.base_power),
+        base_power = _require_base_power("MonitoredLine", po.id, po.base_power),
     )
 end
 
 function from_openapi(po::PO.MonitoredLine, refs::OpenAPIRefs, ::NaturalUnit)
-    sbp = _resolve_base_power(refs, po.base_power)
+    sbp = _require_base_power("MonitoredLine", po.id, po.base_power)
     return MonitoredLine(;
         name = po.name,
         available = po.available,
@@ -326,13 +354,13 @@ function from_openapi(po::PO.GenericArcImpedance, refs::OpenAPIRefs, ::DeviceBas
         arc = refs[po.arc],
         r = po.r,
         x = po.x,
-        base_power = _resolve_base_power(refs, po.base_power),
+        base_power = _require_base_power("GenericArcImpedance", po.id, po.base_power),
     )
 end
 
 function from_openapi(po::PO.GenericArcImpedance, refs::OpenAPIRefs, ::NaturalUnit)
     _check_generic_arc_param_units(po)
-    sbp = _resolve_base_power(refs, po.base_power)
+    sbp = _require_base_power("GenericArcImpedance", po.id, po.base_power)
     return GenericArcImpedance(;
         name = po.name,
         available = po.available,
@@ -350,13 +378,12 @@ end
 # Same posture as `Line`: the PSY descriptor tags `r`/`x` `needs_conversion`/`:ohm` for the
 # general SU/DU/NU getter/setter machinery, but neither the struct nor the document carries a
 # companion `base_voltage` to compute Zbase from — the PO field's own docstring says `r`/`x`
-# are already "per-unit on base_power" — so, like `Line`, both pass through unconverted here
-# regardless of unit_system. `base_power` on this type is documented as "System base power ...
-# recorded per component in lieu of a system-level table" — the same schema pattern as
-# `Line`/`Area`/`LoadZone`/`TwoTerminalGenericHVDCLine`, not a genuine per-device rating — so
-# `active_power_flow`/`reactive_power_flow`/`rating` divide by `_resolve_base_power`
-# (falling back to the document system base if a producer omits the field) exactly like Line,
-# rather than trusting `po.base_power` blindly.
+# are already "per-unit on base_power" — so, like `Line`, both pass through unconverted in
+# both methods. `base_power` on this type is documented as "System base power ... recorded per
+# component in lieu of a system-level table" — the same schema pattern as `Line`/`Area`/
+# `LoadZone`/`TwoTerminalGenericHVDCLine`, not a genuine per-device rating — so
+# `active_power_flow`/`reactive_power_flow`/`rating` divide by `_require_base_power`'s result
+# exactly like Line.
 
 function from_openapi(
     po::PO.DiscreteControlledACBranch,
@@ -375,7 +402,11 @@ function from_openapi(
         discrete_branch_type = DiscreteControlledBranchType(po.discrete_branch_type),
         branch_status = DiscreteControlledBranchStatus(po.branch_status),
         normal_branch_status = DiscreteControlledBranchStatus(po.normal_branch_status),
-        base_power = _resolve_base_power(refs, po.base_power),
+        base_power = _require_base_power(
+            "DiscreteControlledACBranch",
+            po.id,
+            po.base_power,
+        ),
     )
 end
 
@@ -384,7 +415,7 @@ function from_openapi(
     refs::OpenAPIRefs,
     ::NaturalUnit,
 )
-    bp = _resolve_base_power(refs, po.base_power)
+    bp = _require_base_power("DiscreteControlledACBranch", po.id, po.base_power)
     return DiscreteControlledACBranch(;
         name = po.name,
         available = po.available,
@@ -588,13 +619,13 @@ function from_openapi(
 end
 
 # ── FixedAdmittance ───────────────────────────────────────────────────────────────
-# `Y`'s basis is the per-field `admittance_units` discriminator, independent of the
-# document's own unit_system — same pattern as TwoWindingTransformer.magnetizing_shunt
-# above. A shunt has no device MVA rating of its own, so `ShuntAdmittanceUnitBasis` is
-# `NATURAL_UNITS`/`COMPONENT_MVAR` only. `COMPONENT_MVAR` is MVAr at unity voltage and divides by
-# the document-level `refs.base_power`, the same fallback Area/LoadZone peaks and reserve
-# requirements use, to land on PSY's system-base pu storage. `NATURAL_UNITS` (physical
-# siemens, needing the bus's own `Z_base`) is not implemented, same posture as
+# `Y`'s basis is the per-field `admittance_units` discriminator — same pattern as
+# TwoWindingTransformer.magnetizing_shunt above. A shunt has no device MVA rating of its own,
+# so `ShuntAdmittanceUnitBasis` is `NATURAL_UNITS`/`COMPONENT_MVAR` only. `COMPONENT_MVAR` is
+# MVAr at unity voltage and divides by `refs.base_power` (the System's own computational base),
+# the same anchor reserve requirements use, to land on PSY's system-base pu storage.
+# `NATURAL_UNITS` (physical siemens, needing the bus's own `Z_base`) is not implemented, same
+# posture as
 # `SHUNT_ADMITTANCE_UNITS_IMPLEMENTED` above.
 const FIXED_ADMITTANCE_UNITS_IMPLEMENTED = Set(["COMPONENT_MVAR"])
 
@@ -629,9 +660,9 @@ end
 # ── SwitchedAdmittance ────────────────────────────────────────────────────────────
 # `Y`/`Y_increase` are the same fixed-natural COMPONENT_MVAR-on-system-base quantity as
 # `FixedAdmittance.Y` (device_base.jl's `_DEVICEBASE_INSTANCE_DISPATCHED` lists both
-# `:skip`, identical treatment) — divided by the document's system base regardless of
-# `unit_system`, so the `NaturalUnit` method delegates to `DeviceBaseUnit` exactly like
-# `FixedAdmittance`. `admittance_limits` is a dimensionless multiplier bound on `Y`
+# `:skip`, identical treatment) — divided by `refs.base_power` in both methods, so the
+# `NaturalUnit` method delegates to `DeviceBaseUnit` exactly like `FixedAdmittance`.
+# `admittance_limits` is a dimensionless multiplier bound on `Y`
 # (default `(min=1, max=1)`), not a raw admittance, and `initial_status`/`number_of_steps`
 # are per-block integer counts — none of the three need a unit conversion.
 const SWITCHED_ADMITTANCE_UNITS_IMPLEMENTED = Set(["COMPONENT_MVAR"])
@@ -672,16 +703,14 @@ function from_openapi(
 end
 
 # ── FACTSControlDevice ────────────────────────────────────────────────────────────
-# `base_power` is a first-class field on this type (like `PowerLoad`'s), giving it an explicit
-# per-unitization base instead of silently borrowing the System's. The schema does not yet
-# carry it, so import falls back to the document's own system base via `get_base_power(refs)`;
-# once a document declares one, this reads `po.base_power` directly, same as `PowerLoad`.
-# `max_shunt_current`/`max_reactive_power` (both MVA, declared `SU` on the PSY side) divide by
-# whatever base is resolved. `voltage_setpoint` is pu on system base per PSY's own docstring;
-# only `voltage_setpoint_units == "COMPONENT_BASE"` is implemented — `NATURAL_UNITS` (kV) would
-# need a bus base-voltage conversion no current producer exercises, so it errors loudly rather
-# than guessing. `reactive_power_required` (a dimensionless 0-1 fraction per the PO schema) and
-# `control_mode`/`shunt_control_type` (enums) pass through / map without scaling.
+# `max_shunt_current`/`max_reactive_power` (both MVA, declared `SU` on the PSY side) are
+# discriminated by `power_units` like every other power-family field: COMPONENT_BASE passes
+# through pu, NATURAL_UNITS divides by the blob's own (required) `base_power`. `voltage_setpoint`
+# is pu on system base per PSY's own docstring; only `voltage_setpoint_units == "COMPONENT_BASE"`
+# is implemented — `NATURAL_UNITS` (kV) would need a bus base-voltage conversion no current
+# producer exercises, so it errors loudly rather than guessing. `reactive_power_required` (a
+# dimensionless 0-1 fraction per the PO schema) and `control_mode`/`shunt_control_type` (enums)
+# pass through / map without scaling.
 
 const FACTS_VOLTAGE_SETPOINT_UNITS_IMPLEMENTED = Set(["COMPONENT_BASE"])
 
@@ -694,7 +723,6 @@ _check_facts_voltage_setpoint_units(po) = _check_unit_basis(
 
 function from_openapi(po::PO.FACTSControlDevice, refs::OpenAPIRefs, ::DeviceBaseUnit)
     _check_facts_voltage_setpoint_units(po)
-    base_power = get_base_power(refs)
     return FACTSControlDevice(;
         name = po.name,
         available = po.available,
@@ -705,16 +733,35 @@ function from_openapi(po::PO.FACTSControlDevice, refs::OpenAPIRefs, ::DeviceBase
             FACTSOperationModes(po.control_mode)
         end,
         voltage_setpoint = po.voltage_setpoint,
-        max_shunt_current = po.max_shunt_current / base_power,
-        max_reactive_power = po.max_reactive_power / base_power,
+        max_shunt_current = po.max_shunt_current,
+        max_reactive_power = po.max_reactive_power,
         shunt_control_type = FACTSShuntControlType(po.shunt_control_type),
         regulated_bus_number = po.regulated_bus_number,
         reactive_power_required = po.reactive_power_required,
+        base_power = _require_base_power("FACTSControlDevice", po.id, po.base_power),
     )
 end
 
 function from_openapi(po::PO.FACTSControlDevice, refs::OpenAPIRefs, ::NaturalUnit)
-    return from_openapi(po, refs, DU)
+    _check_facts_voltage_setpoint_units(po)
+    bp = _require_base_power("FACTSControlDevice", po.id, po.base_power)
+    return FACTSControlDevice(;
+        name = po.name,
+        available = po.available,
+        bus = refs[po.bus],
+        control_mode = if isnothing(po.control_mode)
+            nothing
+        else
+            FACTSOperationModes(po.control_mode)
+        end,
+        voltage_setpoint = po.voltage_setpoint,
+        max_shunt_current = po.max_shunt_current / bp,
+        max_reactive_power = po.max_reactive_power / bp,
+        shunt_control_type = FACTSShuntControlType(po.shunt_control_type),
+        regulated_bus_number = po.regulated_bus_number,
+        reactive_power_required = po.reactive_power_required,
+        base_power = bp,
+    )
 end
 
 # ── HydroReservoir ──────────────────────────────────────────────────────────────
@@ -821,7 +868,7 @@ function from_openapi(
         efficiency = _inout(po.efficiency),
         reactive_power = po.reactive_power,
         reactive_power_limits = _opt_minmax(po.reactive_power_limits),
-        base_power = po.base_power,
+        base_power = _require_base_power("EnergyReservoirStorage", po.id, po.base_power),
         operation_cost = convert_cost(po.operation_cost),
         conversion_factor = po.conversion_factor,
         storage_target = po.storage_target,
@@ -838,7 +885,7 @@ function from_openapi(
     ::NaturalUnit,
 )
     _check_energy_units(po)
-    dbp = po.base_power
+    dbp = _require_base_power("EnergyReservoirStorage", po.id, po.base_power)
     return EnergyReservoirStorage(;
         name = po.name,
         available = po.available,
@@ -869,8 +916,8 @@ end
 # ── TwoTerminalGenericHVDCLine ──────────────────────────────────────────────────
 # `loss::Union{LinearCurve, PiecewiseIncrementalCurve}` is a Union of two concrete curve
 # types, not the generator's `Union{Nothing, X}` nullable pattern — unclassifiable, and what
-# keeps this hand-written. The struct gained its own `base_power` field. `_resolve_base_power`
-# falls back to `get_base_power(refs)` when a producer omits the new field, same as Area/LoadZone/
+# keeps this hand-written. The struct's own `base_power` field is required — `_require_base_power`
+# errors, naming the type/id, when a producer omits it, same as Area/LoadZone/
 # TransmissionInterface/Line above. `loss` has no `display_units_arg`/`get_value` machinery
 # on the PSY side (its docstring gives the constant term in physical MW directly) and passes
 # through unconverted in both methods.
@@ -907,7 +954,11 @@ function from_openapi(
         reactive_power_limits_from = _minmax(po.reactive_power_limits_from),
         reactive_power_limits_to = _minmax(po.reactive_power_limits_to),
         loss = _hvdc_loss(po.loss),
-        base_power = _resolve_base_power(refs, po.base_power),
+        base_power = _require_base_power(
+            "TwoTerminalGenericHVDCLine",
+            po.id,
+            po.base_power,
+        ),
     )
 end
 
@@ -916,7 +967,7 @@ function from_openapi(
     refs::OpenAPIRefs,
     ::NaturalUnit,
 )
-    sbp = _resolve_base_power(refs, po.base_power)
+    sbp = _require_base_power("TwoTerminalGenericHVDCLine", po.id, po.base_power)
     return TwoTerminalGenericHVDCLine(;
         name = po.name,
         available = po.available,
@@ -933,8 +984,8 @@ end
 
 # ── TwoTerminalLCCLine ────────────────────────────────────────────────────────────
 # `parameter_units`/`dc_voltage_units` are always "NATURAL_UNITS" for every current producer
-# (fixed ohm/kV regardless of the document's overall unit_system, the mirror image of
-# TwoWindingTransformer's always-"COMPONENT_BASE" fields) — only
+# (fixed ohm/kV, the mirror image of TwoWindingTransformer's always-"COMPONENT_BASE" fields) —
+# only
 # that basis is implemented; "COMPONENT_BASE" errors loudly rather than guessing. Because that
 # representation is fixed, `r`/`rectifier_rc`/`rectifier_xc`/`rectifier_capacitor_reactance`/
 # `inverter_rc`/`inverter_xc`/`inverter_capacitor_reactance`/`compounding_resistance` need the
@@ -989,7 +1040,7 @@ _lcc_transfer_setpoint(transfer_setpoint, ::Val{false}, _base_power) = transfer_
 function from_openapi(po::PO.TwoTerminalLCCLine, refs::OpenAPIRefs, ::DeviceBaseUnit)
     _check_lcc_parameter_units(po)
     _check_lcc_dc_voltage_units(po)
-    base_power = po.base_power
+    base_power = _require_base_power("TwoTerminalLCCLine", po.id, po.base_power)
     return TwoTerminalLCCLine(;
         name = po.name,
         available = po.available,
@@ -1050,7 +1101,7 @@ end
 function from_openapi(po::PO.TwoTerminalLCCLine, refs::OpenAPIRefs, ::NaturalUnit)
     _check_lcc_parameter_units(po)
     _check_lcc_dc_voltage_units(po)
-    base_power = po.base_power
+    base_power = _require_base_power("TwoTerminalLCCLine", po.id, po.base_power)
     return TwoTerminalLCCLine(;
         name = po.name,
         available = po.available,
@@ -1376,16 +1427,18 @@ function from_openapi(
     refs::OpenAPIRefs,
     unit::DeviceBaseUnit,
 )
-    return _two_terminal_vsc_line(po, refs, _resolve_base_power(refs, po.base_power), unit)
+    bp = _require_base_power("TwoTerminalVSCLine", po.id, po.base_power)
+    return _two_terminal_vsc_line(po, refs, bp, unit)
 end
 
 function from_openapi(po::PO.TwoTerminalVSCLine, refs::OpenAPIRefs, unit::NaturalUnit)
-    return _two_terminal_vsc_line(po, refs, _resolve_base_power(refs, po.base_power), unit)
+    bp = _require_base_power("TwoTerminalVSCLine", po.id, po.base_power)
+    return _two_terminal_vsc_line(po, refs, bp, unit)
 end
 
 # ── Source ──────────────────────────────────────────────────────────────────────
-# A genuine device base: `base_power` is the unit's own rating, not the denormalized system
-# base, so the MVA/MW fields divide by `po.base_power` rather than `_resolve_base_power`.
+# A genuine device base: `base_power` is the unit's own (required) rating, not the System's
+# computational base, so the MVA/MW fields divide by `_require_base_power`'s result directly.
 # `R_th`/`X_th` carry no `needs_conversion` in the descriptor — they are pu on the source's
 # own base already — but the document states which basis it wrote them in, so the
 # discriminator is checked rather than assumed. `base_voltage` is a plain kV passthrough.
@@ -1413,7 +1466,7 @@ function from_openapi(po::PO.Source, refs::OpenAPIRefs, ::DeviceBaseUnit)
         X_th = po.X_th,
         internal_voltage = po.internal_voltage,
         internal_angle = po.internal_angle,
-        base_power = po.base_power,
+        base_power = _require_base_power("Source", po.id, po.base_power),
         base_voltage = po.base_voltage,
         operation_cost = _convert_source_operation_cost(
             po.operation_cost, get_store(refs), get_base_power(refs),
@@ -1423,7 +1476,7 @@ end
 
 function from_openapi(po::PO.Source, refs::OpenAPIRefs, ::NaturalUnit)
     _check_source_param_units(po)
-    dbp = po.base_power
+    dbp = _require_base_power("Source", po.id, po.base_power)
     return Source(;
         name = po.name,
         available = po.available,
@@ -1523,7 +1576,7 @@ function from_openapi(po::PO.InterconnectingConverter, refs::OpenAPIRefs, ::Devi
         active_power = po.active_power,
         rating = po.rating,
         active_power_limits = _minmax(po.active_power_limits),
-        base_power = po.base_power,
+        base_power = _require_base_power("InterconnectingConverter", po.id, po.base_power),
         reactive_power_limits = _opt_minmax(po.reactive_power_limits),
         dc_current = po.dc_current,
         max_dc_current = po.max_dc_current,
@@ -1542,7 +1595,7 @@ end
 
 function from_openapi(po::PO.InterconnectingConverter, refs::OpenAPIRefs, ::NaturalUnit)
     _check_ic_voltage_setpoint_units(po)
-    dbp = po.base_power
+    dbp = _require_base_power("InterconnectingConverter", po.id, po.base_power)
     return InterconnectingConverter(;
         name = po.name,
         available = po.available,
@@ -1648,11 +1701,13 @@ end
 # ── Reserves: OnlineReserve, OfflineReserve, GroupReserve ───────────────────────
 # The parametric case: `reserve_direction` is a document enum property while PSY encodes it
 # as a type parameter, resolved through a literal table (direction is not a codegen case).
-# `requirement` is the one converted field: MW in the document, system-base pu in PSY,
-# divided by the document-level `refs.base_power` — a reserve has no device base of its own,
-# same fallback `TwoTerminalGenericHVDCLine` uses. `variable` (the Operating Reserve Demand
-# Curve) goes through `convert_reserve_variable` (already handles the `nothing` →
-# `ZERO_OFFER_CURVE` default).
+# `requirement`'s schema (`Operations/Service/{OnlineReserve,OfflineReserve,GroupReserve}.json`)
+# declares x-unit "MW" outright — fixed natural units, with no `power_units` discriminator field
+# on these PO structs — so it divides by `get_base_power(refs)` (the System's own computational
+# base; a reserve has no base of its own) in BOTH marker methods. Both methods are therefore
+# identical, so the 2-arg selector below is the trivial `DU` delegate like every other
+# non-power-family type. `variable` (the Operating Reserve Demand Curve) goes through
+# `convert_reserve_variable` (already handles the `nothing` → `ZERO_OFFER_CURVE` default).
 
 function from_openapi(po::PO.OnlineReserve, refs::OpenAPIRefs, ::DeviceBaseUnit)
     direction = _resolve_reserve_direction(po.reserve_direction, po.name)
@@ -1660,7 +1715,7 @@ function from_openapi(po::PO.OnlineReserve, refs::OpenAPIRefs, ::DeviceBaseUnit)
         name = po.name,
         available = po.available,
         time_frame = po.time_frame,
-        requirement = po.requirement,
+        requirement = po.requirement / get_base_power(refs),
         variable = convert_reserve_variable(po.variable),
         sustained_time = po.sustained_time,
         max_output_fraction = po.max_output_fraction,
@@ -1670,18 +1725,7 @@ function from_openapi(po::PO.OnlineReserve, refs::OpenAPIRefs, ::DeviceBaseUnit)
 end
 
 function from_openapi(po::PO.OnlineReserve, refs::OpenAPIRefs, ::NaturalUnit)
-    direction = _resolve_reserve_direction(po.reserve_direction, po.name)
-    return OnlineReserve{direction}(;
-        name = po.name,
-        available = po.available,
-        time_frame = po.time_frame,
-        requirement = po.requirement / get_base_power(refs),
-        variable = convert_reserve_variable(po.variable),
-        sustained_time = po.sustained_time,
-        max_output_fraction = po.max_output_fraction,
-        max_participation_factor = po.max_participation_factor,
-        deployed_fraction = po.deployed_fraction,
-    )
+    return from_openapi(po, refs, DU)
 end
 
 function from_openapi(po::PO.OfflineReserve, refs::OpenAPIRefs, ::DeviceBaseUnit)
@@ -1689,7 +1733,7 @@ function from_openapi(po::PO.OfflineReserve, refs::OpenAPIRefs, ::DeviceBaseUnit
         name = po.name,
         available = po.available,
         time_frame = po.time_frame,
-        requirement = po.requirement,
+        requirement = po.requirement / get_base_power(refs),
         variable = convert_reserve_variable(po.variable),
         sustained_time = po.sustained_time,
         max_output_fraction = po.max_output_fraction,
@@ -1699,17 +1743,7 @@ function from_openapi(po::PO.OfflineReserve, refs::OpenAPIRefs, ::DeviceBaseUnit
 end
 
 function from_openapi(po::PO.OfflineReserve, refs::OpenAPIRefs, ::NaturalUnit)
-    return OfflineReserve(;
-        name = po.name,
-        available = po.available,
-        time_frame = po.time_frame,
-        requirement = po.requirement / get_base_power(refs),
-        variable = convert_reserve_variable(po.variable),
-        sustained_time = po.sustained_time,
-        max_output_fraction = po.max_output_fraction,
-        max_participation_factor = po.max_participation_factor,
-        deployed_fraction = po.deployed_fraction,
-    )
+    return from_openapi(po, refs, DU)
 end
 
 function from_openapi(po::PO.GroupReserve, refs::OpenAPIRefs, ::DeviceBaseUnit)
@@ -1717,15 +1751,10 @@ function from_openapi(po::PO.GroupReserve, refs::OpenAPIRefs, ::DeviceBaseUnit)
     return GroupReserve{direction}(;
         name = po.name,
         available = po.available,
-        requirement = po.requirement,
+        requirement = po.requirement / get_base_power(refs),
     )
 end
 
 function from_openapi(po::PO.GroupReserve, refs::OpenAPIRefs, ::NaturalUnit)
-    direction = _resolve_reserve_direction(po.reserve_direction, po.name)
-    return GroupReserve{direction}(;
-        name = po.name,
-        available = po.available,
-        requirement = po.requirement / get_base_power(refs),
-    )
+    return from_openapi(po, refs, DU)
 end

--- a/src/openapi/refs.jl
+++ b/src/openapi/refs.jl
@@ -18,10 +18,11 @@ struct OpenAPIRefs
     by_id::Dict{Int, IS.InfrastructureSystemsType}
     "Component → id, keyed by object identity."
     id_by_component::IdDict{IS.InfrastructureSystemsType, Int}
-    "The document's declared unit system (e.g. \"NATURAL_UNITS\"), fixed for the whole document."
-    unit_system::String
-    "The document's system base power (MVA), used by converters for types carrying no
-    device-level `base_power` of their own."
+    "The System's computational base power (MVA): the caller-supplied anchor for import
+    (`from_openapi(::Type{System}, doc; base_power)`) or `get_base_power(sys)` on export, used
+    by the handful of converters for types carrying no device-level per-unit basis of their
+    own (e.g. a reserve's `requirement`). Every power-bearing component blob is otherwise
+    self-interpretable via its own `base_power`/`power_units`."
     base_power::Float64
     "Component→component reference resolutions queued by [`defer_ref!`](@ref) because the
     referenced component had not converted yet — drained by [`resolve_deferred_refs!`](@ref).
@@ -34,11 +35,11 @@ struct OpenAPIRefs
     store::Union{Nothing, IS.Store}
 end
 
-function OpenAPIRefs(unit_system::AbstractString, base_power::Real = 100.0; store = nothing)
+function OpenAPIRefs(base_power::Real = 100.0; store = nothing)
     return OpenAPIRefs(
         Dict{Int, IS.InfrastructureSystemsType}(),
         IdDict{IS.InfrastructureSystemsType, Int}(),
-        String(unit_system), Float64(base_power), Function[], store,
+        Float64(base_power), Function[], store,
     )
 end
 
@@ -72,10 +73,7 @@ function resolve_deferred_refs!(refs::OpenAPIRefs)
     return nothing
 end
 
-"""Get the document-level unit system this [`OpenAPIRefs`](@ref) was built for."""
-get_unit_system(refs::OpenAPIRefs) = refs.unit_system
-
-"""Get the document-level system base power (MVA) this [`OpenAPIRefs`](@ref) was built for."""
+"""Get the System computational base power (MVA) this [`OpenAPIRefs`](@ref) was built for."""
 get_base_power(refs::OpenAPIRefs) = refs.base_power
 
 """Get the time series store bound for this import (see [`OpenAPIRefs`](@ref)'s `store`
@@ -140,3 +138,49 @@ end
 
 """Whether `component` has a registered id."""
 has_component_id(refs::OpenAPIRefs, component) = haskey(refs.id_by_component, component)
+
+# ── per-component power_units selection ─────────────────────────────────────────
+# Each of the 32 power-bearing component types carries its own `power_units` field.
+# `_power_units_marker` translates that wire string to the DU/NU singleton selecting which
+# converter method runs; the generated per-type 2-arg `from_openapi(po, refs)` selector calls
+# it, as do the hand-written converters for the types the generator cannot emit.
+
+"""
+The `DU`/`NU` marker `raw` (a component blob's `power_units` string) selects, for the type
+named `component_type` and document id `id` — both carried only for the error message.
+
+`OpenAPI.from_json` does not enforce the schema's `required`, so a blob whose `power_units`
+deserializes to `nothing` must still error here, naming the offending type and id, rather than
+silently defaulting to either basis.
+"""
+function _power_units_marker(component_type::AbstractString, id, raw)
+    isnothing(raw) && error(
+        "from_openapi: $component_type id=$id has no power_units — every power-bearing " *
+        "component blob must state \"COMPONENT_BASE\" or \"NATURAL_UNITS\"",
+    )
+    raw == "COMPONENT_BASE" && return DU
+    raw == "NATURAL_UNITS" && return NU
+    error(
+        "from_openapi: $component_type id=$id has unmapped power_units=\"$raw\" — expected " *
+        "\"COMPONENT_BASE\" or \"NATURAL_UNITS\"",
+    )
+end
+
+"""The wire `power_units` string a `DU`/`NU` marker stamps on export — the inverse of
+[`_power_units_marker`](@ref)."""
+_power_units_string(::DeviceBaseUnit) = "COMPONENT_BASE"
+_power_units_string(::NaturalUnit) = "NATURAL_UNITS"
+
+"""
+`po.base_power`, required: every power-bearing component blob must state its own.
+`OpenAPI.from_json` does not enforce the schema's `required`, so a blob whose `base_power`
+deserializes to `nothing` must still error here, naming the offending type and id, rather than
+silently defaulting.
+"""
+function _require_base_power(component_type::AbstractString, id, base_power)
+    isnothing(base_power) && error(
+        "from_openapi: $component_type id=$id has no base_power — every power-bearing " *
+        "component blob must state its own base_power",
+    )
+    return Float64(base_power)
+end

--- a/src/openapi/sqlite_load.jl
+++ b/src/openapi/sqlite_load.jl
@@ -139,5 +139,18 @@ function load_supplemental_attribute_associations!(
         )
         _attach_service_membership!(refs[entity_id], refs[service_id], sys)
     end
+    for assoc in doc.trading_hub_associations
+        trading_hub_id = Int(assoc.trading_hub_id)
+        entity_id = Int(assoc.entity_id)
+        has_ref(refs, trading_hub_id) || error(
+            "load_supplemental_attribute_associations!: trading_hub_associations row " *
+            "references unresolved trading_hub_id=$trading_hub_id (entity_id=$entity_id)",
+        )
+        has_ref(refs, entity_id) || error(
+            "load_supplemental_attribute_associations!: trading_hub_associations row " *
+            "references unresolved entity_id=$entity_id (trading_hub_id=$trading_hub_id)",
+        )
+        _attach_trading_hub_membership!(refs[entity_id], refs[trading_hub_id], sys)
+    end
     return nothing
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -36,17 +36,21 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
 
 [sources]
+# LOCAL PATH CO-DEV PINS: PowerOpenAPIModels' power_units/cost-rename regen is only on local
+# disk (SiennaSchemas jd/schemas-0.1.0, PowerOpenAPIModels working tree), not yet pushed to
+# `main` — the git pins below cannot resolve it. Revert to the git pins once that regen is
+# pushed/merged upstream.
 InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
 InfraStore = {rev = "main", url = "https://github.com/NatLabRockies/infrastore", subdir = "julia/InfraStore.jl"}
-PowerCoreOpenAPIModels = {rev = "main", subdir = "PowerCoreOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
-PowerDynamicsOpenAPIModels = {rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerDynamicsOpenAPIModels.jl"}
 PowerFlowFileParser = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl"}
-PowerInvestmentsOpenAPIModels = {rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
-PowerOpenAPIModels = {rev = "main", subdir = "PowerOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
-PowerOperationsOpenAPIModels = {rev = "main", subdir = "PowerOperationsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerInvestmentsOpenAPIModels.jl"}
+PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerOperationsOpenAPIModels.jl"}
 PowerSystemCaseBuilder = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl"}
 PowerTableDataParser = {rev = "psy6", url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl"}
-PowerTimeSeriesOpenAPIModels = {rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
 
 [compat]
 InfrastructureSystems = "3"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -32,15 +32,15 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [sources]
 InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
-PowerCoreOpenAPIModels = {rev = "main", subdir = "PowerCoreOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
-PowerDynamicsOpenAPIModels = {rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerCoreOpenAPIModels = {rev = "jd/market_components", subdir = "PowerCoreOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerDynamicsOpenAPIModels = {rev = "jd/market_components", subdir = "PowerDynamicsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 PowerFlowFileParser = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl"}
-PowerInvestmentsOpenAPIModels = {rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
-PowerOpenAPIModels = {rev = "main", subdir = "PowerOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
-PowerOperationsOpenAPIModels = {rev = "main", subdir = "PowerOperationsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerInvestmentsOpenAPIModels = {rev = "jd/market_components", subdir = "PowerInvestmentsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerOpenAPIModels = {rev = "jd/market_components", subdir = "PowerOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerOperationsOpenAPIModels = {rev = "jd/market_components", subdir = "PowerOperationsOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 PowerSystemCaseBuilder = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl"}
 PowerTableDataParser = {rev = "psy6", url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl"}
-PowerTimeSeriesOpenAPIModels = {rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
+PowerTimeSeriesOpenAPIModels = {rev = "jd/market_components", subdir = "PowerTimeSeriesOpenAPIModels.jl", url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git"}
 
 [compat]
 InfrastructureSystems = "3"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,7 +6,9 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+InfrastructureCoreOpenAPIModels = "1f5e1c8d-e0cc-4dbf-8c6d-f2a3d2ae70a8"
 InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
+InfrastructureTimeSeriesOpenAPIModels = "37a216c8-a490-47cf-89d7-db2cb9618199"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -22,7 +24,6 @@ PowerOperationsOpenAPIModels = "a372b6d7-45a2-44c2-8199-6a724b72e8ff"
 PowerSystemCaseBuilder = "f00506e0-b84f-492a-93c2-c0a9afc4364e"
 PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 PowerTableDataParser = "2b750c0e-0bff-11f1-9200-1befd75df6be"
-PowerTimeSeriesOpenAPIModels = "8c2f6a0d-6b0e-4d0a-9d8f-2b5e6a4f9c31"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -38,18 +39,33 @@ InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
 [sources]
 PowerSystems = {path = ".."}
 # IS4 carries the association-id time series keys; InfraStore 0.11 is registered, so it
-# needs no source pin. The OpenAPI packages track jd/schemas-0.1.0, which carries both the
-# power_units and market-component regeneration.
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+# needs no source pin.
+# LOCAL PATH CO-DEV PIN (temporary): see ../Project.toml — IS4's local checkout already
+# migrated off PowerCoreOpenAPIModels/PowerTimeSeriesOpenAPIModels, uncommitted; the pushed
+# IS4 branch fails to resolve. Revert to the git rev once IS4 is pushed.
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "jd/openapi-package-split"}
+# LOCAL PATH CO-DEV PINS (temporary): the InfrastructureCore/InfrastructureTimeSeries package
+# split exists only on local disk, not pushed to jd/schemas-0.1.0 yet. Revert to the git pins
+# once pushed/merged.
+InfrastructureCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "InfrastructureCoreOpenAPIModels.jl"}
+InfrastructureTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "InfrastructureTimeSeriesOpenAPIModels.jl"}
 PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerCoreOpenAPIModels.jl"}
 PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerDynamicsOpenAPIModels.jl"}
-PowerFlowFileParser = {rev = "jd/power-units-rename", url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl"}
+# LOCAL PATH CO-DEV PIN (temporary): PFFP's own local checkout already migrated off
+# PowerCoreOpenAPIModels/PowerTimeSeriesOpenAPIModels, uncommitted; the pushed
+# jd/power-units-rename branch fails to resolve. Revert to the git rev once it is pushed.
+PowerFlowFileParser = {url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl", rev = "jd/power-units-rename"}
 PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerInvestmentsOpenAPIModels.jl"}
 PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerOpenAPIModels.jl"}
 PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerOperationsOpenAPIModels.jl"}
-PowerSystemCaseBuilder = {rev = "jd/power-units-rename", url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl"}
-PowerTableDataParser = {rev = "jd/power-units-rename", url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl"}
-PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "jd/schemas-0.1.0", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
+# LOCAL PATH CO-DEV PIN (temporary): PSB's own local checkout already migrated off
+# PowerCoreOpenAPIModels/PowerTimeSeriesOpenAPIModels, uncommitted; the pushed
+# jd/power-units-rename branch fails to resolve. Revert to the git rev once it is pushed.
+PowerSystemCaseBuilder = {url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl", rev = "jd/power-units-rename"}
+# LOCAL PATH CO-DEV PIN (temporary): PowerTableDataParser's own local checkout already
+# migrated off PowerCoreOpenAPIModels/PowerTimeSeriesOpenAPIModels, uncommitted; the pushed
+# jd/power-units-rename branch fails to resolve. Revert to the git rev once it is pushed.
+PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl", rev = "jd/power-units-rename"}
 
 [compat]
 InfrastructureSystems = "3"

--- a/test/common.jl
+++ b/test/common.jl
@@ -368,6 +368,7 @@ function make_openapi_test_doc(;
         "service_associations" => [
             Dict{String, Any}("service_id" => 8, "entity_id" => 6),
         ],
+        "trading_hub_associations" => [],
         "time_series_associations" => [],
         "ext" => Dict{String, Any}(),
         "time_series_storage_file" => nothing,
@@ -439,4 +440,21 @@ function _file_io_fixture(; with_time_series = true)
         )
     end
     return sys
+end
+
+"""Fresh 100 MVA system with two attached buses (`b1` REF, `b2` PV) and a `TradingHub`
+named `western_hub` over both. Returns `(sys, b1, b2, hub)`."""
+function _market_hub_fixture()
+    sys = System(100.0)
+    b1 = ACBus(; number = 1, name = "b1", available = true, bustype = ACBusTypes.REF,
+        angle = 0.0, magnitude = 1.0, voltage_limits = (min = 0.9, max = 1.1),
+        base_voltage = 230.0)
+    b2 = ACBus(; number = 2, name = "b2", available = true, bustype = ACBusTypes.PV,
+        angle = 0.0, magnitude = 1.0, voltage_limits = (min = 0.9, max = 1.1),
+        base_voltage = 230.0)
+    add_component!(sys, b1)
+    add_component!(sys, b2)
+    hub = TradingHub(; name = "western_hub", buses = [b1, b2])
+    add_component!(sys, hub)
+    return (sys, b1, b2, hub)
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -261,7 +261,7 @@ Which one fires depends on where the defect is caught: `PowerCoreOpenAPIModels` 
 an unresolved id, a duplicate id), while PowerSystems `error()`s for semantic ones only it can
 judge (a component type with no converter, an unmapped time series type or multiplier).
 """
-const DocumentError = Union{ErrorException, PSY.PC.DocumentFormatError}
+const DocumentError = Union{ErrorException, PSY.IC.DocumentFormatError}
 
 """A minimal, internally-consistent OpenAPI document: Area/LoadZone, two buses, an arc, a
 thermal generator with a real cost curve, a load, and an online reserve the generator
@@ -284,13 +284,13 @@ function make_openapi_test_doc(;
     bus1_po = PSY.PO.ACBus(;
         id = 3, number = 1, name = "bus1", available = true, bustype = bus1_bustype,
         angle = 0.0, magnitude = 1.0,
-        voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        voltage_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
         base_voltage = 138.0, area = 1, load_zone = 2,
     )
     bus2_po = PSY.PO.ACBus(;
         id = 4, number = 2, name = "bus2", available = true, bustype = "PQ",
         angle = 0.0, magnitude = 1.0,
-        voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        voltage_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
         base_voltage = 138.0, area = 1, load_zone = 2,
     )
     arc_po = PSY.PO.Arc(; id = 5, from_id = 3, to_id = 4)
@@ -303,7 +303,7 @@ function make_openapi_test_doc(;
                 value_curve = PSY.PC.ValueCurve(
                     PSY.PC.InputOutputCurve(;
                         function_data = PSY.PC.InputOutputCurveFunctionData(
-                            PSY.PC.LinearFunctionData(;
+                            PSY.IC.LinearFunctionData(;
                                 proportional_term = 10.0, constant_term = 5.0,
                             ),
                         ),
@@ -315,11 +315,11 @@ function make_openapi_test_doc(;
     thermal_po = PSY.PO.ThermalStandard(;
         id = 6, name = "gen1", available = true, status = true, bus = 4,
         active_power = 50.0, reactive_power = 10.0, rating = 100.0,
-        active_power_limits = PSY.PC.MinMax(; min = 10.0, max = 100.0),
-        reactive_power_limits = PSY.PC.MinMax(; min = -50.0, max = 50.0),
-        ramp_limits = PSY.PC.UpDown(; up = 20.0, down = 20.0),
+        active_power_limits = PSY.IC.MinMax(; min = 10.0, max = 100.0),
+        reactive_power_limits = PSY.IC.MinMax(; min = -50.0, max = 50.0),
+        ramp_limits = PSY.IC.UpDown(; up = 20.0, down = 20.0),
         operation_cost = cost_po, base_power = 100.0, power_units = "NATURAL_UNITS",
-        time_limits = PSY.PC.UpDown(; up = 2.0, down = 2.0),
+        time_limits = PSY.IC.UpDown(; up = 2.0, down = 2.0),
         must_run = false, prime_mover_type = "OT", fuel = "NATURAL_GAS",
         time_at_status = 100.0,
     )
@@ -349,7 +349,7 @@ function make_openapi_test_doc(;
         shunt_po = PSY.PO.FixedAdmittance(;
             id = 9, name = "shunt1", available = true, bus = 4,
             admittance_units = "COMPONENT_MVAR",
-            Y = PSY.PC.ComplexNumber(; real = 0.0, imag = -50.0),
+            Y = PSY.IC.ComplexNumber(; real = 0.0, imag = -50.0),
         )
         components["FixedAdmittance"] = [openapi_raw(shunt_po)]
     end

--- a/test/common.jl
+++ b/test/common.jl
@@ -232,10 +232,10 @@ The serde itself is tested once, in `test_openapi_file_io.jl`. Use this only whe
 a restored system to check that some *component* survives conversion. A document carries
 component ids rather than UUIDs and does not carry component `ext`, so neither survives.
 """
-function roundtrip_system(sys::System; unit_system = :device_base, kwargs...)
+function roundtrip_system(sys::System; power_units = :component_base, kwargs...)
     dir = mktempdir()
     bundle = joinpath(dir, "case")
-    to_file(sys, bundle; unit_system = unit_system, force = true)
+    to_file(sys, bundle; power_units = power_units, force = true)
     return from_file(System, bundle; kwargs...)
 end
 
@@ -275,10 +275,11 @@ function make_openapi_test_doc(;
 )
     area_po = PSY.PO.Area(;
         id = 1, name = "area1", peak_active_power = 100.0, peak_reactive_power = 20.0,
-        load_response = 0.0,
+        load_response = 0.0, base_power = 100.0, power_units = "NATURAL_UNITS",
     )
     lz_po = PSY.PO.LoadZone(;
         id = 2, name = "lz1", peak_active_power = 100.0, peak_reactive_power = 20.0,
+        base_power = 100.0, power_units = "NATURAL_UNITS",
     )
     bus1_po = PSY.PO.ACBus(;
         id = 3, number = 1, name = "bus1", available = true, bustype = bus1_bustype,
@@ -296,7 +297,7 @@ function make_openapi_test_doc(;
 
     cost_po = PSY.PC.ThermalGenerationCost(;
         fixed = 100.0, shut_down = 50.0, start_up = 200.0,
-        variable = PSY.PC.ProductionVariableCostCurve(
+        variable_operation_cost = PSY.PC.ProductionVariableCostCurve(
             PSY.PC.CostCurve(;
                 power_units = "NATURAL_UNITS",
                 value_curve = PSY.PC.ValueCurve(
@@ -317,7 +318,7 @@ function make_openapi_test_doc(;
         active_power_limits = PSY.PC.MinMax(; min = 10.0, max = 100.0),
         reactive_power_limits = PSY.PC.MinMax(; min = -50.0, max = 50.0),
         ramp_limits = PSY.PC.UpDown(; up = 20.0, down = 20.0),
-        operation_cost = cost_po, base_power = 100.0,
+        operation_cost = cost_po, base_power = 100.0, power_units = "NATURAL_UNITS",
         time_limits = PSY.PC.UpDown(; up = 2.0, down = 2.0),
         must_run = false, prime_mover_type = "OT", fuel = "NATURAL_GAS",
         time_at_status = 100.0,
@@ -325,6 +326,7 @@ function make_openapi_test_doc(;
     load_po = PSY.PO.PowerLoad(;
         id = 7, name = "load1", available = true, bus = 4,
         active_power = 30.0, reactive_power = 5.0, base_power = 100.0,
+        power_units = "NATURAL_UNITS",
         max_active_power = 50.0, max_reactive_power = 10.0, conformity = "CONFORMING",
     )
     reserve_po = PSY.PO.OnlineReserve(;
@@ -356,8 +358,6 @@ function make_openapi_test_doc(;
     # ones: a real producer always emits all of them, so a fixture that omits some would let
     # a reader regress into tolerating incomplete documents.
     return Dict{String, Any}(
-        "base_power" => 100.0,
-        "unit_system" => "NATURAL_UNITS",
         "components" => components,
         "supplemental_attributes" => [],
         "supplemental_attribute_associations" => [],
@@ -372,6 +372,17 @@ function make_openapi_test_doc(;
         "ext" => Dict{String, Any}(),
         "time_series_storage_file" => nothing,
     )
+end
+
+"""Stamp `power_units` to `value` on every raw component row in a JSON-shaped test document
+that carries the field (rows of types without a `power_units` member are left alone)."""
+function set_all_power_units!(doc::AbstractDict, value::AbstractString)
+    for rows in values(doc["components"])
+        for row in rows
+            haskey(row, "power_units") && (row["power_units"] = value)
+        end
+    end
+    return doc
 end
 
 """

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -512,6 +512,43 @@ end
     @test TimeSeries.timestamp(resolved) == collect(timestamps)[1:3]
 end
 
+@testset "set_fuel_cost! round-trips a fixed value and a time-series key" begin
+    sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    generator = get_component(ThermalStandard, sys, "322_CT_6")
+
+    old_cost = get_operation_cost(generator)
+    old_variable = get_variable(old_cost)
+    set_operation_cost!(
+        generator,
+        ThermalGenerationCost(;
+            fixed = get_fixed(old_cost),
+            shut_down = get_shut_down(old_cost),
+            start_up = get_start_up(old_cost),
+            variable = FuelCurve(;
+                value_curve = get_value_curve(old_variable),
+                power_units = get_power_units(old_variable),
+                fuel_cost = 2.0,
+            ),
+        ),
+    )
+
+    set_fuel_cost!(sys, generator, 9.5)
+    updated_variable = get_variable_operation_cost(get_operation_cost(generator))
+    @test get_fuel_cost(updated_variable) == 9.5
+    @test isnothing(get_fuel_cost_time_series(updated_variable))
+
+    timestamps = range(_TS_RESOLVE_INITIAL_TIME; step = _TS_RESOLVE_RESOLUTION, length = 24)
+    prices = collect(1.0:24.0)
+    ts = IS.SingleTimeSeries(;
+        name = "fuel_price",
+        data = TimeSeries.TimeArray(collect(timestamps), prices),
+    )
+    set_fuel_cost!(sys, generator, ts)
+    resolved = get_fuel_cost(generator; start_time = _TS_RESOLVE_INITIAL_TIME, len = 3)
+    @test TimeSeries.values(resolved) == prices[1:3]
+    @test TimeSeries.timestamp(resolved) == collect(timestamps)[1:3]
+end
+
 @testset "Time-series ORDC resolves variable cost at start_time" begin
     sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
     # A key names one stored association, which belongs to one owner — so the reserve's

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -118,7 +118,7 @@ test_costs = Dict(
 
 @testset "Test MarketBidCost defaults and nothing constructor" begin
     mbc = MarketBidCost(nothing)
-    @test get_no_load_cost(mbc) == LinearCurve(0.0)
+    @test get_minimum_energy_offer(mbc) == LinearCurve(0.0)
     @test get_start_up(mbc) ==
           (hot = PSY.START_COST, warm = PSY.START_COST, cold = PSY.START_COST)
     @test get_shut_down(mbc) == LinearCurve(0.0)
@@ -378,7 +378,7 @@ end
     )
 
     mbtc = MarketBidTimeSeriesCost(;
-        no_load_cost = IS.TimeSeriesLinearCurve(nl_key),
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
         start_up = su_key,
         shut_down = IS.TimeSeriesLinearCurve(sd_key),
         incremental_offer_curves = make_market_bid_ts_curve(inc_key),
@@ -422,7 +422,7 @@ end
     su_key = add_time_series!(sys, generator, su_sts)
 
     mbtc = MarketBidTimeSeriesCost(;
-        no_load_cost = IS.TimeSeriesLinearCurve(nl_key),
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
         start_up = su_key,
         shut_down = IS.TimeSeriesLinearCurve(sd_key),
         incremental_offer_curves = make_market_bid_ts_curve(inc_key),
@@ -530,7 +530,7 @@ function _build_min_mbtc(sys, component)
         IS.SingleTimeSeries(; name = "start_up_stages_len", data = su_ta),
     )
     return MarketBidTimeSeriesCost(;
-        no_load_cost = IS.TimeSeriesLinearCurve(nl_key),
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
         start_up = su_key,
         shut_down = IS.TimeSeriesLinearCurve(sd_key),
         incremental_offer_curves = make_market_bid_ts_curve(inc_key),
@@ -556,7 +556,7 @@ end
     @test get_function_data(get_value_curve(window[2])) == _TS_RESOLVE_PWL_DATA[2]
     @test only(get_variable_cost(gen, mbtc; start_time = t0, len = 1)) == resolved
 
-    nl_window = get_no_load_cost(gen, mbtc; start_time = t0, len = 24)
+    nl_window = get_minimum_energy_offer(gen, mbtc; start_time = t0, len = 24)
     @test nl_window isa Vector
     @test length(nl_window) == 24
 

--- a/test/test_market_components.jl
+++ b/test/test_market_components.jl
@@ -1,0 +1,389 @@
+@testset "Market component abstract hierarchy" begin
+    @test PSY.MarketComponent <: PSY.Component
+    @test PSY.MarketTransaction <: PSY.MarketComponent
+    @test IS.supports_time_series(TradingHub(nothing))
+end
+
+@testset "TradingHub membership and round-trip" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+    @test get_associated_buses(get_component(TradingHub, sys, "western_hub")) == [b1, b2]
+
+    # a hub with a detached bus must be rejected loudly
+    b3 = ACBus(; number = 3, name = "b3", available = true, bustype = ACBusTypes.PQ,
+        angle = 0.0, magnitude = 1.0, voltage_limits = (min = 0.9, max = 1.1),
+        base_voltage = 230.0)
+    bad = TradingHub(; name = "bad_hub", buses = [b3])
+    @test_throws ArgumentError add_component!(sys, bad)
+
+    # serialization round-trip: buses encode as ids, resolve on read-back
+    path = joinpath(mktempdir(), "hub_sys.json")
+    to_json(sys, path)
+    sys2 = System(path)
+    hub2 = get_component(TradingHub, sys2, "western_hub")
+    @test get_name.(get_associated_buses(hub2)) == ["b1", "b2"]
+end
+
+@testset "CurveStyles numeric contract" begin
+    # The wire representation (SiennaSchemas' `curve_style` field) is a plain integer,
+    # not the string-enum convention used elsewhere in the schemas; pin the mapping.
+    @test CurveStyles.CURVE.value == 0
+    @test CurveStyles.FIXED.value == 1
+    @test CurveStyles.VARIABLE.value == 2
+end
+
+@testset "MarketBidCost extensions" begin
+    c = MarketBidCost(; incremental_slope = true)
+    @test get_incremental_slope(c)
+    @test !get_decremental_slope(c)
+    @test !get_incremental_slope(MarketBidCost(nothing))
+    @test get_curve_style(MarketBidCost(nothing)) == CurveStyles.CURVE
+
+    c2 = MarketBidCost(; curve_style = CurveStyles.FIXED)
+    @test get_curve_style(c2) == CurveStyles.FIXED
+
+    @test_throws ArgumentError MarketBidCost(;
+        incremental_slope = true,
+        curve_style = CurveStyles.FIXED,
+    )
+    @test_throws ArgumentError MarketBidCost(;
+        decremental_slope = true,
+        curve_style = CurveStyles.VARIABLE,
+    )
+end
+
+@testset "MarketBidTimeSeriesCost extensions" begin
+    sys = System(100.0)
+    bus = ACBus(nothing)
+    bus.bustype = ACBusTypes.REF
+    add_component!(sys, bus)
+    generator = ThermalStandard(nothing)
+    generator.name = "market_gen_ext"
+    generator.bus = bus
+    add_component!(sys, generator)
+
+    inc_key = _attach_pwl_forecast(sys, generator, "inc_offer_ext")
+    dec_key = _attach_pwl_forecast(sys, generator, "dec_offer_ext")
+    nl_key = _attach_linear_forecast(sys, generator, "no_load_ext")
+    sd_key = _attach_linear_forecast(sys, generator, "shut_down_ext")
+    timestamps =
+        range(_TS_RESOLVE_INITIAL_TIME; step = _TS_RESOLVE_RESOLUTION, length = 24)
+
+    su_ta = TimeSeries.TimeArray(collect(timestamps), fill((0.0, 0.0, 0.0), 24))
+    su_key = add_time_series!(
+        sys, generator,
+        IS.SingleTimeSeries(; name = "start_up_stages_ext", data = su_ta),
+    )
+
+    mbtc = MarketBidTimeSeriesCost(;
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
+        start_up = su_key,
+        shut_down = IS.TimeSeriesLinearCurve(sd_key),
+        incremental_offer_curves = make_market_bid_ts_curve(inc_key),
+        decremental_offer_curves = make_market_bid_ts_curve(dec_key),
+    )
+    @test !get_incremental_slope(mbtc)
+    @test !get_decremental_slope(mbtc)
+    @test get_curve_style(mbtc) == CurveStyles.CURVE
+
+    mbtc_slope = MarketBidTimeSeriesCost(;
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
+        start_up = su_key,
+        shut_down = IS.TimeSeriesLinearCurve(sd_key),
+        incremental_offer_curves = make_market_bid_ts_curve(inc_key),
+        decremental_offer_curves = make_market_bid_ts_curve(dec_key),
+        incremental_slope = true,
+    )
+    @test get_incremental_slope(mbtc_slope)
+
+    mbtc_fixed = MarketBidTimeSeriesCost(;
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
+        start_up = su_key,
+        shut_down = IS.TimeSeriesLinearCurve(sd_key),
+        incremental_offer_curves = make_market_bid_ts_curve(inc_key),
+        decremental_offer_curves = make_market_bid_ts_curve(dec_key),
+        curve_style = CurveStyles.FIXED,
+    )
+    @test get_curve_style(mbtc_fixed) == CurveStyles.FIXED
+
+    @test_throws ArgumentError MarketBidTimeSeriesCost(;
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
+        start_up = su_key,
+        shut_down = IS.TimeSeriesLinearCurve(sd_key),
+        incremental_offer_curves = make_market_bid_ts_curve(inc_key),
+        decremental_offer_curves = make_market_bid_ts_curve(dec_key),
+        incremental_slope = true,
+        curve_style = CurveStyles.FIXED,
+    )
+    @test_throws ArgumentError MarketBidTimeSeriesCost(;
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
+        start_up = su_key,
+        shut_down = IS.TimeSeriesLinearCurve(sd_key),
+        incremental_offer_curves = make_market_bid_ts_curve(inc_key),
+        decremental_offer_curves = make_market_bid_ts_curve(dec_key),
+        decremental_slope = true,
+        curve_style = CurveStyles.VARIABLE,
+    )
+end
+
+@testset "CurveStyles round-trips through JSON serialization" begin
+    sys = System(100.0)
+    bus = ACBus(nothing)
+    bus.bustype = ACBusTypes.REF
+    add_component!(sys, bus)
+    gen = ThermalStandard(nothing)
+    gen.name = "curve_style_gen"
+    gen.bus = bus
+    add_component!(sys, gen)
+    mbc = MarketBidCost(;
+        start_up = (hot = 0.0, warm = 0.0, cold = 0.0),
+        curve_style = CurveStyles.FIXED,
+    )
+    set_operation_cost!(gen, mbc)
+
+    path = joinpath(mktempdir(), "curve_style_sys.json")
+    to_json(sys, path)
+    sys2 = System(path)
+    gen2 = get_component(ThermalStandard, sys2, "curve_style_gen")
+    @test get_curve_style(get_operation_cost(gen2)) == CurveStyles.FIXED
+end
+
+@testset "MarketBidTimeSeriesCost keys survive JSON round trip as association ids" begin
+    sys = System(100.0)
+    bus = ACBus(nothing)
+    bus.bustype = ACBusTypes.REF
+    add_component!(sys, bus)
+    gen = ThermalStandard(nothing)
+    gen.name = "market_gen"
+    gen.bus = bus
+    add_component!(sys, gen)
+
+    inc_key = _attach_pwl_forecast(sys, gen, "inc_offer_rt")
+    dec_key = _attach_pwl_forecast(sys, gen, "dec_offer_rt")
+    nl_key = _attach_linear_forecast(sys, gen, "no_load_rt")
+    sd_key = _attach_linear_forecast(sys, gen, "shut_down_rt")
+    timestamps =
+        range(_TS_RESOLVE_INITIAL_TIME; step = _TS_RESOLVE_RESOLUTION, length = 24)
+    su_ta = TimeSeries.TimeArray(collect(timestamps), fill((1.5, 2.5, 3.5), 24))
+    su_key = add_time_series!(
+        sys, gen,
+        IS.SingleTimeSeries(; name = "start_up_stages_rt", data = su_ta),
+    )
+    mbtc = MarketBidTimeSeriesCost(;
+        minimum_energy_offer = IS.TimeSeriesLinearCurve(nl_key),
+        start_up = su_key,
+        shut_down = IS.TimeSeriesLinearCurve(sd_key),
+        incremental_offer_curves = make_market_bid_ts_curve(inc_key),
+        decremental_offer_curves = make_market_bid_ts_curve(dec_key),
+    )
+    set_operation_cost!(gen, mbtc)
+    original_su_values = get_time_series_values(gen, su_key)
+
+    path = joinpath(mktempdir(), "mbtc_round_trip.json")
+    to_json(sys, path)
+
+    # The keys cross the wire as bare association ids, nothing else.
+    raw = open(path) do io
+        return JSON.parse(io; dicttype = Dict{String, Any})
+    end
+    gen_json = only(
+        filter(
+            c -> get(c, "name", "") == "market_gen",
+            raw["data"]["components"],
+        ),
+    )
+    op_json = gen_json["operation_cost"]
+    @test op_json["start_up"] isa Int
+    @test op_json["start_up"] == IS.get_association_id(su_key)
+
+    # A regression to field-by-field key serialization would put these back in the JSON.
+    json_text = read(path, String)
+    @test !occursin("owner_category", json_text)
+    @test !occursin("association_id", json_text)
+    @test !occursin("start_up_stages_rt", json_text)
+    @test !occursin("inc_offer_rt", json_text)
+
+    sys2 = System(path)
+    gen2 = get_component(ThermalStandard, sys2, "market_gen")
+    cost2 = get_operation_cost(gen2)
+    su_key2 = get_start_up(cost2)
+    @test su_key2 == su_key
+    for field in fieldnames(typeof(su_key))
+        @test getproperty(su_key2, field) == getproperty(su_key, field)
+    end
+    @test get_time_series_values(gen2, su_key2) == original_su_values
+
+    inc_fd = get_function_data(get_value_curve(get_incremental_offer_curves(cost2)))
+    @test IS.get_time_series_key(inc_fd) == inc_key
+end
+
+@testset "VirtualParticipant location modes and hub bids" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+
+    vp = VirtualParticipant(; name = "vp1", available = true,
+        max_supply = 100.0, max_demand = 50.0, operation_cost = MarketBidCost(nothing))
+    add_component!(sys, vp)
+    add_trading_hub!(sys, vp, hub)
+    @test has_trading_hub(vp, hub)
+    @test get_contributing_virtuals(sys, hub) == [vp]
+
+    # both location modes set at once is rejected on add
+    vp2 = VirtualParticipant(; name = "vp2", available = true, settlement_point = b1,
+        trading_hubs = [hub], max_supply = 10.0, max_demand = 0.0,
+        operation_cost = MarketBidCost(nothing))
+    @test_throws ArgumentError add_component!(sys, vp2)
+
+    # hub bid: name-keyed series, hub association required first
+    dates = collect(DateTime("2026-01-01T00:00:00"):Hour(1):DateTime("2026-01-01T01:00:00"))
+    data = PiecewiseStepData.(
+        [[0.0, 50.0, 100.0], [0.0, 50.0, 100.0]],
+        [[25.0, 30.0], [26.0, 31.0]],
+    )
+    ta = TimeSeries.TimeArray(dates, data)
+    ts = SingleTimeSeries(; name = get_name(hub), data = ta)
+
+    vp_noassoc = VirtualParticipant(; name = "vp_noassoc", available = true,
+        max_supply = 5.0, max_demand = 5.0, operation_cost = MarketBidCost(nothing))
+    add_component!(sys, vp_noassoc)
+    @test_throws ErrorException set_hub_bid!(sys, vp_noassoc, hub, ts, IS.NaturalUnit())
+
+    set_hub_bid!(sys, vp, hub, ts, IS.NaturalUnit())
+    @test get_time_series(SingleTimeSeries, vp, get_name(hub)) isa SingleTimeSeries
+
+    # duplicate hub bid is rejected loudly, not silently overwritten
+    @test_throws ErrorException set_hub_bid!(sys, vp, hub, ts, IS.NaturalUnit())
+
+    # wrong-eltype time series is rejected with an actionable error
+    bad_ta = TimeSeries.TimeArray(dates, [1.0, 2.0])
+    bad_ts = SingleTimeSeries(; name = get_name(hub), data = bad_ta)
+    vp_bad = VirtualParticipant(; name = "vp_bad", available = true,
+        max_supply = 5.0, max_demand = 5.0, operation_cost = MarketBidCost(nothing))
+    add_component!(sys, vp_bad)
+    add_trading_hub!(sys, vp_bad, hub)
+    @test_throws TypeError set_hub_bid!(sys, vp_bad, hub, bad_ts, IS.NaturalUnit())
+
+    # remove_trading_hub! / clear_trading_hubs!
+    remove_trading_hub!(vp_bad, hub)
+    @test !has_trading_hub(vp_bad, hub)
+    add_trading_hub!(sys, vp_bad, hub)
+    clear_trading_hubs!(vp_bad)
+    @test !has_trading_hub(vp_bad, hub)
+
+    # removing a hub strips it from every contributing virtual participant
+    hub2 = TradingHub(; name = "removable_hub", buses = [b1])
+    add_component!(sys, hub2)
+    add_trading_hub!(sys, vp_bad, hub2)
+    @test has_trading_hub(vp_bad, hub2)
+    remove_component!(sys, hub2)
+    @test !has_trading_hub(vp_bad, hub2)
+
+    # nodal round-trip: settlement_point encodes as id
+    vp3 = VirtualParticipant(; name = "vp3", available = true, settlement_point = b2,
+        max_supply = 10.0, max_demand = 10.0, operation_cost = MarketBidCost(nothing))
+    add_component!(sys, vp3)
+    path = joinpath(mktempdir(), "vp_sys.json")
+    to_json(sys, path)
+    sys2 = System(path)
+    @test get_name(get_settlement_point(get_component(VirtualParticipant, sys2, "vp3"))) ==
+          "b2"
+    @test get_name.(get_trading_hubs(get_component(VirtualParticipant, sys2, "vp1"))) ==
+          ["western_hub"]
+end
+
+@testset "VirtualParticipant detached settlement point rejected on add" begin
+    sys = System(100.0)
+    detached_bus = ACBus(; number = 99, name = "detached", available = true,
+        bustype = ACBusTypes.PQ, angle = 0.0, magnitude = 1.0,
+        voltage_limits = (min = 0.9, max = 1.1), base_voltage = 230.0)
+    vp = VirtualParticipant(; name = "vp_detached", available = true,
+        settlement_point = detached_bus, max_supply = 10.0, max_demand = 10.0,
+        operation_cost = MarketBidCost(nothing))
+    @test_throws ArgumentError add_component!(sys, vp)
+end
+
+@testset "add_trading_hub! rejects a VP with settlement_point set" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+    vp = VirtualParticipant(; name = "vp_settled", available = true, settlement_point = b1,
+        max_supply = 10.0, max_demand = 0.0, operation_cost = MarketBidCost(nothing))
+    add_component!(sys, vp)
+    @test_throws ArgumentError add_trading_hub!(sys, vp, hub)
+end
+
+@testset "add_component! rejects a VP carrying a detached trading hub" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+    detached_hub = TradingHub(; name = "detached_hub", buses = [b1])
+    vp = VirtualParticipant(; name = "vp_detached_hub", available = true,
+        trading_hubs = [detached_hub], max_supply = 10.0, max_demand = 0.0,
+        operation_cost = MarketBidCost(nothing))
+    @test_throws ArgumentError add_component!(sys, vp)
+end
+
+@testset "TradingHub removal is refused while a PointToPointBid terminates on it" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+    ptp = PointToPointBid(; name = "ptp_hub_term", available = true, from = b1, to = hub,
+        max_active_power = 10.0, spread_bid = MarketBidCost(nothing),
+        price_limits = (min = 0.0, max = 1.0))
+    add_component!(sys, ptp)
+    @test_throws ArgumentError remove_component!(sys, hub)
+    remove_component!(sys, ptp)
+    remove_component!(sys, hub)
+    @test !PSY.is_attached(hub, sys)
+end
+
+@testset "ACBus removal is refused while a TradingHub lists it as a member" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+    @test_throws ArgumentError remove_component!(sys, b1)
+    set_buses!(hub, [b2])
+    remove_component!(sys, b1)
+    @test !PSY.is_attached(b1, sys)
+end
+
+@testset "Topology removal is refused while a VirtualParticipant settles there" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+    b3 = ACBus(; number = 3, name = "b3", available = true, bustype = ACBusTypes.PQ,
+        angle = 0.0, magnitude = 1.0, voltage_limits = (min = 0.9, max = 1.1),
+        base_voltage = 230.0)
+    add_component!(sys, b3)
+    vp =
+        VirtualParticipant(; name = "vp_settled2", available = true, settlement_point = b3,
+            max_supply = 10.0, max_demand = 0.0, operation_cost = MarketBidCost(nothing))
+    add_component!(sys, vp)
+    @test_throws ArgumentError remove_component!(sys, b3)
+    set_settlement_point!(vp, nothing)
+    remove_component!(sys, b3)
+    @test !PSY.is_attached(b3, sys)
+end
+
+@testset "PointToPointBid terminals" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+
+    ptp = PointToPointBid(; name = "utc1", available = true, from = b1, to = hub,
+        max_active_power = 50.0, spread_bid = MarketBidCost(nothing),
+        price_limits = (min = -50.0, max = 50.0))
+    add_component!(sys, ptp)
+    @test get_name(get_from(ptp)) == "b1"
+
+    @test_throws ArgumentError add_component!(sys,
+        PointToPointBid(; name = "bad_same", available = true, from = b1, to = b1,
+            max_active_power = 1.0, spread_bid = MarketBidCost(nothing),
+            price_limits = (min = 0.0, max = 1.0)))
+
+    # a Device terminal is inadmissible
+    some_generator = ThermalStandard(nothing)
+    some_generator.name = "some_generator"
+    some_generator.bus = b1
+    add_component!(sys, some_generator)
+
+    @test_throws ArgumentError add_component!(sys,
+        PointToPointBid(; name = "bad_dev", available = true, from = some_generator,
+            to = b2,
+            max_active_power = 1.0, spread_bid = MarketBidCost(nothing),
+            price_limits = (min = 0.0, max = 1.0)))
+
+    # round-trip
+    path = joinpath(mktempdir(), "ptp_sys.json")
+    to_json(sys, path)
+    sys2 = System(path)
+    ptp2 = get_component(PointToPointBid, sys2, "utc1")
+    @test get_name(get_from(ptp2)) == "b1"
+    @test get_name(get_to(ptp2)) == "western_hub"
+end

--- a/test/test_openapi_converters.jl
+++ b/test/test_openapi_converters.jl
@@ -964,6 +964,61 @@ end
     @test get_base_power(hvdc_device) == 100.0
 end
 
+@testset "OpenAPI converters: TModelHVDCLine" begin
+    # No device `base_power` at all (unlike TwoTerminalGenericHVDCLine): the active-power
+    # fields per-unitize on the *system* base via `get_base_power(refs)`; `base_current`,
+    # not a power base, is `r`/`l`/`c`'s own anchor.
+    refs = PSY.OpenAPIRefs(100.0)
+    dcbus_from_po = PSY.PO.DCBus(;
+        id = 30, number = 30, name = "dcbus30", available = true,
+        magnitude = 1.0, voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        base_voltage = 500.0,
+    )
+    dcbus_to_po = PSY.PO.DCBus(;
+        id = 31, number = 31, name = "dcbus31", available = true,
+        magnitude = 1.0, voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        base_voltage = 500.0,
+    )
+    refs[30] = PSY.from_openapi(dcbus_from_po, refs)
+    refs[31] = PSY.from_openapi(dcbus_to_po, refs)
+    arc_po = PSY.PO.Arc(; id = 32, from_id = 30, to_id = 31)
+    refs[32] = PSY.from_openapi(arc_po, refs, NU)
+
+    sys = System(100.0)
+    add_component!(sys, refs[30])
+    add_component!(sys, refs[31])
+
+    tmodel_po = PSY.PO.TModelHVDCLine(;
+        id = 33, name = "tmodel1", available = true, active_power_flow = 50.0, arc = 32,
+        parameter_units = "COMPONENT_BASE", base_current = 200.0,
+        r = 0.01, l = 0.02, c = 0.03,
+        active_power_limits_from = PSY.PC.MinMax(; min = -100.0, max = 100.0),
+        active_power_limits_to = PSY.PC.MinMax(; min = -100.0, max = 100.0),
+        power_units = "NATURAL_UNITS",
+    )
+
+    tmodel_natural = PSY.from_openapi(tmodel_po, refs, NU)
+    add_component!(sys, tmodel_natural)
+    @test get_active_power_flow(tmodel_natural, SU) == 0.5
+    @test get_active_power_limits_from(tmodel_natural, SU) == (min = -1.0, max = 1.0)
+    @test get_active_power_limits_to(tmodel_natural, SU) == (min = -1.0, max = 1.0)
+    @test get_base_current(tmodel_natural) == 200.0
+
+    tmodel_po_du = PSY.PO.TModelHVDCLine(;
+        id = 34, name = "tmodel2", available = true, active_power_flow = 0.5, arc = 32,
+        parameter_units = "COMPONENT_BASE", base_current = 200.0,
+        r = 0.01, l = 0.02, c = 0.03,
+        active_power_limits_from = PSY.PC.MinMax(; min = -1.0, max = 1.0),
+        active_power_limits_to = PSY.PC.MinMax(; min = -1.0, max = 1.0),
+        power_units = "COMPONENT_BASE",
+    )
+    tmodel_device = PSY.from_openapi(tmodel_po_du, refs, DU)
+    add_component!(sys, tmodel_device)
+    @test get_active_power_flow(tmodel_device, SU) == 0.5
+    @test get_active_power_limits_from(tmodel_device, SU) == (min = -1.0, max = 1.0)
+    @test !hasfield(PSY.PO.TModelHVDCLine, :base_power)
+end
+
 @testset "OpenAPI converters: AreaInterchange (generated)" begin
     # First type to carry `openapi_type` while sharing the "no device `base_power`"
     # shape that previously forced Area/LoadZone/TransmissionInterface/Line/

--- a/test/test_openapi_converters.jl
+++ b/test/test_openapi_converters.jl
@@ -5,14 +5,14 @@
 _bus_po(id; area = 1, load_zone = 2, bustype = "REF") = PSY.PO.ACBus(;
     id = id, number = id, name = "bus$id", available = true, bustype = bustype,
     angle = 0.0, magnitude = 1.0,
-    voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+    voltage_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
     base_voltage = 138.0, area = area, load_zone = load_zone,
 )
 
 """A LINEAR `InputOutputCurve`, the shape every `converter_loss`/`loss` field carries."""
 _io_curve(proportional_term, constant_term) = PSY.PC.InputOutputCurve(;
     function_data = PSY.PC.InputOutputCurveFunctionData(
-        PSY.PC.LinearFunctionData(;
+        PSY.IC.LinearFunctionData(;
             proportional_term = proportional_term,
             constant_term = constant_term,
         ),
@@ -27,26 +27,26 @@ mutable, so the error-path testsets mutate one field of their own copy.
 _vsc_po_minimal() = PSY.PO.TwoTerminalVSCLine(;
     id = 20, name = "vsc1", available = true, arc = 10,
     active_power_flow = 50.0, rating = 200.0,
-    active_power_limits_from = PSY.PC.MinMax(; min = -200.0, max = 200.0),
-    active_power_limits_to = PSY.PC.MinMax(; min = -200.0, max = 200.0),
+    active_power_limits_from = PSY.IC.MinMax(; min = -200.0, max = 200.0),
+    active_power_limits_to = PSY.IC.MinMax(; min = -200.0, max = 200.0),
     admittance_units = "NATURAL_UNITS", g = 0.5,
     dc_current = 300.0, reactive_power_from = 10.0,
     dc_control_from = "DC_POWER", ac_control_from = "AC_REACTIVE_POWER",
     dc_setpoint_from = 40.0, ac_setpoint_from = 0.95,
     converter_loss_from = _io_curve(1.2, 0.5),
     max_dc_current_from = 1000.0, rating_from = 200.0,
-    reactive_power_limits_from = PSY.PC.MinMax(; min = -100.0, max = 100.0),
+    reactive_power_limits_from = PSY.IC.MinMax(; min = -100.0, max = 100.0),
     power_factor_weighting_fraction_from = 0.5,
     voltage_units = "NATURAL_UNITS",
-    voltage_limits_from = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+    voltage_limits_from = PSY.IC.MinMax(; min = 0.9, max = 1.1),
     dc_voltage_droop_from = 0.0, reactive_power_to = 20.0,
     dc_control_to = "DC_POWER", ac_control_to = "AC_REACTIVE_POWER",
     dc_setpoint_to = 40.0, ac_setpoint_to = 0.98,
     converter_loss_to = _io_curve(1.1, 0.4),
     max_dc_current_to = 1000.0, rating_to = 200.0,
-    reactive_power_limits_to = PSY.PC.MinMax(; min = -100.0, max = 100.0),
+    reactive_power_limits_to = PSY.IC.MinMax(; min = -100.0, max = 100.0),
     power_factor_weighting_fraction_to = 0.5,
-    voltage_limits_to = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+    voltage_limits_to = PSY.IC.MinMax(; min = 0.9, max = 1.1),
     dc_voltage_droop_to = 0.0, rated_dc_voltage = 200.0,
     remote_bus_control_from = nothing, remote_bus_control_to = 4,
     rmpct_from = 100.0, rmpct_to = 100.0, base_power = 100.0,
@@ -181,7 +181,7 @@ end
 
     tx_po_du = PSY.PO.TransmissionInterface(;
         id = 1, name = "iface_du", available = true,
-        active_power_flow_limits = PSY.PC.MinMax(; min = -10.0, max = 10.0),
+        active_power_flow_limits = PSY.IC.MinMax(; min = -10.0, max = 10.0),
         violation_penalty = 5000.0,
         direction_mapping = Dict{String, Int64}("line1" => 1, "line2" => -1),
         base_power = 100.0,
@@ -195,7 +195,7 @@ end
 
     tx_po_nu = PSY.PO.TransmissionInterface(;
         id = 2, name = "iface_nu", available = true,
-        active_power_flow_limits = PSY.PC.MinMax(; min = -1000.0, max = 1000.0),
+        active_power_flow_limits = PSY.IC.MinMax(; min = -1000.0, max = 1000.0),
         violation_penalty = 5000.0,
         direction_mapping = Dict{String, Int64}("line1" => 1, "line2" => -1),
         base_power = 100.0,
@@ -208,7 +208,7 @@ end
     # A blob omitting the now-required `base_power` errors loudly rather than falling back.
     tx_po_missing_base = PSY.PO.TransmissionInterface(;
         id = 3, name = "iface_missing_base", available = true,
-        active_power_flow_limits = PSY.PC.MinMax(; min = -1000.0, max = 1000.0),
+        active_power_flow_limits = PSY.IC.MinMax(; min = -1000.0, max = 1000.0),
         violation_penalty = 5000.0,
         direction_mapping = Dict{String, Int64}(),
     )
@@ -225,10 +225,10 @@ end
         id = 20, name = "line1", available = true,
         active_power_flow = 10.0, reactive_power_flow = 2.0, arc = 10,
         r = 0.01, x = 0.1, base_power = 100.0,
-        b = PSY.PC.FromTo(; from = 0.001, to = 0.002),
+        b = PSY.IC.FromTo(; from = 0.001, to = 0.002),
         rating = 175.0, rating_b = 175.0, rating_c = nothing,
-        angle_limits = PSY.PC.MinMax(; min = -1.57, max = 1.57),
-        g = PSY.PC.FromTo(; from = 0.0, to = 0.0),
+        angle_limits = PSY.IC.MinMax(; min = -1.57, max = 1.57),
+        g = PSY.IC.FromTo(; from = 0.0, to = 0.0),
     )
 
     sys = System(100.0)
@@ -255,10 +255,10 @@ end
         id = 21, name = "line2", available = true,
         active_power_flow = 10.0, reactive_power_flow = 2.0, arc = 10,
         r = 0.01, x = 0.1, base_power = 100.0,
-        b = PSY.PC.FromTo(; from = 0.001, to = 0.002),
+        b = PSY.IC.FromTo(; from = 0.001, to = 0.002),
         rating = 175.0, rating_b = 175.0, rating_c = nothing,
-        angle_limits = PSY.PC.MinMax(; min = -1.57, max = 1.57),
-        g = PSY.PC.FromTo(; from = 0.0, to = 0.0),
+        angle_limits = PSY.IC.MinMax(; min = -1.57, max = 1.57),
+        g = PSY.IC.FromTo(; from = 0.0, to = 0.0),
     )
     line_device = PSY.from_openapi(line_po_device, refs, DU)
     add_component!(sys, line_device)
@@ -275,10 +275,10 @@ end
         id = 22, name = "line3", available = true,
         active_power_flow = 10.0, reactive_power_flow = 2.0, arc = 10,
         r = 0.01, x = 0.1,
-        b = PSY.PC.FromTo(; from = 0.001, to = 0.002),
+        b = PSY.IC.FromTo(; from = 0.001, to = 0.002),
         rating = 175.0, rating_b = 175.0, rating_c = nothing,
-        angle_limits = PSY.PC.MinMax(; min = -1.57, max = 1.57),
-        g = PSY.PC.FromTo(; from = 0.0, to = 0.0),
+        angle_limits = PSY.IC.MinMax(; min = -1.57, max = 1.57),
+        g = PSY.IC.FromTo(; from = 0.0, to = 0.0),
     )
     @test isnothing(line_po_omitted.base_power)
     @test_throws ErrorException PSY.from_openapi(line_po_omitted, refs, NU)
@@ -293,8 +293,8 @@ end
         id = 20, available = true, arc = 10, tap = 1.0, alpha = 0.05,
         parameter_units = "COMPONENT_BASE", r = 0.01, x = 0.1,
         control_objective = "UNDEFINED", regulated_bus_number = 0,
-        control_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
-        controlled_quantity_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        control_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
+        controlled_quantity_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
         number_of_tap_positions = 33,
         rating = 100.0, rating_b = nothing, rating_c = nothing,
         active_power_flow = 5.0, reactive_power_flow = 1.0,
@@ -321,8 +321,8 @@ end
         id = 21, available = true, arc = 10, tap = 1.0, alpha = 0.0,
         parameter_units = "NATURAL_UNITS", r = 0.01, x = 0.1,
         control_objective = "UNDEFINED", regulated_bus_number = 0,
-        control_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
-        controlled_quantity_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        control_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
+        controlled_quantity_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
         number_of_tap_positions = 33,
         rating = nothing, rating_b = nothing, rating_c = nothing,
         active_power_flow = 0.0, reactive_power_flow = 0.0,
@@ -334,7 +334,7 @@ end
     refs[20] = circuit_natural
     xfmr_po = PSY.PO.TwoWindingTransformer(;
         id = 30, name = "xfmr1", circuit = 20, admittance_units = "COMPONENT_BASE",
-        magnetizing_shunt = PSY.PC.ComplexNumber(; real = 0.01, imag = 0.02),
+        magnetizing_shunt = PSY.IC.ComplexNumber(; real = 0.01, imag = 0.02),
         shunt_location = "PRIMARY",
     )
     for val in (DU, NU)
@@ -346,7 +346,7 @@ end
 
     bad_xfmr_po = PSY.PO.TwoWindingTransformer(;
         id = 31, name = "xfmr2", circuit = 20, admittance_units = "COMPONENT_MVAR",
-        magnetizing_shunt = PSY.PC.ComplexNumber(; real = 0.0, imag = 0.0),
+        magnetizing_shunt = PSY.IC.ComplexNumber(; real = 0.0, imag = 0.0),
         shunt_location = "PRIMARY",
     )
     @test_throws ErrorException PSY.from_openapi(bad_xfmr_po, refs, DU
@@ -369,8 +369,8 @@ end
         id = id, available = true, arc = arc, tap = 1.0, alpha = 0.0,
         parameter_units = "COMPONENT_BASE", r = 0.001, x = 0.01,
         control_objective = "UNDEFINED", regulated_bus_number = 0,
-        control_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
-        controlled_quantity_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        control_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
+        controlled_quantity_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
         number_of_tap_positions = 33,
         rating = 100.0, rating_b = nothing, rating_c = nothing,
         active_power_flow = 0.0, reactive_power_flow = 0.0,
@@ -389,7 +389,7 @@ end
         r_12 = 0.01, x_12 = 0.1, r_23 = 0.015, x_23 = 0.15, r_31 = 0.02, x_31 = 0.2,
         base_power_12 = 100.0, base_power_23 = 100.0, base_power_31 = 100.0,
         admittance_units = "COMPONENT_BASE",
-        magnetizing_shunt = PSY.PC.ComplexNumber(; real = 0.03, imag = 0.0),
+        magnetizing_shunt = PSY.IC.ComplexNumber(; real = 0.03, imag = 0.0),
         shunt_location = "STAR",
     )
     for val in (DU, NU)
@@ -411,7 +411,7 @@ end
         id = 31, name = "t3w2", primary_circuit = 20, secondary_circuit = 21,
         tertiary_circuit = 22, star_bus = 5, parameter_units = "NATURAL_UNITS",
         admittance_units = "COMPONENT_BASE",
-        magnetizing_shunt = PSY.PC.ComplexNumber(; real = 0.0, imag = 0.0),
+        magnetizing_shunt = PSY.IC.ComplexNumber(; real = 0.0, imag = 0.0),
         shunt_location = "STAR",
     )
     @test_throws ErrorException PSY.from_openapi(bad_t3w_po, refs, DU
@@ -428,7 +428,7 @@ end
                 value_curve = PSY.PC.ValueCurve(
                     PSY.PC.InputOutputCurve(;
                         function_data = PSY.PC.InputOutputCurveFunctionData(
-                            PSY.PC.LinearFunctionData(;
+                            PSY.IC.LinearFunctionData(;
                                 proportional_term = 10.0, constant_term = 5.0,
                             ),
                         ),
@@ -440,11 +440,11 @@ end
     thermal_po = PSY.PO.ThermalStandard(;
         id = 20, name = "gen1", available = true, status = true, bus = 3,
         active_power = 50.0, reactive_power = 10.0, rating = 100.0,
-        active_power_limits = PSY.PC.MinMax(; min = 10.0, max = 100.0),
-        reactive_power_limits = PSY.PC.MinMax(; min = -50.0, max = 50.0),
-        ramp_limits = PSY.PC.UpDown(; up = 20.0, down = 20.0),
+        active_power_limits = PSY.IC.MinMax(; min = 10.0, max = 100.0),
+        reactive_power_limits = PSY.IC.MinMax(; min = -50.0, max = 50.0),
+        ramp_limits = PSY.IC.UpDown(; up = 20.0, down = 20.0),
         operation_cost = cost_po, base_power = 200.0,
-        time_limits = PSY.PC.UpDown(; up = 2.0, down = 2.0),
+        time_limits = PSY.IC.UpDown(; up = 2.0, down = 2.0),
         must_run = false, prime_mover_type = "OT", fuel = "NATURAL_GAS",
         time_at_status = 100.0,
     )
@@ -496,7 +496,7 @@ end
             value_curve = PSY.PC.ValueCurve(
                 PSY.PC.InputOutputCurve(;
                     function_data = PSY.PC.InputOutputCurveFunctionData(
-                        PSY.PC.LinearFunctionData(;
+                        PSY.IC.LinearFunctionData(;
                             proportional_term = 150.0, constant_term = 0.0,
                         ),
                     ),
@@ -525,7 +525,7 @@ end
     sload_po = PSY.PO.ShiftablePowerLoad(;
         id = 21, name = "sload1", available = true, bus = 4,
         active_power = 30.0,
-        active_power_limits = PSY.PC.MinMax(; min = 3.0, max = 30.0),
+        active_power_limits = PSY.IC.MinMax(; min = 3.0, max = 30.0),
         reactive_power = 5.0, max_active_power = 30.0, max_reactive_power = 5.0,
         base_power = 100.0, load_balance_time_horizon = 24, operation_cost = cost_po,
     )
@@ -548,7 +548,7 @@ end
     mvar_po = PSY.PO.FixedAdmittance(;
         id = 20, name = "shunt1", available = true, bus = 4,
         admittance_units = "COMPONENT_MVAR",
-        Y = PSY.PC.ComplexNumber(; real = 0.0, imag = -100.0),
+        Y = PSY.IC.ComplexNumber(; real = 0.0, imag = -100.0),
     )
     for val in (DU, NU)
         shunt = PSY.from_openapi(mvar_po, refs, val)
@@ -574,7 +574,7 @@ end
     bad_po = PSY.PO.FixedAdmittance(;
         id = 22, name = "shunt3", available = true, bus = 4,
         admittance_units = "NATURAL_UNITS",
-        Y = PSY.PC.ComplexNumber(; real = 0.0, imag = 0.0),
+        Y = PSY.IC.ComplexNumber(; real = 0.0, imag = 0.0),
     )
     @test_throws ErrorException PSY.from_openapi(bad_po, refs, DU
     )
@@ -590,7 +590,7 @@ end
                 value_curve = PSY.PC.ValueCurve(
                     PSY.PC.InputOutputCurve(;
                         function_data = PSY.PC.InputOutputCurveFunctionData(
-                            PSY.PC.LinearFunctionData(;
+                            PSY.IC.LinearFunctionData(;
                                 proportional_term = 1.0, constant_term = 0.0,
                             ),
                         ),
@@ -602,13 +602,13 @@ end
     turbine_po = PSY.PO.HydroTurbine(;
         id = 20, name = "turb1", available = true, bus = 3,
         active_power = 20.0, reactive_power = 5.0, rating = 50.0,
-        active_power_limits = PSY.PC.MinMax(; min = 0.0, max = 50.0),
-        reactive_power_limits = PSY.PC.MinMax(; min = -20.0, max = 20.0),
+        active_power_limits = PSY.IC.MinMax(; min = 0.0, max = 50.0),
+        reactive_power_limits = PSY.IC.MinMax(; min = -20.0, max = 20.0),
         base_power = 100.0, operation_cost = hydro_cost_po,
         powerhouse_elevation = 100.0,
-        ramp_limits = PSY.PC.UpDown(; up = 10.0, down = 10.0),
-        time_limits = PSY.PC.UpDown(; up = 1.0, down = 1.0),
-        outflow_limits = PSY.PC.MinMax(; min = 0.0, max = 500.0),
+        ramp_limits = PSY.IC.UpDown(; up = 10.0, down = 10.0),
+        time_limits = PSY.IC.UpDown(; up = 1.0, down = 1.0),
+        outflow_limits = PSY.IC.MinMax(; min = 0.0, max = 500.0),
         efficiency = 0.9, turbine_type = "FRANCIS", conversion_factor = 1.0,
         prime_mover_type = "HY", travel_time = 5.0,
     )
@@ -621,13 +621,13 @@ end
 
     reservoir_po = PSY.PO.HydroReservoir(;
         id = 21, name = "reservoir1", available = true,
-        storage_level_limits = PSY.PC.MinMax(; min = 0.0, max = 1000.0),
+        storage_level_limits = PSY.IC.MinMax(; min = 0.0, max = 1000.0),
         initial_level = 500.0,
-        spillage_limits = PSY.PC.MinMax(; min = 0.0, max = 100.0),
+        spillage_limits = PSY.IC.MinMax(; min = 0.0, max = 100.0),
         inflow = 10.0, outflow = 8.0, level_targets = 600.0,
         intake_elevation = 50.0,
-        head_to_volume_factor = PSY.PC.FunctionData(
-            PSY.PC.LinearFunctionData(; proportional_term = 0.001, constant_term = 0.0),
+        head_to_volume_factor = PSY.IC.FunctionData(
+            PSY.IC.LinearFunctionData(; proportional_term = 0.001, constant_term = 0.0),
         ),
         upstream_turbines = [20], downstream_turbines = Int[],
         upstream_reservoirs = Int[],
@@ -657,13 +657,13 @@ end
     # input. Must yield empty vectors, not a `MethodError: length(::Nothing)`.
     reservoir_head_po = PSY.PO.HydroReservoir(;
         id = 23, name = "reservoir_head", available = true,
-        storage_level_limits = PSY.PC.MinMax(; min = 0.0, max = 1000.0),
+        storage_level_limits = PSY.IC.MinMax(; min = 0.0, max = 1000.0),
         initial_level = 500.0,
-        spillage_limits = PSY.PC.MinMax(; min = 0.0, max = 100.0),
+        spillage_limits = PSY.IC.MinMax(; min = 0.0, max = 100.0),
         inflow = 10.0, outflow = 8.0, level_targets = 600.0,
         intake_elevation = 50.0,
-        head_to_volume_factor = PSY.PC.FunctionData(
-            PSY.PC.LinearFunctionData(; proportional_term = 0.001, constant_term = 0.0),
+        head_to_volume_factor = PSY.IC.FunctionData(
+            PSY.IC.LinearFunctionData(; proportional_term = 0.001, constant_term = 0.0),
         ),
         upstream_turbines = nothing, downstream_turbines = [20],
         upstream_reservoirs = nothing,
@@ -699,13 +699,13 @@ end
     # later as a JSON write failure.
     reservoir_tail_po = PSY.PO.HydroReservoir(;
         id = 24, name = "reservoir_tail", available = true,
-        storage_level_limits = PSY.PC.MinMax(; min = 0.0, max = 0.0),
+        storage_level_limits = PSY.IC.MinMax(; min = 0.0, max = 0.0),
         initial_level = 0.0,
         spillage_limits = nothing,
         inflow = 0.0, outflow = 0.0, level_targets = nothing,
         intake_elevation = 0.0,
-        head_to_volume_factor = PSY.PC.FunctionData(
-            PSY.PC.LinearFunctionData(; proportional_term = 0.0, constant_term = 0.0),
+        head_to_volume_factor = PSY.IC.FunctionData(
+            PSY.IC.LinearFunctionData(; proportional_term = 0.0, constant_term = 0.0),
         ),
         upstream_turbines = [20], downstream_turbines = Int[],
         upstream_reservoirs = Int[],
@@ -724,13 +724,13 @@ end
     # undefined, so it must fail loudly rather than import a NaN.
     bad_reservoir_po = PSY.PO.HydroReservoir(;
         id = 25, name = "reservoir_bad", available = true,
-        storage_level_limits = PSY.PC.MinMax(; min = 0.0, max = 0.0),
+        storage_level_limits = PSY.IC.MinMax(; min = 0.0, max = 0.0),
         initial_level = 500.0,
         spillage_limits = nothing,
         inflow = 0.0, outflow = 0.0, level_targets = nothing,
         intake_elevation = 0.0,
-        head_to_volume_factor = PSY.PC.FunctionData(
-            PSY.PC.LinearFunctionData(; proportional_term = 0.0, constant_term = 0.0),
+        head_to_volume_factor = PSY.IC.FunctionData(
+            PSY.IC.LinearFunctionData(; proportional_term = 0.0, constant_term = 0.0),
         ),
         upstream_turbines = [20], downstream_turbines = Int[],
         upstream_reservoirs = Int[],
@@ -745,10 +745,10 @@ end
         id = 22, name = "ror1", available = true, bus = 3,
         active_power = 15.0, reactive_power = 3.0, rating = 40.0,
         prime_mover_type = "HY",
-        active_power_limits = PSY.PC.MinMax(; min = 0.0, max = 40.0),
-        reactive_power_limits = PSY.PC.MinMax(; min = -15.0, max = 15.0),
-        ramp_limits = PSY.PC.UpDown(; up = 10.0, down = 10.0),
-        time_limits = PSY.PC.UpDown(; up = 1.0, down = 1.0),
+        active_power_limits = PSY.IC.MinMax(; min = 0.0, max = 40.0),
+        reactive_power_limits = PSY.IC.MinMax(; min = -15.0, max = 15.0),
+        ramp_limits = PSY.IC.UpDown(; up = 10.0, down = 10.0),
+        time_limits = PSY.IC.UpDown(; up = 1.0, down = 1.0),
         base_power = 100.0, status = true, time_at_status = 50.0,
         operation_cost = hydro_cost_po,
     )
@@ -769,7 +769,7 @@ end
                 value_curve = PSY.PC.ValueCurve(
                     PSY.PC.InputOutputCurve(;
                         function_data = PSY.PC.InputOutputCurveFunctionData(
-                            PSY.PC.LinearFunctionData(;
+                            PSY.IC.LinearFunctionData(;
                                 proportional_term = 0.0, constant_term = 0.0,
                             ),
                         ),
@@ -782,7 +782,7 @@ end
         id = 20, name = "wind1", available = true, bus = 4,
         active_power = 25.0, reactive_power = 5.0, rating = 50.0,
         prime_mover_type = "WT",
-        reactive_power_limits = PSY.PC.MinMax(; min = -20.0, max = 20.0),
+        reactive_power_limits = PSY.IC.MinMax(; min = -20.0, max = 20.0),
         power_factor = 0.95, operation_cost = ren_cost_po, base_power = 100.0,
     )
     wind = PSY.from_openapi(wind_po, refs, NU)
@@ -803,7 +803,7 @@ end
     condenser_po = PSY.PO.SynchronousCondenser(;
         id = 22, name = "syncon1", available = true, bus = 3,
         reactive_power = 5.0, rating = 20.0,
-        reactive_power_limits = PSY.PC.MinMax(; min = -20.0, max = 20.0),
+        reactive_power_limits = PSY.IC.MinMax(; min = -20.0, max = 20.0),
         base_power = 100.0, active_power_losses = 1.0,
     )
     condenser =
@@ -824,17 +824,17 @@ end
         id = 20, name = "storage1", available = true, bus = 4,
         prime_mover_type = "BA", storage_technology_type = "LIB",
         storage_capacity = 400.0, energy_units = "MWH",
-        storage_level_limits = PSY.PC.MinMax(; min = 0.0, max = 1.0),
+        storage_level_limits = PSY.IC.MinMax(; min = 0.0, max = 1.0),
         initial_storage_capacity_level = 0.5,
         rating = 100.0, active_power = 20.0,
-        input_active_power_limits = PSY.PC.MinMax(; min = 0.0, max = 100.0),
-        output_active_power_limits = PSY.PC.MinMax(; min = 0.0, max = 100.0),
-        efficiency = PSY.PC.InOut(; in = 0.9, out = 0.9),
+        input_active_power_limits = PSY.IC.MinMax(; min = 0.0, max = 100.0),
+        output_active_power_limits = PSY.IC.MinMax(; min = 0.0, max = 100.0),
+        efficiency = PSY.IC.InOut(; in = 0.9, out = 0.9),
         reactive_power = 5.0,
-        reactive_power_limits = PSY.PC.MinMax(; min = -50.0, max = 50.0),
+        reactive_power_limits = PSY.IC.MinMax(; min = -50.0, max = 50.0),
         base_power = 200.0, operation_cost = storage_cost_po,
         conversion_factor = 1.0, storage_target = 0.5, cycle_limits = 10000,
-        ramp_limits = PSY.PC.UpDown(; up = 100.0, down = 100.0),
+        ramp_limits = PSY.IC.UpDown(; up = 100.0, down = 100.0),
         self_discharge = 0.0, standing_loss = 2.0,
     )
     storage_natural =
@@ -859,17 +859,17 @@ end
         id = 21, name = "storage2", available = true, bus = 4,
         prime_mover_type = "BA", storage_technology_type = "LIB",
         storage_capacity = 400.0, energy_units = "MWMIN",
-        storage_level_limits = PSY.PC.MinMax(; min = 0.0, max = 1.0),
+        storage_level_limits = PSY.IC.MinMax(; min = 0.0, max = 1.0),
         initial_storage_capacity_level = 0.5,
         rating = 100.0, active_power = 20.0,
-        input_active_power_limits = PSY.PC.MinMax(; min = 0.0, max = 100.0),
-        output_active_power_limits = PSY.PC.MinMax(; min = 0.0, max = 100.0),
-        efficiency = PSY.PC.InOut(; in = 0.9, out = 0.9),
+        input_active_power_limits = PSY.IC.MinMax(; min = 0.0, max = 100.0),
+        output_active_power_limits = PSY.IC.MinMax(; min = 0.0, max = 100.0),
+        efficiency = PSY.IC.InOut(; in = 0.9, out = 0.9),
         reactive_power = 5.0,
-        reactive_power_limits = PSY.PC.MinMax(; min = -50.0, max = 50.0),
+        reactive_power_limits = PSY.IC.MinMax(; min = -50.0, max = 50.0),
         base_power = 200.0, operation_cost = storage_cost_po,
         conversion_factor = 1.0, storage_target = 0.5, cycle_limits = 10000,
-        ramp_limits = PSY.PC.UpDown(; up = 100.0, down = 100.0),
+        ramp_limits = PSY.IC.UpDown(; up = 100.0, down = 100.0),
         self_discharge = 0.0, standing_loss = 2.0,
     )
     @test_throws ErrorException PSY.from_openapi(bad_storage_po, refs, NU
@@ -883,14 +883,14 @@ end
 
     hvdc_po = PSY.PO.TwoTerminalGenericHVDCLine(;
         id = 20, name = "hvdc1", available = true, active_power_flow = 50.0, arc = 10,
-        active_power_limits_from = PSY.PC.MinMax(; min = -100.0, max = 100.0),
-        active_power_limits_to = PSY.PC.MinMax(; min = -100.0, max = 100.0),
-        reactive_power_limits_from = PSY.PC.MinMax(; min = -50.0, max = 50.0),
-        reactive_power_limits_to = PSY.PC.MinMax(; min = -50.0, max = 50.0),
+        active_power_limits_from = PSY.IC.MinMax(; min = -100.0, max = 100.0),
+        active_power_limits_to = PSY.IC.MinMax(; min = -100.0, max = 100.0),
+        reactive_power_limits_from = PSY.IC.MinMax(; min = -50.0, max = 50.0),
+        reactive_power_limits_to = PSY.IC.MinMax(; min = -50.0, max = 50.0),
         loss = PSY.PC.TwoTerminalLoss(
             PSY.PC.InputOutputCurve(;
                 function_data = PSY.PC.InputOutputCurveFunctionData(
-                    PSY.PC.LinearFunctionData(;
+                    PSY.IC.LinearFunctionData(;
                         proportional_term = 0.01,
                         constant_term = 0.0,
                     ),
@@ -918,14 +918,14 @@ end
     hvdc_po_missing_base = PSY.PO.TwoTerminalGenericHVDCLine(;
         id = 25, name = "hvdc_missing_base", available = true, active_power_flow = 50.0,
         arc = 10,
-        active_power_limits_from = PSY.PC.MinMax(; min = -100.0, max = 100.0),
-        active_power_limits_to = PSY.PC.MinMax(; min = -100.0, max = 100.0),
-        reactive_power_limits_from = PSY.PC.MinMax(; min = -50.0, max = 50.0),
-        reactive_power_limits_to = PSY.PC.MinMax(; min = -50.0, max = 50.0),
+        active_power_limits_from = PSY.IC.MinMax(; min = -100.0, max = 100.0),
+        active_power_limits_to = PSY.IC.MinMax(; min = -100.0, max = 100.0),
+        reactive_power_limits_from = PSY.IC.MinMax(; min = -50.0, max = 50.0),
+        reactive_power_limits_to = PSY.IC.MinMax(; min = -50.0, max = 50.0),
         loss = PSY.PC.TwoTerminalLoss(
             PSY.PC.InputOutputCurve(;
                 function_data = PSY.PC.InputOutputCurveFunctionData(
-                    PSY.PC.LinearFunctionData(;
+                    PSY.IC.LinearFunctionData(;
                         proportional_term = 0.01,
                         constant_term = 0.0,
                     ),
@@ -938,14 +938,14 @@ end
 
     hvdc_po_device = PSY.PO.TwoTerminalGenericHVDCLine(;
         id = 21, name = "hvdc2", available = true, active_power_flow = 50.0, arc = 10,
-        active_power_limits_from = PSY.PC.MinMax(; min = -100.0, max = 100.0),
-        active_power_limits_to = PSY.PC.MinMax(; min = -100.0, max = 100.0),
-        reactive_power_limits_from = PSY.PC.MinMax(; min = -50.0, max = 50.0),
-        reactive_power_limits_to = PSY.PC.MinMax(; min = -50.0, max = 50.0),
+        active_power_limits_from = PSY.IC.MinMax(; min = -100.0, max = 100.0),
+        active_power_limits_to = PSY.IC.MinMax(; min = -100.0, max = 100.0),
+        reactive_power_limits_from = PSY.IC.MinMax(; min = -50.0, max = 50.0),
+        reactive_power_limits_to = PSY.IC.MinMax(; min = -50.0, max = 50.0),
         loss = PSY.PC.TwoTerminalLoss(
             PSY.PC.InputOutputCurve(;
                 function_data = PSY.PC.InputOutputCurveFunctionData(
-                    PSY.PC.LinearFunctionData(;
+                    PSY.IC.LinearFunctionData(;
                         proportional_term = 0.01,
                         constant_term = 0.0,
                     ),
@@ -965,58 +965,63 @@ end
 end
 
 @testset "OpenAPI converters: TModelHVDCLine" begin
-    # No device `base_power` at all (unlike TwoTerminalGenericHVDCLine): the active-power
-    # fields per-unitize on the *system* base via `get_base_power(refs)`; `base_current`,
-    # not a power base, is `r`/`l`/`c`'s own anchor.
-    refs = PSY.OpenAPIRefs(100.0)
-    dcbus_from_po = PSY.PO.DCBus(;
-        id = 30, number = 30, name = "dcbus30", available = true,
-        magnitude = 1.0, voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
-        base_voltage = 500.0,
-    )
-    dcbus_to_po = PSY.PO.DCBus(;
-        id = 31, number = 31, name = "dcbus31", available = true,
-        magnitude = 1.0, voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
-        base_voltage = 500.0,
-    )
-    refs[30] = PSY.from_openapi(dcbus_from_po, refs)
-    refs[31] = PSY.from_openapi(dcbus_to_po, refs)
-    arc_po = PSY.PO.Arc(; id = 32, from_id = 30, to_id = 31)
-    refs[32] = PSY.from_openapi(arc_po, refs, NU)
-
-    sys = System(100.0)
-    add_component!(sys, refs[30])
-    add_component!(sys, refs[31])
+    # Exception among the branches: no `power_units` discriminator and no `base_power` at
+    # all — `active_power_flow`/`active_power_limits_from/to` are fixed natural units (MW),
+    # same posture as reserves' `requirement`, so import always divides by
+    # `get_base_power(refs)`; `base_current`, not a power base, is `r`/`l`/`c`'s own anchor.
+    # Self-interpretability: the physical MW value must survive regardless of which system
+    # base the blob is imported into (100.0 here, 250.0 below) — there is no recorded base
+    # on the wire to go stale.
+    function _tmodel_refs_with_dcbuses(base_power)
+        refs = PSY.OpenAPIRefs(base_power)
+        dcbus_from_po = PSY.PO.DCBus(;
+            id = 30, number = 30, name = "dcbus30", available = true,
+            magnitude = 1.0, voltage_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
+            base_voltage = 500.0,
+        )
+        dcbus_to_po = PSY.PO.DCBus(;
+            id = 31, number = 31, name = "dcbus31", available = true,
+            magnitude = 1.0, voltage_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
+            base_voltage = 500.0,
+        )
+        refs[30] = PSY.from_openapi(dcbus_from_po, refs)
+        refs[31] = PSY.from_openapi(dcbus_to_po, refs)
+        arc_po = PSY.PO.Arc(; id = 32, from_id = 30, to_id = 31)
+        refs[32] = PSY.from_openapi(arc_po, refs, NU)
+        return refs
+    end
 
     tmodel_po = PSY.PO.TModelHVDCLine(;
-        id = 33, name = "tmodel1", available = true, active_power_flow = 50.0, arc = 32,
+        id = 33, name = "tmodel1", available = true, active_power_flow = 125.0,
+        arc = 32,
         parameter_units = "COMPONENT_BASE", base_current = 200.0,
         r = 0.01, l = 0.02, c = 0.03,
-        active_power_limits_from = PSY.PC.MinMax(; min = -100.0, max = 100.0),
-        active_power_limits_to = PSY.PC.MinMax(; min = -100.0, max = 100.0),
-        power_units = "NATURAL_UNITS",
+        active_power_limits_from = PSY.IC.MinMax(; min = -250.0, max = 250.0),
+        active_power_limits_to = PSY.IC.MinMax(; min = -250.0, max = 250.0),
     )
-
-    tmodel_natural = PSY.from_openapi(tmodel_po, refs, NU)
-    add_component!(sys, tmodel_natural)
-    @test get_active_power_flow(tmodel_natural, SU) == 0.5
-    @test get_active_power_limits_from(tmodel_natural, SU) == (min = -1.0, max = 1.0)
-    @test get_active_power_limits_to(tmodel_natural, SU) == (min = -1.0, max = 1.0)
-    @test get_base_current(tmodel_natural) == 200.0
-
-    tmodel_po_du = PSY.PO.TModelHVDCLine(;
-        id = 34, name = "tmodel2", available = true, active_power_flow = 0.5, arc = 32,
-        parameter_units = "COMPONENT_BASE", base_current = 200.0,
-        r = 0.01, l = 0.02, c = 0.03,
-        active_power_limits_from = PSY.PC.MinMax(; min = -1.0, max = 1.0),
-        active_power_limits_to = PSY.PC.MinMax(; min = -1.0, max = 1.0),
-        power_units = "COMPONENT_BASE",
-    )
-    tmodel_device = PSY.from_openapi(tmodel_po_du, refs, DU)
-    add_component!(sys, tmodel_device)
-    @test get_active_power_flow(tmodel_device, SU) == 0.5
-    @test get_active_power_limits_from(tmodel_device, SU) == (min = -1.0, max = 1.0)
+    @test !hasfield(PSY.PO.TModelHVDCLine, :power_units)
     @test !hasfield(PSY.PO.TModelHVDCLine, :base_power)
+
+    refs_100 = _tmodel_refs_with_dcbuses(100.0)
+    sys_100 = System(100.0)
+    add_component!(sys_100, refs_100[30])
+    add_component!(sys_100, refs_100[31])
+    tmodel_100 = PSY.from_openapi(tmodel_po, refs_100)
+    add_component!(sys_100, tmodel_100)
+    @test get_active_power_flow(tmodel_100, MW) == 125.0
+    @test get_active_power_limits_from(tmodel_100, MW) == (min = -250.0, max = 250.0)
+    @test get_base_current(tmodel_100) == 200.0
+
+    # Default import kwarg is 100.0 (see `from_openapi(::Type{System}, doc)`); a mismatched
+    # target base (250.0 here) must still recover the same physical MW value.
+    refs_250 = _tmodel_refs_with_dcbuses(250.0)
+    sys_250 = System(250.0)
+    add_component!(sys_250, refs_250[30])
+    add_component!(sys_250, refs_250[31])
+    tmodel_250 = PSY.from_openapi(tmodel_po, refs_250)
+    add_component!(sys_250, tmodel_250)
+    @test get_active_power_flow(tmodel_250, MW) == 125.0
+    @test get_active_power_limits_to(tmodel_250, MW) == (min = -250.0, max = 250.0)
 end
 
 @testset "OpenAPI converters: AreaInterchange (generated)" begin
@@ -1038,7 +1043,7 @@ end
     interchange_po = PSY.PO.AreaInterchange(;
         id = 10, name = "flow12", available = true, active_power_flow = 25.0,
         from_area = 1, to_area = 20,
-        flow_limits = PSY.PC.FromToToFrom(; from_to = 100.0, to_from = -100.0),
+        flow_limits = PSY.IC.FromToToFrom(; from_to = 100.0, to_from = -100.0),
         base_power = 100.0,
     )
     device = PSY.from_openapi(interchange_po, refs, DU)
@@ -1057,7 +1062,7 @@ end
         PSY.PO.AreaInterchange(;
             id = 11, name = "bad", available = true, active_power_flow = 1.0,
             from_area = 999, to_area = 20,
-            flow_limits = PSY.PC.FromToToFrom(; from_to = 0.0, to_from = 0.0),
+            flow_limits = PSY.IC.FromToToFrom(; from_to = 0.0, to_from = 0.0),
             base_power = 100.0,
         ),
         refs,
@@ -1141,7 +1146,7 @@ end
         value_curve = PSY.PC.ValueCurve(
             PSY.PC.IncrementalCurve(;
                 function_data = PSY.PC.IncrementalCurveFunctionData(
-                    PSY.PC.PiecewiseStepData(; x_coords = [0.0, 100.0], y_coords = [10.0]),
+                    PSY.IC.PiecewiseStepData(; x_coords = [0.0, 100.0], y_coords = [10.0]),
                 ),
                 initial_input = 0.0,
             ),
@@ -1207,26 +1212,26 @@ end
     vsc_po = PSY.PO.TwoTerminalVSCLine(;
         id = 20, name = "vsc1", available = true, arc = 10,
         active_power_flow = 50.0, rating = 200.0,
-        active_power_limits_from = PSY.PC.MinMax(; min = -200.0, max = 200.0),
-        active_power_limits_to = PSY.PC.MinMax(; min = -200.0, max = 200.0),
+        active_power_limits_from = PSY.IC.MinMax(; min = -200.0, max = 200.0),
+        active_power_limits_to = PSY.IC.MinMax(; min = -200.0, max = 200.0),
         admittance_units = "NATURAL_UNITS", g = 0.5,
         dc_current = 300.0, reactive_power_from = 10.0,
         dc_control_from = "DC_POWER", ac_control_from = "AC_REACTIVE_POWER",
         dc_setpoint_from = 40.0, ac_setpoint_from = 0.95,
         converter_loss_from = _io_curve(1.2, 0.5),
         max_dc_current_from = 1000.0, rating_from = 200.0,
-        reactive_power_limits_from = PSY.PC.MinMax(; min = -100.0, max = 100.0),
+        reactive_power_limits_from = PSY.IC.MinMax(; min = -100.0, max = 100.0),
         power_factor_weighting_fraction_from = 0.5,
         voltage_units = "NATURAL_UNITS",
-        voltage_limits_from = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        voltage_limits_from = PSY.IC.MinMax(; min = 0.9, max = 1.1),
         dc_voltage_droop_from = 0.0, reactive_power_to = 20.0,
         dc_control_to = "DC_VOLTAGE", ac_control_to = "AC_REACTIVE_POWER",
         dc_setpoint_to = 204.0, ac_setpoint_to = 0.98,
         converter_loss_to = _io_curve(1.1, 0.4),
         max_dc_current_to = 1000.0, rating_to = 200.0,
-        reactive_power_limits_to = PSY.PC.MinMax(; min = -100.0, max = 100.0),
+        reactive_power_limits_to = PSY.IC.MinMax(; min = -100.0, max = 100.0),
         power_factor_weighting_fraction_to = 0.5,
-        voltage_limits_to = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+        voltage_limits_to = PSY.IC.MinMax(; min = 0.9, max = 1.1),
         dc_voltage_droop_to = 0.0, rated_dc_voltage = 200.0,
         remote_bus_control_from = nothing, remote_bus_control_to = 4,
         rmpct_from = 100.0, rmpct_to = 100.0, base_power = 100.0,
@@ -1324,7 +1329,7 @@ end
     vsc_po = _vsc_po_minimal()
     vsc_po.converter_loss_to = PSY.PC.InputOutputCurve(;
         function_data = PSY.PC.InputOutputCurveFunctionData(
-            PSY.PC.QuadraticFunctionData(;
+            PSY.IC.QuadraticFunctionData(;
                 quadratic_term = 0.01, proportional_term = 1.1, constant_term = 0.4,
             ),
         ),

--- a/test/test_openapi_converters.jl
+++ b/test/test_openapi_converters.jl
@@ -52,14 +52,15 @@ _vsc_po_minimal() = PSY.PO.TwoTerminalVSCLine(;
     rmpct_from = 100.0, rmpct_to = 100.0, base_power = 100.0,
 )
 
-function _refs_with_area_bus(unit_system = "NATURAL_UNITS"; base_power = 100.0)
-    refs = PSY.OpenAPIRefs(unit_system, base_power)
+function _refs_with_area_bus(; base_power = 100.0)
+    refs = PSY.OpenAPIRefs(base_power)
     area_po = PSY.PO.Area(;
         id = 1, name = "area1", peak_active_power = 100.0, peak_reactive_power = 20.0,
-        load_response = 0.0,
+        load_response = 0.0, base_power = base_power,
     )
     lz_po = PSY.PO.LoadZone(;
         id = 2, name = "lz1", peak_active_power = 100.0, peak_reactive_power = 20.0,
+        base_power = base_power,
     )
     refs[1] = PSY.from_openapi(area_po, refs, NU)
     refs[2] = PSY.from_openapi(lz_po, refs, NU)
@@ -108,85 +109,110 @@ end
     )
 end
 
-@testset "OpenAPI converters: Area / LoadZone (fixed-natural-unit peak conversion)" begin
-    # x-unit for peak_active_power/peak_reactive_power is fixed MW/MVAr (SiennaSchemas
-    # Operations/Topology/{Area,LoadZone}.json) — the document always carries these
-    # natural, so the conversion by the document base is the same in BOTH unit-system
-    # methods (mirrors reserve `requirement`, x-unit MW).
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
-    for (i, val) in enumerate((DU, NU))
-        area_po = PSY.PO.Area(;
-            id = 1, name = "area$i", peak_active_power = 250.0,
-            peak_reactive_power = 50.0, load_response = 12.5,
-        )
-        lz_po = PSY.PO.LoadZone(;
-            id = 2, name = "lz$i", peak_active_power = 250.0, peak_reactive_power = 50.0,
-        )
-        sys = System(100.0)
-        area = PSY.from_openapi(area_po, refs, val)
-        add_component!(sys, area)
-        @test get_peak_active_power(area, SU) == 2.5
-        @test get_peak_reactive_power(area, SU) == 0.5
-        @test get_load_response(area) == 12.5
+@testset "OpenAPI converters: Area / LoadZone (power_units-discriminated peak conversion)" begin
+    # x-unit for peak_active_power/peak_reactive_power is MW/MVAr (SiennaSchemas
+    # Operations/Topology/{Area,LoadZone}.json), discriminated per blob by `power_units`
+    # like every other power-family field: COMPONENT_BASE passes through pu, NATURAL_UNITS
+    # divides by the blob's own `base_power`.
+    refs = PSY.OpenAPIRefs(100.0)
 
-        lz = PSY.from_openapi(lz_po, refs, val)
-        add_component!(sys, lz)
-        @test get_peak_active_power(lz, SU) == 2.5
-        @test get_peak_reactive_power(lz, SU) == 0.5
+    area_po_du = PSY.PO.Area(;
+        id = 1, name = "area_du", peak_active_power = 2.5,
+        peak_reactive_power = 0.5, load_response = 12.5, base_power = 100.0,
+    )
+    lz_po_du = PSY.PO.LoadZone(;
+        id = 2, name = "lz_du", peak_active_power = 2.5, peak_reactive_power = 0.5,
+        base_power = 100.0,
+    )
+    sys_du = System(100.0)
+    area_du = PSY.from_openapi(area_po_du, refs, DU)
+    add_component!(sys_du, area_du)
+    lz_du = PSY.from_openapi(lz_po_du, refs, DU)
+    add_component!(sys_du, lz_du)
+    @test get_peak_active_power(area_du, SU) == 2.5
+    @test get_peak_reactive_power(area_du, SU) == 0.5
+    @test get_load_response(area_du) == 12.5
+    @test get_peak_active_power(lz_du, SU) == 2.5
+    @test get_peak_reactive_power(lz_du, SU) == 0.5
+    @test get_base_power(area_du) == 100.0
+    @test get_base_power(lz_du) == 100.0
 
-        # Both structs gained their own `base_power`. The
-        # document omits it above, so
-        # `_resolve_base_power` falls back to `get_base_power(refs)` — proving the
-        # backward-compat path, not just the happy path.
-        @test get_base_power(area) == 100.0
-        @test get_base_power(lz) == 100.0
-    end
-end
+    area_po_nu = PSY.PO.Area(;
+        id = 3, name = "area_nu", peak_active_power = 250.0,
+        peak_reactive_power = 50.0, load_response = 12.5, base_power = 100.0,
+    )
+    lz_po_nu = PSY.PO.LoadZone(;
+        id = 4, name = "lz_nu", peak_active_power = 250.0, peak_reactive_power = 50.0,
+        base_power = 100.0,
+    )
+    sys_nu = System(100.0)
+    area_nu = PSY.from_openapi(area_po_nu, refs, NU)
+    add_component!(sys_nu, area_nu)
+    lz_nu = PSY.from_openapi(lz_po_nu, refs, NU)
+    add_component!(sys_nu, lz_nu)
+    @test get_peak_active_power(area_nu, SU) == 2.5
+    @test get_peak_reactive_power(area_nu, SU) == 0.5
+    @test get_peak_active_power(lz_nu, SU) == 2.5
+    @test get_peak_reactive_power(lz_nu, SU) == 0.5
 
-@testset "OpenAPI converters: Area / LoadZone base_power stated explicitly" begin
-    # When a producer does state the component's own `base_power`, it is honored exactly
-    # (not silently overridden by the document-level system base), including when the two
-    # differ.
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
-    area_po = PSY.PO.Area(;
-        id = 1, name = "area_explicit", peak_active_power = 250.0,
+    # A blob whose own `base_power` differs from the System's is honored exactly.
+    area_po_explicit = PSY.PO.Area(;
+        id = 5, name = "area_explicit", peak_active_power = 250.0,
         peak_reactive_power = 50.0, load_response = 12.5, base_power = 250.0,
     )
-    lz_po = PSY.PO.LoadZone(;
-        id = 2, name = "lz_explicit", peak_active_power = 250.0,
-        peak_reactive_power = 50.0,
-        base_power = 250.0,
+    area_explicit = PSY.from_openapi(area_po_explicit, refs, NU)
+    @test get_base_power(area_explicit) == 250.0
+
+    # A blob omitting the now-required `base_power` errors loudly rather than falling back.
+    area_po_missing_base = PSY.PO.Area(;
+        id = 6, name = "area_missing_base", peak_active_power = 250.0,
+        peak_reactive_power = 50.0, load_response = 12.5,
     )
-    area = PSY.from_openapi(area_po, refs, NU)
-    lz = PSY.from_openapi(lz_po, refs, NU)
-    @test get_base_power(area) == 250.0
-    @test get_base_power(lz) == 250.0
+    @test isnothing(area_po_missing_base.base_power)
+    @test_throws ErrorException PSY.from_openapi(area_po_missing_base, refs, NU)
 end
 
-@testset "OpenAPI converters: TransmissionInterface (fixed-natural-unit conversion)" begin
-    # x-unit for active_power_flow_limits is fixed MW (SiennaSchemas
-    # Operations/Service/TransmissionInterface.json) — same disposition as Area/LoadZone's
-    # peak_active_power above, dividing by the document-level base in BOTH unit-system
-    # methods. The struct has its own `base_power` field, but
-    # `direction_mapping::Dict{String, Int}` still blocks codegen. The document below omits
-    # `base_power` is absent from the document, exercising the
-    # `_resolve_base_power` fallback to `get_base_power(refs)`.
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
-    for (i, val) in enumerate((DU, NU))
-        sys = System(100.0)
-        tx_po = PSY.PO.TransmissionInterface(;
-            id = 1, name = "iface$i", available = true,
-            active_power_flow_limits = PSY.PC.MinMax(; min = -1000.0, max = 1000.0),
-            violation_penalty = 5000.0,
-            direction_mapping = Dict{String, Int64}("line1" => 1, "line2" => -1),
-        )
-        tx = PSY.from_openapi(tx_po, refs, val)
-        add_component!(sys, tx)
-        @test get_active_power_flow_limits(tx, SU) == (min = -10.0, max = 10.0)
-        @test get_violation_penalty(tx) == 5000.0
-        @test get_direction_mapping(tx) == Dict("line1" => 1, "line2" => -1)
-        @test get_base_power(tx) == 100.0
-    end
+@testset "OpenAPI converters: TransmissionInterface (power_units-discriminated conversion)" begin
+    # x-unit for active_power_flow_limits is MW (SiennaSchemas
+    # Operations/Service/TransmissionInterface.json), discriminated by `power_units` like
+    # Area/LoadZone's peak fields above. `direction_mapping::Dict{String, Int}` still blocks
+    # codegen.
+    refs = PSY.OpenAPIRefs(100.0)
+
+    tx_po_du = PSY.PO.TransmissionInterface(;
+        id = 1, name = "iface_du", available = true,
+        active_power_flow_limits = PSY.PC.MinMax(; min = -10.0, max = 10.0),
+        violation_penalty = 5000.0,
+        direction_mapping = Dict{String, Int64}("line1" => 1, "line2" => -1),
+        base_power = 100.0,
+    )
+    tx_du = PSY.from_openapi(tx_po_du, refs, DU)
+    add_component!(System(100.0), tx_du)
+    @test get_active_power_flow_limits(tx_du, SU) == (min = -10.0, max = 10.0)
+    @test get_violation_penalty(tx_du) == 5000.0
+    @test get_direction_mapping(tx_du) == Dict("line1" => 1, "line2" => -1)
+    @test get_base_power(tx_du) == 100.0
+
+    tx_po_nu = PSY.PO.TransmissionInterface(;
+        id = 2, name = "iface_nu", available = true,
+        active_power_flow_limits = PSY.PC.MinMax(; min = -1000.0, max = 1000.0),
+        violation_penalty = 5000.0,
+        direction_mapping = Dict{String, Int64}("line1" => 1, "line2" => -1),
+        base_power = 100.0,
+    )
+    tx_nu = PSY.from_openapi(tx_po_nu, refs, NU)
+    add_component!(System(100.0), tx_nu)
+    @test get_active_power_flow_limits(tx_nu, SU) == (min = -10.0, max = 10.0)
+    @test get_base_power(tx_nu) == 100.0
+
+    # A blob omitting the now-required `base_power` errors loudly rather than falling back.
+    tx_po_missing_base = PSY.PO.TransmissionInterface(;
+        id = 3, name = "iface_missing_base", available = true,
+        active_power_flow_limits = PSY.PC.MinMax(; min = -1000.0, max = 1000.0),
+        violation_penalty = 5000.0,
+        direction_mapping = Dict{String, Int64}(),
+    )
+    @test_throws ErrorException PSY.from_openapi(tx_po_missing_base, refs, NU)
 end
 
 @testset "OpenAPI converters: Line" begin
@@ -244,8 +270,7 @@ end
     @test get_b(line_device, SU) == (from = 0.001, to = 0.002)
     @test get_base_power(line_device) == 100.0
 
-    # A producer that omits `base_power` (backward compat) falls back to the document's
-    # system base, via `_resolve_base_power` — same fallback as Area/LoadZone above.
+    # A blob omitting the now-required `base_power` errors loudly rather than falling back.
     line_po_omitted = PSY.PO.Line(;
         id = 22, name = "line3", available = true,
         active_power_flow = 10.0, reactive_power_flow = 2.0, arc = 10,
@@ -256,10 +281,7 @@ end
         g = PSY.PC.FromTo(; from = 0.0, to = 0.0),
     )
     @test isnothing(line_po_omitted.base_power)
-    line_omitted = PSY.from_openapi(line_po_omitted, refs, NU)
-    add_component!(sys, line_omitted)
-    @test get_base_power(line_omitted) == 100.0
-    @test get_rating(line_omitted, SU) == 1.75
+    @test_throws ErrorException PSY.from_openapi(line_po_omitted, refs, NU)
 end
 
 @testset "OpenAPI converters: TransformerCircuit / TwoWindingTransformer" begin
@@ -400,7 +422,7 @@ end
     refs = _refs_with_area_bus()
     cost_po = PSY.PC.ThermalGenerationCost(;
         fixed = 100.0, shut_down = 50.0, start_up = 200.0,
-        variable = PSY.PC.ProductionVariableCostCurve(
+        variable_operation_cost = PSY.PC.ProductionVariableCostCurve(
             PSY.PC.CostCurve(;
                 power_units = "NATURAL_UNITS",
                 value_curve = PSY.PC.ValueCurve(
@@ -469,7 +491,7 @@ end
     refs = _refs_with_area_bus()
     cost_po = PSY.PC.LoadCost(;
         fixed = 2400.0,
-        variable = PSY.PC.CostCurve(;
+        variable_operation_cost = PSY.PC.CostCurve(;
             power_units = "NATURAL_UNITS",
             value_curve = PSY.PC.ValueCurve(
                 PSY.PC.InputOutputCurve(;
@@ -562,7 +584,7 @@ end
     refs = _refs_with_area_bus()
     hydro_cost_po = PSY.PC.HydroGenerationCost(;
         fixed = 1.0,
-        variable = PSY.PC.ProductionVariableCostCurve(
+        variable_operation_cost = PSY.PC.ProductionVariableCostCurve(
             PSY.PC.CostCurve(;
                 power_units = "NATURAL_UNITS",
                 value_curve = PSY.PC.ValueCurve(
@@ -741,7 +763,7 @@ end
     refs = _refs_with_area_bus()
     ren_cost_po = PSY.PC.RenewableGenerationCost(;
         fixed = 0.0,
-        variable = PSY.PC.ProductionVariableCostCurve(
+        variable_operation_cost = PSY.PC.ProductionVariableCostCurve(
             PSY.PC.CostCurve(;
                 power_units = "NATURAL_UNITS",
                 value_curve = PSY.PC.ValueCurve(
@@ -875,6 +897,7 @@ end
                 ),
             ),
         ),
+        base_power = 100.0,
     )
     sys = System(100.0)
     add_component!(sys, refs[1])
@@ -889,10 +912,29 @@ end
     @test get_active_power_limits_from(hvdc_natural, SU) == (min = -1.0, max = 1.0)
     @test get_reactive_power_limits_to(hvdc_natural, SU) == (min = -0.5, max = 0.5)
     @test get_loss(hvdc_natural) == LinearCurve(0.01, 0.0)
-    # `hvdc_po` omits `base_power` (backward compat with
-    # `_resolve_base_power` falls back to `get_base_power(refs)`.
-    @test isnothing(hvdc_po.base_power)
     @test get_base_power(hvdc_natural) == 100.0
+
+    # A blob omitting the now-required `base_power` errors loudly rather than falling back.
+    hvdc_po_missing_base = PSY.PO.TwoTerminalGenericHVDCLine(;
+        id = 25, name = "hvdc_missing_base", available = true, active_power_flow = 50.0,
+        arc = 10,
+        active_power_limits_from = PSY.PC.MinMax(; min = -100.0, max = 100.0),
+        active_power_limits_to = PSY.PC.MinMax(; min = -100.0, max = 100.0),
+        reactive_power_limits_from = PSY.PC.MinMax(; min = -50.0, max = 50.0),
+        reactive_power_limits_to = PSY.PC.MinMax(; min = -50.0, max = 50.0),
+        loss = PSY.PC.TwoTerminalLoss(
+            PSY.PC.InputOutputCurve(;
+                function_data = PSY.PC.InputOutputCurveFunctionData(
+                    PSY.PC.LinearFunctionData(;
+                        proportional_term = 0.01,
+                        constant_term = 0.0,
+                    ),
+                ),
+            ),
+        ),
+    )
+    @test isnothing(hvdc_po_missing_base.base_power)
+    @test_throws ErrorException PSY.from_openapi(hvdc_po_missing_base, refs, NU)
 
     hvdc_po_device = PSY.PO.TwoTerminalGenericHVDCLine(;
         id = 21, name = "hvdc2", available = true, active_power_flow = 50.0, arc = 10,
@@ -910,6 +952,7 @@ end
                 ),
             ),
         ),
+        base_power = 100.0,
     )
     hvdc_device = PSY.from_openapi(hvdc_po_device,
         refs,
@@ -933,7 +976,7 @@ end
     # second `Area` is needed since AreaInterchange's `to_area` is typed `Area`, not `LoadZone`.
     area2_po = PSY.PO.Area(;
         id = 20, name = "area2", peak_active_power = 50.0, peak_reactive_power = 10.0,
-        load_response = 0.0,
+        load_response = 0.0, base_power = 100.0,
     )
     refs[20] = PSY.from_openapi(area2_po, refs, NU)
 
@@ -968,7 +1011,7 @@ end
 end
 
 @testset "OpenAPI converters: Substation (hand-written, no descriptor entry)" begin
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     po =
         PSY.PO.Substation(; id = 30, name = "SUB1", number = 7, grounding_resistance = 0.25)
     attr = PSY.from_openapi(po, refs)
@@ -982,7 +1025,7 @@ end
 end
 
 @testset "OpenAPI converters: reserves" begin
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     sys = System(100.0)
 
     online_po = PSY.PO.OnlineReserve(;
@@ -1006,7 +1049,7 @@ end
     online_device =
         PSY.from_openapi(online_po_device, refs, DU)
     add_component!(sys, online_device)
-    @test get_requirement(online_device, SU) == 100.0
+    @test get_requirement(online_device, SU) == 1.0
 
     down_po = PSY.PO.OnlineReserve(;
         id = 2, name = "spin_down", available = true, time_frame = 10.0,
@@ -1079,7 +1122,7 @@ end
     offline_device =
         PSY.from_openapi(offline_po_device, refs, DU)
     add_component!(sys, offline_device)
-    @test get_requirement(offline_device, SU) == 50.0
+    @test get_requirement(offline_device, SU) == 0.5
 
     group_po = PSY.PO.GroupReserve(;
         id = 7, name = "group_up", available = true, requirement = 150.0,
@@ -1096,7 +1139,7 @@ end
     )
     group_device = PSY.from_openapi(group_po_device, refs, DU)
     add_component!(sys, group_device)
-    @test get_requirement(group_device, SU) == 150.0
+    @test get_requirement(group_device, SU) == 1.5
 end
 
 @testset "OpenAPI converters: TwoTerminalVSCLine" begin
@@ -1315,7 +1358,7 @@ end
         id = 30, name = "load1", available = true, bus = 3, base_power = 100.0,
         operation_cost = PSY.PC.LoadCost(;
             fixed = 2400.0,
-            variable = PSY.PC.CostCurve(;
+            variable_operation_cost = PSY.PC.CostCurve(;
                 power_units = "NATURAL_UNITS",
                 value_curve = PSY.PC.ValueCurve(_io_curve(150.0, 0.0)),
             ),

--- a/test/test_openapi_cost_conversion.jl
+++ b/test/test_openapi_cost_conversion.jl
@@ -413,7 +413,7 @@ end
     )
     @test_throws ErrorException PSY.convert_cost(
         PSY.PC.MarketBidTimeSeriesCost(;
-            no_load_cost = PSY.PC.TimeSeriesInputOutputCurve(;
+            minimum_energy_offer = PSY.PC.TimeSeriesInputOutputCurve(;
                 function_data = PSY.PC.FunctionData(
                     PSY.PC.TimeSeriesLinearFunctionData(; association_id = 1),
                 ),

--- a/test/test_openapi_cost_conversion.jl
+++ b/test/test_openapi_cost_conversion.jl
@@ -2,7 +2,7 @@
 
 _po_linear_io(prop, const_) = PSY.PC.InputOutputCurve(;
     function_data = PSY.PC.InputOutputCurveFunctionData(
-        PSY.PC.LinearFunctionData(; proportional_term = prop, constant_term = const_),
+        PSY.IC.LinearFunctionData(; proportional_term = prop, constant_term = const_),
     ),
 )
 
@@ -14,11 +14,11 @@ _po_cost_curve(; power_units = "NATURAL_UNITS", vom_cost = nothing) = PSY.PC.Cos
 
 @testset "convert_cost: FunctionData variants" begin
     @test PSY.convert_cost(
-        PSY.PC.LinearFunctionData(; proportional_term = 2.0, constant_term = 3.0),
+        PSY.IC.LinearFunctionData(; proportional_term = 2.0, constant_term = 3.0),
     ) == LinearFunctionData(2.0, 3.0)
 
     @test PSY.convert_cost(
-        PSY.PC.QuadraticFunctionData(;
+        PSY.IC.QuadraticFunctionData(;
             quadratic_term = 1.0,
             proportional_term = 2.0,
             constant_term = 3.0,
@@ -26,16 +26,16 @@ _po_cost_curve(; power_units = "NATURAL_UNITS", vom_cost = nothing) = PSY.PC.Cos
     ) == QuadraticFunctionData(1.0, 2.0, 3.0)
 
     @test PSY.convert_cost(
-        PSY.PC.PiecewiseLinearData(;
+        PSY.IC.PiecewiseLinearData(;
             points = [
-                PSY.PC.XYCoords(; x = 0.0, y = 0.0),
-                PSY.PC.XYCoords(; x = 10.0, y = 100.0),
+                PSY.IC.XYCoords(; x = 0.0, y = 0.0),
+                PSY.IC.XYCoords(; x = 10.0, y = 100.0),
             ],
         ),
     ) == PiecewiseLinearData([(x = 0.0, y = 0.0), (x = 10.0, y = 100.0)])
 
     @test PSY.convert_cost(
-        PSY.PC.PiecewiseStepData(; x_coords = [0.0, 10.0, 20.0], y_coords = [5.0, 6.0]),
+        PSY.IC.PiecewiseStepData(; x_coords = [0.0, 10.0, 20.0], y_coords = [5.0, 6.0]),
     ) == PiecewiseStepData([0.0, 10.0, 20.0], [5.0, 6.0])
 
     @test_throws ErrorException PSY.convert_cost(nothing)
@@ -48,7 +48,7 @@ end
     inc = PSY.convert_cost(
         PSY.PC.IncrementalCurve(;
             function_data = PSY.PC.IncrementalCurveFunctionData(
-                PSY.PC.PiecewiseStepData(; x_coords = [0.0, 10.0], y_coords = [5.0]),
+                PSY.IC.PiecewiseStepData(; x_coords = [0.0, 10.0], y_coords = [5.0]),
             ),
             initial_input = 50.0,
         ),
@@ -58,7 +58,7 @@ end
     avg = PSY.convert_cost(
         PSY.PC.AverageRateCurve(;
             function_data = PSY.PC.IncrementalCurveFunctionData(
-                PSY.PC.LinearFunctionData(; proportional_term = 1.0, constant_term = 0.0),
+                PSY.IC.LinearFunctionData(; proportional_term = 1.0, constant_term = 0.0),
             ),
             initial_input = 20.0,
         ),
@@ -111,7 +111,7 @@ end
             value_curve = PSY.PC.ValueCurve(
                 PSY.PC.IncrementalCurve(;
                     function_data = PSY.PC.IncrementalCurveFunctionData(
-                        PSY.PC.PiecewiseStepData(;
+                        PSY.IC.PiecewiseStepData(;
                             x_coords = [0.0, 10.0, 20.0],
                             y_coords = [5.0, 6.0],
                         ),
@@ -131,7 +131,7 @@ end
     bad = _po_cost_curve(;
         vom_cost = PSY.PC.InputOutputCurve(;
             function_data = PSY.PC.InputOutputCurveFunctionData(
-                PSY.PC.QuadraticFunctionData(;
+                PSY.IC.QuadraticFunctionData(;
                     quadratic_term = 1.0,
                     proportional_term = 1.0,
                     constant_term = 1.0,
@@ -239,7 +239,7 @@ _po_offer_curve(x_coords, y_coords; power_units = "NATURAL_UNITS") = PSY.PC.Cost
     value_curve = PSY.PC.ValueCurve(
         PSY.PC.IncrementalCurve(;
             function_data = PSY.PC.IncrementalCurveFunctionData(
-                PSY.PC.PiecewiseStepData(; x_coords = x_coords, y_coords = y_coords),
+                PSY.IC.PiecewiseStepData(; x_coords = x_coords, y_coords = y_coords),
             ),
             initial_input = 0.0,
         ),
@@ -314,7 +314,7 @@ end
         value_curve = PSY.PC.ValueCurve(
             PSY.PC.IncrementalCurve(;
                 function_data = PSY.PC.IncrementalCurveFunctionData(
-                    PSY.PC.PiecewiseStepData(; x_coords = [0.0, 100.0], y_coords = [10.0]),
+                    PSY.IC.PiecewiseStepData(; x_coords = [0.0, 100.0], y_coords = [10.0]),
                 ),
                 initial_input = 0.0,
             ),
@@ -389,8 +389,8 @@ end
                     power_units = "NATURAL_UNITS",
                     value_curve = PSY.PC.ValueCurve(
                         PSY.PC.TimeSeriesIncrementalCurve(;
-                            function_data = PSY.PC.FunctionData(
-                                PSY.PC.TimeSeriesLinearFunctionData(;
+                            function_data = PSY.IC.FunctionData(
+                                PSY.IC.TimeSeriesLinearFunctionData(;
                                     association_id = assoc_id,
                                 ),
                             ),
@@ -423,22 +423,22 @@ end
     @test_throws ErrorException PSY.convert_cost(
         PSY.PC.MarketBidTimeSeriesCost(;
             minimum_energy_offer = PSY.PC.TimeSeriesInputOutputCurve(;
-                function_data = PSY.PC.FunctionData(
-                    PSY.PC.TimeSeriesLinearFunctionData(; association_id = 1),
+                function_data = PSY.IC.FunctionData(
+                    PSY.IC.TimeSeriesLinearFunctionData(; association_id = 1),
                 ),
             ),
             start_up_association_id = 2,
             shut_down = PSY.PC.TimeSeriesInputOutputCurve(;
-                function_data = PSY.PC.FunctionData(
-                    PSY.PC.TimeSeriesLinearFunctionData(; association_id = 3),
+                function_data = PSY.IC.FunctionData(
+                    PSY.IC.TimeSeriesLinearFunctionData(; association_id = 3),
                 ),
             ),
             incremental_offer_curves = PSY.PC.CostCurve(;
                 power_units = "NATURAL_UNITS",
                 value_curve = PSY.PC.ValueCurve(
                     PSY.PC.TimeSeriesIncrementalCurve(;
-                        function_data = PSY.PC.FunctionData(
-                            PSY.PC.TimeSeriesPiecewiseStepData(; association_id = 4),
+                        function_data = PSY.IC.FunctionData(
+                            PSY.IC.TimeSeriesPiecewiseStepData(; association_id = 4),
                         ),
                     ),
                 ),
@@ -447,8 +447,8 @@ end
                 power_units = "NATURAL_UNITS",
                 value_curve = PSY.PC.ValueCurve(
                     PSY.PC.TimeSeriesIncrementalCurve(;
-                        function_data = PSY.PC.FunctionData(
-                            PSY.PC.TimeSeriesPiecewiseStepData(; association_id = 5),
+                        function_data = PSY.IC.FunctionData(
+                            PSY.IC.TimeSeriesPiecewiseStepData(; association_id = 5),
                         ),
                     ),
                 ),

--- a/test/test_openapi_cost_conversion.jl
+++ b/test/test_openapi_cost_conversion.jl
@@ -147,14 +147,14 @@ end
         fixed = 100.0,
         shut_down = 50.0,
         start_up = 200.0,
-        variable = PSY.PC.ProductionVariableCostCurve(_po_cost_curve()),
+        variable_operation_cost = PSY.PC.ProductionVariableCostCurve(_po_cost_curve()),
     )
     cost = PSY.convert_cost(po)
     @test cost isa ThermalGenerationCost
     @test get_fixed(cost) == 100.0
     @test get_shut_down(cost) == 50.0
     @test get_start_up(cost) == 200.0
-    @test get_function_data(get_value_curve(get_variable(cost))) ==
+    @test get_function_data(get_value_curve(get_variable_operation_cost(cost))) ==
           LinearFunctionData(10.0, 5.0)
 
     po_stages = PSY.PC.ThermalGenerationCost(;
@@ -163,7 +163,7 @@ end
         start_up = PSY.PC.ThermalGenerationCostStartUp(
             PSY.PC.StartUpStages(; hot = 1.0, warm = 2.0, cold = 3.0),
         ),
-        variable = PSY.PC.ProductionVariableCostCurve(_po_cost_curve()),
+        variable_operation_cost = PSY.PC.ProductionVariableCostCurve(_po_cost_curve()),
     )
     cost_stages = PSY.convert_cost(po_stages)
     @test get_start_up(cost_stages) == (hot = 1.0, warm = 2.0, cold = 3.0)
@@ -172,25 +172,27 @@ end
         fixed = 0.0,
         shut_down = 0.0,
         start_up = 0.0,
-        variable = nothing,
+        variable_operation_cost = nothing,
     )
     @test_throws ErrorException PSY.convert_cost(po_missing_variable)
 end
 
 @testset "convert_cost: RenewableGenerationCost" begin
-    po = PSY.PC.RenewableGenerationCost(; variable = _po_cost_curve(), fixed = 10.0)
+    po = PSY.PC.RenewableGenerationCost(;
+        variable_operation_cost = _po_cost_curve(), fixed = 10.0,
+    )
     cost = PSY.convert_cost(po)
     @test cost isa RenewableGenerationCost
     @test get_fixed(cost) == 10.0
     @test get_curtailment_cost(cost) == zero(CostCurve)
-    @test get_function_data(get_value_curve(get_variable(cost))) ==
+    @test get_function_data(get_value_curve(get_variable_operation_cost(cost))) ==
           LinearFunctionData(10.0, 5.0)
 end
 
 @testset "convert_cost: HydroGenerationCost" begin
     po = PSY.PC.HydroGenerationCost(;
         fixed = 1.0,
-        variable = PSY.PC.ProductionVariableCostCurve(_po_cost_curve()),
+        variable_operation_cost = PSY.PC.ProductionVariableCostCurve(_po_cost_curve()),
     )
     cost = PSY.convert_cost(po)
     @test cost isa HydroGenerationCost
@@ -379,7 +381,7 @@ end
             series,
         )
         IS.commit_batch!(store, batch)
-        assoc_id = IS.get_association_id(only(IS.list_metadata(store)))
+        assoc_id = IS.get_association_id(only(IS.list_time_series_metadata(store)))
 
         fc = PSY._with_import_store(store) do
             PSY.convert_cost(
@@ -511,7 +513,7 @@ end
             series,
         )
         IS.commit_batch!(store, batch)
-        assoc_id = IS.get_association_id(only(IS.list_metadata(store)))
+        assoc_id = IS.get_association_id(only(IS.list_time_series_metadata(store)))
         ts_key = IS.get_time_series_key(store, Int(assoc_id))
 
         static_cost = ImportExportCost(;
@@ -590,7 +592,7 @@ end
     set_operation_cost!(
         gen,
         ThermalGenerationCost(;
-            variable = FuelCurve(LinearCurve(1.0), key),
+            variable_operation_cost = FuelCurve(LinearCurve(1.0), key),
             fixed = 0.0, start_up = 0.0, shut_down = 0.0,
         ),
     )

--- a/test/test_openapi_document.jl
+++ b/test/test_openapi_document.jl
@@ -150,7 +150,7 @@ end
         # Association references an unresolved entity_id.
         doc = make_openapi_test_doc()
         doc["supplemental_attributes"] =
-            [openapi_raw(PSY.PC.GeographicInfo(; id = 1, geo_json = Dict{String, Any}()))]
+            [openapi_raw(PSY.IC.GeographicInfo(; id = 1, geo_json = Dict{String, Any}()))]
         doc["supplemental_attribute_associations"] = [
             Dict{String, Any}(
                 "attribute_id" => 1, "component_id" => 999, "component_type" => "ACBus",
@@ -163,7 +163,7 @@ end
 
 @testset "from_openapi(System, doc): supplemental attribute real dispatch" begin
     doc = make_openapi_test_doc()
-    geo_po = PSY.PC.GeographicInfo(;
+    geo_po = PSY.IC.GeographicInfo(;
         id = 100,
         geo_json = Dict{String, Any}("type" => "Point", "coordinates" => [1.0, 2.0]),
     )
@@ -172,7 +172,7 @@ end
         emission_rate = PSY.PC.ValueCurve(
             PSY.PC.IncrementalCurve(;
                 function_data = PSY.PC.IncrementalCurveFunctionData(
-                    PSY.PC.LinearFunctionData(;
+                    PSY.IC.LinearFunctionData(;
                         proportional_term = 0.0,
                         constant_term = 1.5,
                     ),
@@ -226,7 +226,7 @@ end
         emission_rate = PSY.PC.ValueCurve(
             PSY.PC.IncrementalCurve(;
                 function_data = PSY.PC.IncrementalCurveFunctionData(
-                    PSY.PC.LinearFunctionData(;
+                    PSY.IC.LinearFunctionData(;
                         proportional_term = 0.0,
                         constant_term = 1.5,
                     ),
@@ -292,7 +292,7 @@ end
     cc_frac = PSY.from_openapi(cc_frac_po, refs)
     @test get_configuration(cc_frac) == CombinedCycleConfiguration.Other
 
-    geo_po = PSY.PC.GeographicInfo(;
+    geo_po = PSY.IC.GeographicInfo(;
         id = 11,
         geo_json = Dict{String, Any}("type" => "Point", "coordinates" => [1.0, 2.0]),
     )

--- a/test/test_openapi_document.jl
+++ b/test/test_openapi_document.jl
@@ -328,12 +328,13 @@ end
     add_service!(sys, svc, [gen])
 
     mbc = MarketBidCost(;
-        no_load_cost = LinearCurve(5.0),
+        minimum_energy_offer = LinearCurve(5.0),
         start_up = (hot = 100.0, warm = 200.0, cold = 300.0),
         shut_down = LinearCurve(2.0),
         incremental_offer_curves = make_market_bid_curve(
             [0.0, 50.0, 100.0], [10.0, 20.0], 0.0; power_units = IS.NaturalUnit(),
         ),
+        incremental_slope = true,
     )
     push!(get_ancillary_service_offers(mbc), svc)
     set_operation_cost!(gen, mbc)
@@ -344,15 +345,89 @@ end
     gen2 = get_component(ThermalStandard, sys2, "gen1")
     mbc2 = get_operation_cost(gen2)
     @test mbc2 isa MarketBidCost
-    @test get_no_load_cost(mbc2) == LinearCurve(5.0)
+    @test get_minimum_energy_offer(mbc2) == LinearCurve(5.0)
     @test get_start_up(mbc2) == (hot = 100.0, warm = 200.0, cold = 300.0)
     @test get_shut_down(mbc2) == LinearCurve(2.0)
     @test get_incremental_offer_curves(mbc2) == get_incremental_offer_curves(mbc)
     @test get_decremental_offer_curves(mbc2) == get_decremental_offer_curves(mbc)
+    @test get_incremental_slope(mbc2)
+    @test !get_decremental_slope(mbc2)
+    @test get_curve_style(mbc2) == CurveStyles.CURVE
     offers = get_ancillary_service_offers(mbc2)
     @test length(offers) == 1
     @test get_name(only(offers)) == "RESERVE"
     @test only(offers) === get_component(OnlineReserve{ReserveUp}, sys2, "RESERVE")
+end
+
+"""Build a `System` with one `ThermalStandard` (`gen1`) carrying a plain `MarketBidCost`.
+Returns `(sys, gen)`. Used to reach the wire-level `curve_style`/`incremental_slope` fields
+by patching the raw JSON text: patching the parsed `PO.MarketBidCost` in place instead would
+go through `OpenAPI.jl`'s own `setproperty!` validation (rejects an out-of-range enum value
+immediately) or would drop a `nothing` field entirely on write (turning "explicit null" back
+into "key omitted, use the struct default")."""
+function _market_bid_cost_fixture()
+    sys = System(100.0)
+    bus = ACBus(nothing)
+    bus.name = "bus1"
+    bus.number = 1
+    bus.bustype = ACBusTypes.REF
+    add_component!(sys, bus)
+    gen = ThermalStandard(nothing)
+    gen.bus = bus
+    gen.name = "gen1"
+    add_component!(sys, gen)
+    mbc = MarketBidCost(;
+        minimum_energy_offer = LinearCurve(5.0),
+        start_up = (hot = 100.0, warm = 200.0, cold = 300.0),
+        shut_down = LinearCurve(2.0),
+        incremental_offer_curves = make_market_bid_curve(
+            [0.0, 50.0, 100.0], [10.0, 20.0], 0.0; power_units = IS.NaturalUnit(),
+        ),
+    )
+    set_operation_cost!(gen, mbc)
+    return (sys, gen)
+end
+
+@testset "convert_cost(MarketBidCost): explicit null curve_style errors loudly, not MethodError" begin
+    sys, gen = _market_bid_cost_fixture()
+    mktempdir() do dir
+        to_file(sys, dir; force = true)
+        document_path = joinpath(dir, "system.json")
+        txt = read(document_path, String)
+        @test occursin("\"curve_style\":0", txt)
+        write(document_path, replace(txt, "\"curve_style\":0" => "\"curve_style\":null"))
+        @test_throws "MarketBidCost.curve_style is required and missing" from_file(
+            System, dir,
+        )
+    end
+end
+
+@testset "convert_cost(MarketBidCost): explicit null incremental_slope errors loudly" begin
+    sys, gen = _market_bid_cost_fixture()
+    mktempdir() do dir
+        to_file(sys, dir; force = true)
+        document_path = joinpath(dir, "system.json")
+        txt = read(document_path, String)
+        @test occursin("\"incremental_slope\":false", txt)
+        write(
+            document_path,
+            replace(txt, "\"incremental_slope\":false" => "\"incremental_slope\":null"),
+        )
+        @test_throws "MarketBidCost.incremental_slope is required and missing" from_file(
+            System, dir,
+        )
+    end
+end
+
+@testset "_curve_style_from_wire rejects an out-of-range integer" begin
+    sys, gen = _market_bid_cost_fixture()
+    mktempdir() do dir
+        to_file(sys, dir; force = true)
+        document_path = joinpath(dir, "system.json")
+        txt = read(document_path, String)
+        write(document_path, replace(txt, "\"curve_style\":0" => "\"curve_style\":7"))
+        @test_throws "curve_style 7 is not a valid CurveStyles value" from_file(System, dir)
+    end
 end
 
 """Build a `System` with one `ThermalStandard` (`gen1`) carrying a
@@ -392,7 +467,7 @@ function _mbtc_service_offer_fixture()
         sys, gen, _mbtc_sts("start_up", fill((100.0, 200.0, 300.0), 24)),
     )
     mbtc = MarketBidTimeSeriesCost(;
-        no_load_cost = TimeSeriesLinearCurve(no_load_key),
+        minimum_energy_offer = TimeSeriesLinearCurve(no_load_key),
         start_up = start_up_key,
         shut_down = TimeSeriesLinearCurve(shut_down_key),
         incremental_offer_curves = make_market_bid_ts_curve(inc_key),
@@ -441,6 +516,80 @@ end
         @test length(offers) == 1
         @test get_name(only(offers)) == "RESERVE"
         @test only(offers) === get_component(OnlineReserve{ReserveUp}, sys2, "RESERVE")
+    end
+end
+
+"""Build a system whose one `ThermalStandard` carries a fully time-series-backed
+`MarketBidTimeSeriesCost`, with `slope_kwargs` forwarded to its constructor."""
+function _mbtc_extension_fixture(; slope_kwargs...)
+    sys = System(100.0)
+    bus = ACBus(nothing)
+    bus.name = "bus1"
+    bus.number = 1
+    bus.bustype = ACBusTypes.REF
+    add_component!(sys, bus)
+    gen = ThermalStandard(nothing)
+    gen.bus = bus
+    gen.name = "gen1"
+    add_component!(sys, gen)
+
+    timestamps =
+        collect(Dates.DateTime(2024, 1, 1):Dates.Hour(1):Dates.DateTime(2024, 1, 1, 23))
+    pwl_values = fill(PiecewiseStepData([0.0, 100.0], [10.0]), 24)
+    linear_values = fill(LinearFunctionData(1.0, 0.0), 24)
+    _mbtc_ext_sts(name, values) =
+        IS.SingleTimeSeries(; name = name, data = TimeSeries.TimeArray(timestamps, values))
+
+    inc_key = add_time_series!(sys, gen, _mbtc_ext_sts("inc_offer_ext", pwl_values))
+    dec_key = add_time_series!(sys, gen, _mbtc_ext_sts("dec_offer_ext", pwl_values))
+    no_load_key = add_time_series!(sys, gen, _mbtc_ext_sts("no_load_ext", linear_values))
+    shut_down_key =
+        add_time_series!(sys, gen, _mbtc_ext_sts("shut_down_ext", linear_values))
+    start_up_key = add_time_series!(
+        sys, gen, _mbtc_ext_sts("start_up_ext", fill((100.0, 200.0, 300.0), 24)),
+    )
+    mbtc = MarketBidTimeSeriesCost(;
+        minimum_energy_offer = TimeSeriesLinearCurve(no_load_key),
+        start_up = start_up_key,
+        shut_down = TimeSeriesLinearCurve(shut_down_key),
+        incremental_offer_curves = make_market_bid_ts_curve(inc_key),
+        decremental_offer_curves = make_market_bid_ts_curve(dec_key),
+        slope_kwargs...,
+    )
+    set_operation_cost!(gen, mbtc)
+    return (sys, gen)
+end
+
+@testset "MarketBidTimeSeriesCost round trip: slope flags" begin
+    sys, gen = _mbtc_extension_fixture(; incremental_slope = true)
+    mktempdir() do dir
+        to_file(sys, dir; force = true)
+        sys2 = from_file(System, dir)
+        gen2 = get_component(ThermalStandard, sys2, "gen1")
+        mbtc2 = get_operation_cost(gen2)
+        @test mbtc2 isa MarketBidTimeSeriesCost
+        @test get_incremental_slope(mbtc2)
+        @test !get_decremental_slope(mbtc2)
+        @test get_curve_style(mbtc2) == CurveStyles.CURVE
+    end
+end
+
+@testset "MarketBidTimeSeriesCost round trip: curve_style" begin
+    sys, gen = _mbtc_extension_fixture(; curve_style = CurveStyles.FIXED)
+
+    # The wire representation is a plain integer (0/1/2), not a string enum.
+    wire = PSY.convert_cost_to_openapi(get_operation_cost(gen))
+    @test wire.curve_style == 1
+
+    mktempdir() do dir
+        to_file(sys, dir; force = true)
+        sys2 = from_file(System, dir)
+        gen2 = get_component(ThermalStandard, sys2, "gen1")
+        mbtc2 = get_operation_cost(gen2)
+        @test mbtc2 isa MarketBidTimeSeriesCost
+        @test !get_incremental_slope(mbtc2)
+        @test !get_decremental_slope(mbtc2)
+        @test get_curve_style(mbtc2) == CurveStyles.FIXED
     end
 end
 

--- a/test/test_openapi_document.jl
+++ b/test/test_openapi_document.jl
@@ -213,7 +213,7 @@ end
 end
 
 @testset "OpenAPI supplemental attribute converters" begin
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     bus = ACBus(;
         number = 1, name = "bus1", available = true, bustype = ACBusTypes.REF,
         angle = 0.0, magnitude = 1.0, voltage_limits = (min = 0.9, max = 1.1),
@@ -338,7 +338,7 @@ end
     push!(get_ancillary_service_offers(mbc), svc)
     set_operation_cost!(gen, mbc)
 
-    doc = to_openapi(sys; unit_system = :natural_units)
+    doc = to_openapi(sys; power_units = :natural_units)
     sys2 = from_openapi(System, doc)
 
     gen2 = get_component(ThermalStandard, sys2, "gen1")
@@ -407,7 +407,7 @@ end
     push!(get_ancillary_service_offers(get_operation_cost(gen)), svc)
     @test_throws ErrorException PSY.convert_cost_to_openapi(get_operation_cost(gen))
     # The document-level export path hits the same error rather than silently dropping it.
-    @test_throws ErrorException to_openapi(sys; unit_system = :natural_units)
+    @test_throws ErrorException to_openapi(sys; power_units = :natural_units)
 end
 
 @testset "MarketBidTimeSeriesCost: ancillary_service_offers resolve on import" begin
@@ -474,8 +474,8 @@ end
     push!(get_ancillary_service_offers(mbc), svc)
     set_operation_cost!(gen, mbc)
 
-    for unit_system in (:device_base, :natural_units)
-        doc = to_openapi(sys; unit_system = unit_system)
+    for power_units in (:component_base, :natural_units)
+        doc = to_openapi(sys; power_units = power_units)
         sys2 = from_openapi(System, doc)
         gen2 = get_component(ThermalMultiStart, sys2, "ms1")
         @test !isnothing(gen2)
@@ -539,8 +539,8 @@ end
     )
     add_component!(sys, tail)
 
-    for unit_system in (:device_base, :natural_units)
-        doc = to_openapi(sys; unit_system = unit_system)
+    for power_units in (:component_base, :natural_units)
+        doc = to_openapi(sys; power_units = power_units)
         sys2 = from_openapi(System, doc)
 
         pump2 = get_component(HydroPumpTurbine, sys2, "pump1")

--- a/test/test_openapi_export.jl
+++ b/test/test_openapi_export.jl
@@ -374,6 +374,53 @@ end
     @test device_po.active_power_limits_from.min == -1.0
 end
 
+@testset "OpenAPI export converters: TModelHVDCLine" begin
+    # No device `base_power`: the active-power fields per-unitize on the *system* base
+    # (`get_base_power(refs)`), same fallback as `Line`'s; `base_current` — not a power
+    # base — is `r`/`l`/`c`'s own anchor and rides through untouched in both bases.
+    dcbus1 = DCBus(;
+        number = 1, name = "dcbus1", available = true,
+        magnitude = 1.0, voltage_limits = (min = 0.9, max = 1.1), base_voltage = 500.0,
+    )
+    dcbus2 = DCBus(;
+        number = 2, name = "dcbus2", available = true,
+        magnitude = 1.0, voltage_limits = (min = 0.9, max = 1.1), base_voltage = 500.0,
+    )
+    arc = Arc(; from = dcbus1, to = dcbus2)
+    tmodel = TModelHVDCLine(;
+        name = "tmodel1", available = true, active_power_flow = 0.5, arc = arc,
+        r = 0.01, l = 0.02, c = 0.03,
+        active_power_limits_from = (min = -1.0, max = 1.0),
+        active_power_limits_to = (min = -1.0, max = 1.0),
+        base_current = 200.0,
+    )
+    sys = System(100.0)
+    add_component!(sys, dcbus1)
+    add_component!(sys, dcbus2)
+    add_component!(sys, arc)
+    add_component!(sys, tmodel)
+
+    refs = PSY.OpenAPIRefs(100.0)
+    refs[1] = dcbus1
+    refs[2] = dcbus2
+    refs[3] = arc
+    refs[4] = tmodel
+
+    natural_po = PSY.to_openapi(tmodel, refs, NU)
+    @test natural_po.power_units == "NATURAL_UNITS"
+    @test natural_po.active_power_flow == 50.0
+    @test natural_po.active_power_limits_from.min == -100.0
+    @test natural_po.active_power_limits_to.max == 100.0
+    @test natural_po.base_current == 200.0
+    @test !hasfield(typeof(natural_po), :base_power)
+
+    device_po = PSY.to_openapi(tmodel, refs, DU)
+    @test device_po.power_units == "COMPONENT_BASE"
+    @test device_po.active_power_flow == 0.5
+    @test device_po.active_power_limits_from.min == -1.0
+    @test device_po.base_current == 200.0
+end
+
 @testset "OpenAPI export converters: AreaInterchange (generated import, hand-written export)" begin
     # Codegen emits only `from_openapi` (see export_generated_types.jl's header); `to_openapi`
     # for this newly openapi_type-annotated struct is hand-written here to match exactly

--- a/test/test_openapi_export.jl
+++ b/test/test_openapi_export.jl
@@ -68,24 +68,29 @@ _export_vsc(
     arc = Arc(; from = bus1, to = bus2)
     add_component!(sys, arc)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = area
     refs[2] = lz
     refs[3] = bus1
     refs[4] = bus2
     refs[5] = arc
 
+    expected_peak(::DeviceBaseUnit, pu) = pu
+    expected_peak(::NaturalUnit, pu) = pu * 100.0
+
     for val in (DU, NU)
         area_po = PSY.to_openapi(area, refs, val)
         @test area_po.id == 1
         @test area_po.name == "area1"
-        @test area_po.peak_active_power == 250.0
-        @test area_po.peak_reactive_power == 50.0
+        @test area_po.peak_active_power == expected_peak(val, 2.5)
+        @test area_po.peak_reactive_power == expected_peak(val, 0.5)
         @test area_po.load_response == 0.0
+        @test area_po.power_units == PSY._power_units_string(val)
 
         lz_po = PSY.to_openapi(lz, refs, val)
-        @test lz_po.peak_active_power == 250.0
-        @test lz_po.peak_reactive_power == 50.0
+        @test lz_po.peak_active_power == expected_peak(val, 2.5)
+        @test lz_po.peak_reactive_power == expected_peak(val, 0.5)
+        @test lz_po.power_units == PSY._power_units_string(val)
 
         bus_po = PSY.to_openapi(bus1, refs, val)
         @test bus_po.id == 3
@@ -117,7 +122,7 @@ end
     add_component!(sys, arc)
     add_component!(sys, line)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = bus2
     refs[3] = arc
@@ -166,7 +171,7 @@ end
     add_component!(sys, arc)
     add_component!(sys, xfmr)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = bus2
     refs[3] = arc
@@ -214,19 +219,24 @@ end
     add_component!(sys, line)
     add_service!(sys, tx, [line])
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = get_arc(line)
     refs[3] = line
     refs[4] = tx
 
+    expected_limits(::DeviceBaseUnit) = (min = -10.0, max = 10.0)
+    expected_limits(::NaturalUnit) = (min = -1000.0, max = 1000.0)
+
     for val in (DU, NU)
         tx_po = PSY.to_openapi(tx, refs, val)
         @test tx_po.id == 4
-        @test tx_po.active_power_flow_limits.min == -1000.0
-        @test tx_po.active_power_flow_limits.max == 1000.0
+        limits = expected_limits(val)
+        @test tx_po.active_power_flow_limits.min == limits.min
+        @test tx_po.active_power_flow_limits.max == limits.max
         @test tx_po.violation_penalty == 5000.0
         @test tx_po.direction_mapping == Dict("line1" => 1)
+        @test tx_po.power_units == PSY._power_units_string(val)
 
         # Round-trip: import(export(x)) == x.
         round_tripped = PSY.from_openapi(tx_po, refs, val)
@@ -270,7 +280,7 @@ end
     foreach(a -> add_component!(sys, a), (arc1, arc2, arc3))
     add_component!(sys, t3w)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = bus2
     refs[3] = bus3
@@ -308,7 +318,7 @@ end
     add_component!(sys, bus1)
     add_component!(sys, shunt)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = shunt
 
@@ -347,7 +357,7 @@ end
     add_component!(sys, arc)
     add_component!(sys, hvdc)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = bus2
     refs[3] = arc
@@ -381,7 +391,7 @@ end
     add_component!(sys, area2)
     add_component!(sys, interchange)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = area1
     refs[2] = area2
     refs[3] = interchange
@@ -399,7 +409,7 @@ end
     @test natural_po.base_power == 100.0
 
     # Round trip through the generated `from_openapi` reproduces the original component.
-    import_refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    import_refs = PSY.OpenAPIRefs(100.0)
     import_refs[1] = area1
     import_refs[2] = area2
     reimported =
@@ -412,7 +422,7 @@ end
 @testset "OpenAPI export converters: ThermalStandard / PowerLoad" begin
     bus = _export_bus(; number = 1)
     cost = ThermalGenerationCost(;
-        variable = CostCurve(;
+        variable_operation_cost = CostCurve(;
             value_curve = InputOutputCurve(LinearFunctionData(10.0, 5.0)),
         ),
         fixed = 100.0, start_up = 200.0, shut_down = 50.0,
@@ -438,7 +448,7 @@ end
     add_component!(sys, gen)
     add_component!(sys, load)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus
     refs[2] = gen
     refs[3] = load
@@ -480,7 +490,7 @@ end
     add_component!(sys, iload)
     add_component!(sys, sload)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus
     refs[2] = iload
     refs[3] = sload
@@ -508,7 +518,7 @@ end
     bus = _export_bus(; number = 1)
     hydro_cost = HydroGenerationCost(;
         fixed = 1.0,
-        variable = CostCurve(;
+        variable_operation_cost = CostCurve(;
             value_curve = InputOutputCurve(LinearFunctionData(1.0, 0.0)),
         ),
     )
@@ -534,7 +544,7 @@ end
         operation_cost = hydro_cost,
     )
     ren_cost = RenewableGenerationCost(;
-        variable = CostCurve(;
+        variable_operation_cost = CostCurve(;
             value_curve = InputOutputCurve(LinearFunctionData(0.0, 0.0)),
         ),
     )
@@ -581,7 +591,7 @@ end
         add_component!(sys, c)
     end
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus
     refs[2] = turbine
     refs[3] = ror
@@ -635,7 +645,7 @@ end
     bus = _export_bus(; number = 1)
     hydro_cost = HydroGenerationCost(;
         fixed = 1.0,
-        variable = CostCurve(;
+        variable_operation_cost = CostCurve(;
             value_curve = InputOutputCurve(LinearFunctionData(1.0, 0.0)),
         ),
     )
@@ -675,7 +685,7 @@ end
     add_component!(sys, reservoir)
     add_component!(sys, reservoir_no_assoc)
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus
     refs[2] = turbine
     refs[3] = reservoir
@@ -738,7 +748,7 @@ end
         add_component!(sys, r)
     end
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = up_reserve
     refs[2] = down_reserve
     refs[3] = offline_reserve
@@ -751,7 +761,7 @@ end
     @test isnothing(up_natural.variable)
 
     up_device = PSY.to_openapi(up_reserve, refs, DU)
-    @test up_device.requirement == 1.0
+    @test up_device.requirement == 100.0
 
     down_natural = PSY.to_openapi(down_reserve, refs, NU)
     @test down_natural.reserve_direction == "DOWN"
@@ -784,7 +794,7 @@ end
 
     # to_openapi's output is from_openapi's input directly: both sides speak SystemDocument,
     # so the round-trip needs no re-serialization through JSON.
-    out = PSY.to_openapi(sys; unit_system = :device_base)
+    out = PSY.to_openapi(sys; power_units = :component_base)
     sys2 = PSY.from_openapi(System, out)
     group2 = only(get_components(GroupReserve, sys2))
     @test get_name.(get_contributing_services(group2)) == ["spin_up_member"]
@@ -793,7 +803,7 @@ end
 @testset "OpenAPI export: supplemental attribute converters" begin
     # The exporters read their own id back from `refs` via `component_id`, exactly like
     # the generated component exporters, so each attribute registers first.
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     emissions = EmissionsData(;
         name = "gen1_CO2", pollutant = PollutantType.CO2,
         emission_rate = IncrementalCurve(;
@@ -857,11 +867,11 @@ end
 
     @testset "COMPONENT_BASE -> PSY -> COMPONENT_BASE is exact" begin
         device_doc = deepcopy(doc)
-        device_doc["unit_system"] = "COMPONENT_BASE"
+        set_all_power_units!(device_doc, "COMPONENT_BASE")
         sys = PSY.from_openapi(System, to_test_document(device_doc))
-        out = PSY.to_openapi(sys; unit_system = :device_base)
-        @test PSY.PD.get_unit_system(out) == "COMPONENT_BASE"
+        out = PSY.to_openapi(sys; power_units = :component_base)
         gen_out = only(PSY.PD.get_components(out, "ThermalStandard"))
+        @test gen_out.power_units == "COMPONENT_BASE"
         @test gen_out.active_power == 50.0
         @test gen_out.rating == 100.0
         gen_in = only(device_doc["components"]["ThermalStandard"])
@@ -871,9 +881,9 @@ end
 
     @testset "NATURAL_UNITS -> PSY -> NATURAL_UNITS is approximate only" begin
         sys = PSY.from_openapi(System, to_test_document(doc))
-        out = PSY.to_openapi(sys; unit_system = :natural_units)
-        @test PSY.PD.get_unit_system(out) == "NATURAL_UNITS"
+        out = PSY.to_openapi(sys; power_units = :natural_units)
         gen_out = only(PSY.PD.get_components(out, "ThermalStandard"))
+        @test gen_out.power_units == "NATURAL_UNITS"
         gen_in = only(doc["components"]["ThermalStandard"])
         @test gen_out.active_power ≈ gen_in["active_power"] rtol = 1e-15
         @test gen_out.rating ≈ gen_in["rating"] rtol = 1e-15
@@ -884,15 +894,15 @@ end
 
     @testset "bustype SLACK round-trips as SLACK" begin
         sys = PSY.from_openapi(System, to_test_document(doc))
-        out = PSY.to_openapi(sys; unit_system = :natural_units)
+        out = PSY.to_openapi(sys; power_units = :natural_units)
         bus1_out = first(b for b in PSY.PD.get_components(out, "ACBus") if b.number == 1)
         @test bus1_out.bustype == "SLACK"
     end
 
-    @testset "to_openapi with an unmapped unit_system errors" begin
+    @testset "to_openapi with an unmapped power_units errors" begin
         sys = System(100.0)
         add_component!(sys, ACBus(nothing))
-        @test_throws ErrorException PSY.to_openapi(sys; unit_system = :bogus_units)
+        @test_throws ErrorException PSY.to_openapi(sys; power_units = :bogus_units)
     end
 
     @testset "Line.base_power on export == get_base_power(sys) exactly" begin
@@ -910,7 +920,7 @@ end
             angle_limits = (min = -1.57, max = 1.57),
         )
         add_component!(sys, line)
-        out = PSY.to_openapi(sys; unit_system = :natural_units)
+        out = PSY.to_openapi(sys; power_units = :natural_units)
         line_out = only(PSY.PD.get_components(out, "Line"))
         @test line_out.base_power == PSY.get_base_power(sys)
     end
@@ -927,13 +937,14 @@ end
     )
     add_component!(sys, load)
 
-    out_device = PSY.to_openapi(sys; unit_system = :device_base)
-    @test PSY.PD.get_unit_system(out_device) == "COMPONENT_BASE"
+    out_device = PSY.to_openapi(sys; power_units = :component_base)
     load_out = only(PSY.PD.get_components(out_device, "PowerLoad"))
+    @test load_out.power_units == "COMPONENT_BASE"
     @test load_out.active_power == 0.3
 
-    out_natural = PSY.to_openapi(sys; unit_system = :natural_units)
+    out_natural = PSY.to_openapi(sys; power_units = :natural_units)
     load_out_nat = only(PSY.PD.get_components(out_natural, "PowerLoad"))
+    @test load_out_nat.power_units == "NATURAL_UNITS"
     @test load_out_nat.active_power == 30.0
 end
 
@@ -942,10 +953,11 @@ end
         area_po = PSY.PO.Area(;
             id = 1, name = "area1", peak_active_power = 100.0,
             peak_reactive_power = 20.0,
-            load_response = 0.0,
+            load_response = 0.0, base_power = 100.0, power_units = "NATURAL_UNITS",
         )
         lz_po = PSY.PO.LoadZone(;
             id = 2, name = "lz1", peak_active_power = 100.0, peak_reactive_power = 20.0,
+            base_power = 100.0, power_units = "NATURAL_UNITS",
         )
         bus1_po = PSY.PO.ACBus(;
             id = 3, number = 1, name = "bus1", available = true, bustype = "REF",
@@ -963,6 +975,7 @@ end
         line_po = PSY.PO.Line(;
             id = 6, name = "line1", available = true, active_power_flow = 10.0,
             reactive_power_flow = 2.0, arc = 5, r = 0.01, x = 0.1, base_power = 100.0,
+            power_units = "NATURAL_UNITS",
             b = PSY.PC.FromTo(; from = 0.0, to = 0.0), rating = 175.0,
             angle_limits = PSY.PC.MinMax(; min = -1.57, max = 1.57),
             g = PSY.PC.FromTo(; from = 0.0, to = 0.0),
@@ -970,6 +983,7 @@ end
         load_po = PSY.PO.PowerLoad(;
             id = 7, name = "load1", available = true, bus = 4,
             active_power = 30.0, reactive_power = 5.0, base_power = 100.0,
+            power_units = "NATURAL_UNITS",
             max_active_power = 50.0, max_reactive_power = 10.0,
             conformity = "CONFORMING",
         )
@@ -995,8 +1009,6 @@ end
             energy_unit = "MMBTU", gwp = 1.0, available = true,
         )
         doc = Dict{String, Any}(
-            "base_power" => 100.0,
-            "unit_system" => "NATURAL_UNITS",
             "components" => Dict{String, Any}(
                 "Area" => [openapi_raw(area_po)],
                 "LoadZone" => [openapi_raw(lz_po)],
@@ -1037,11 +1049,11 @@ end
         ts_out_path = joinpath(dir, "export_time_series_storage.h5")
         out = PSY.to_openapi(
             sys;
-            unit_system = :natural_units,
+            power_units = :natural_units,
             time_series_storage_path = ts_out_path,
         )
 
-        @test PSY.PD.get_unit_system(out) == "NATURAL_UNITS"
+        @test only(PSY.PD.get_components(out, "Line")).power_units == "NATURAL_UNITS"
         @test length(PSY.PD.get_components(out, "ACBus")) == 2
         @test length(only(PSY.PD.get_components(out, "Line")) |> x -> [x]) == 1
         @test length(PSY.PD.get_components(out, "OnlineReserve")) == 1
@@ -1114,7 +1126,7 @@ end
 
         ts_out_path = joinpath(dir, "forecast_time_series_storage.h5")
         doc = PSY.to_openapi(
-            sys; unit_system = :device_base, time_series_storage_path = ts_out_path,
+            sys; power_units = :component_base, time_series_storage_path = ts_out_path,
         )
         @test isfile(ts_out_path)
         # 3 rows: the "load_hist" SingleTimeSeries, the DeterministicSingleTimeSeries its
@@ -1170,7 +1182,7 @@ end
         add_component!(sys, component)
     end
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = bus2
     refs[3] = arc
@@ -1216,7 +1228,7 @@ end
         add_component!(sys, component)
     end
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = bus2
     refs[3] = arc
@@ -1236,7 +1248,7 @@ end
 end
 
 @testset "OpenAPI export: TwoTerminalVSCLine survives a document round trip" begin
-    for unit_system in (:natural_units, :device_base)
+    for power_units in (:natural_units, :component_base)
         bus1 = _export_bus(; number = 1)
         bus2 = _export_bus(; number = 2, bustype = ACBusTypes.PQ)
         arc = Arc(; from = bus1, to = bus2)
@@ -1247,7 +1259,7 @@ end
         end
 
         dir = mktempdir()
-        PSY.to_file(sys, dir; unit_system = unit_system, force = true)
+        PSY.to_file(sys, dir; power_units = power_units, force = true)
         restored = get_component(TwoTerminalVSCLine, PSY.from_file(System, dir), "vsc1")
         for field in fieldnames(TwoTerminalVSCLine)
             field in (:internal, :arc, :services) && continue
@@ -1260,7 +1272,7 @@ end
     # `ac_control_*` on `AC_VOLTAGE` with a non-zero `rated_ac_voltage_from`/`_to`: the wire
     # row must carry both bases (not just convert the setpoints through them) for a
     # PSY→doc→PSY round trip to reproduce the same PSY values back.
-    for unit_system in (:natural_units, :device_base)
+    for power_units in (:natural_units, :component_base)
         bus1 = _export_bus(; number = 1)
         bus2 = _export_bus(; number = 2, bustype = ACBusTypes.PQ)
         arc = Arc(; from = bus1, to = bus2)
@@ -1277,7 +1289,7 @@ end
         end
 
         dir = mktempdir()
-        PSY.to_file(sys, dir; unit_system = unit_system, force = true)
+        PSY.to_file(sys, dir; power_units = power_units, force = true)
         restored = get_component(TwoTerminalVSCLine, PSY.from_file(System, dir), "vsc1")
         for field in fieldnames(TwoTerminalVSCLine)
             field in (:internal, :arc, :services) && continue
@@ -1290,7 +1302,7 @@ end
     bus1 = _export_bus(; number = 1)
     bus2 = _export_bus(; number = 2, bustype = ACBusTypes.PQ)
     arc = Arc(; from = bus1, to = bus2)
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
 
     # A non-zero ac_setpoint_from with no AC voltage base (`rated_ac_voltage_from` unset,
     # the default) has nothing to be expressed against.
@@ -1313,7 +1325,7 @@ end
         add_component!(sys, component)
     end
 
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
     refs[1] = bus1
     refs[2] = bus2
     refs[3] = arc
@@ -1329,7 +1341,7 @@ end
     # fallbacks are symmetric only for the degenerate `g == 0.0` case, which never needed
     # tolerating in the first place.
     dir = mktempdir()
-    PSY.to_file(sys, dir; unit_system = :natural_units, force = true)
+    PSY.to_file(sys, dir; power_units = :natural_units, force = true)
     @test_throws ErrorException PSY.from_file(System, dir)
 end
 
@@ -1366,7 +1378,7 @@ _export_thermal_gen(bus; name = "gen1") = ThermalStandard(;
 
         ts_out_path = joinpath(dir, "attr_owned_series.h5")
         doc = PSY.to_openapi(
-            sys; unit_system = :device_base, time_series_storage_path = ts_out_path,
+            sys; power_units = :component_base, time_series_storage_path = ts_out_path,
         )
         @test isfile(ts_out_path)
         ts_row = only(doc.time_series_associations).value
@@ -1417,7 +1429,8 @@ end
             (:warn, r"omitting 1 time series row"),
             match_mode = :any,
             PSY.to_openapi(
-                sys; unit_system = :device_base, time_series_storage_path = ts_out_path,
+                sys; power_units = :component_base,
+                time_series_storage_path = ts_out_path,
             ),
         )
         # The sidecar still holds both series — only the document's description of the

--- a/test/test_openapi_export.jl
+++ b/test/test_openapi_export.jl
@@ -851,7 +851,7 @@ end
 @testset "OpenAPI export: TradingHub membership round-trip" begin
     sys, b1, b2, hub = _market_hub_fixture()
 
-    out = PSY.to_openapi(sys; unit_system = :device_base)
+    out = PSY.to_openapi(sys; power_units = :component_base)
     sys2 = PSY.from_openapi(System, out)
     hub2 = only(get_components(TradingHub, sys2))
     @test get_name.(get_associated_buses(hub2)) == ["b1", "b2"]
@@ -859,7 +859,7 @@ end
 
 @testset "OpenAPI import: duplicate trading hub bus association errors loudly" begin
     sys, b1, b2, hub = _market_hub_fixture()
-    out = PSY.to_openapi(sys; unit_system = :device_base)
+    out = PSY.to_openapi(sys; power_units = :component_base)
     duplicate_row = deepcopy(first(out.trading_hub_associations))
     push!(out.trading_hub_associations, duplicate_row)
     @test_throws ArgumentError PSY.from_openapi(System, out)
@@ -1090,13 +1090,13 @@ end
         bus1_po = PSY.PO.ACBus(;
             id = 3, number = 1, name = "bus1", available = true, bustype = "REF",
             angle = 0.0, magnitude = 1.0,
-            voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+            voltage_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
             base_voltage = 138.0, area = 1, load_zone = 2,
         )
         bus2_po = PSY.PO.ACBus(;
             id = 4, number = 2, name = "bus2", available = true, bustype = "PQ",
             angle = 0.0, magnitude = 1.0,
-            voltage_limits = PSY.PC.MinMax(; min = 0.9, max = 1.1),
+            voltage_limits = PSY.IC.MinMax(; min = 0.9, max = 1.1),
             base_voltage = 138.0, area = 1, load_zone = 2,
         )
         arc_po = PSY.PO.Arc(; id = 5, from_id = 3, to_id = 4)
@@ -1104,9 +1104,9 @@ end
             id = 6, name = "line1", available = true, active_power_flow = 10.0,
             reactive_power_flow = 2.0, arc = 5, r = 0.01, x = 0.1, base_power = 100.0,
             power_units = "NATURAL_UNITS",
-            b = PSY.PC.FromTo(; from = 0.0, to = 0.0), rating = 175.0,
-            angle_limits = PSY.PC.MinMax(; min = -1.57, max = 1.57),
-            g = PSY.PC.FromTo(; from = 0.0, to = 0.0),
+            b = PSY.IC.FromTo(; from = 0.0, to = 0.0), rating = 175.0,
+            angle_limits = PSY.IC.MinMax(; min = -1.57, max = 1.57),
+            g = PSY.IC.FromTo(; from = 0.0, to = 0.0),
         )
         load_po = PSY.PO.PowerLoad(;
             id = 7, name = "load1", available = true, bus = 4,
@@ -1126,7 +1126,7 @@ end
             emission_rate = PSY.PC.ValueCurve(
                 PSY.PC.IncrementalCurve(;
                     function_data = PSY.PC.IncrementalCurveFunctionData(
-                        PSY.PC.LinearFunctionData(;
+                        PSY.IC.LinearFunctionData(;
                             proportional_term = 0.0, constant_term = 1.5,
                         ),
                     ),
@@ -1648,7 +1648,10 @@ end
     add_component!(sys, zone)
     stamps = collect(range(DateTime(2026, 1, 1); step = Hour(1), length = 3))
     for (number, value) in ((1, 0.25), (2, 0.75))
-        ts = SingleTimeSeries(; name = "factor", data = TimeSeries.TimeArray(stamps, fill(value, 3)))
+        ts = SingleTimeSeries(;
+            name = "factor",
+            data = TimeSeries.TimeArray(stamps, fill(value, 3)),
+        )
         add_time_series!(sys, zone, ts; features = Dict("bus" => number))
     end
     mktempdir() do dir

--- a/test/test_openapi_export.jl
+++ b/test/test_openapi_export.jl
@@ -790,6 +790,86 @@ end
     @test get_name.(get_contributing_services(group2)) == ["spin_up_member"]
 end
 
+@testset "OpenAPI export: TradingHub membership round-trip" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+
+    out = PSY.to_openapi(sys; unit_system = :device_base)
+    sys2 = PSY.from_openapi(System, out)
+    hub2 = only(get_components(TradingHub, sys2))
+    @test get_name.(get_associated_buses(hub2)) == ["b1", "b2"]
+end
+
+@testset "OpenAPI import: duplicate trading hub bus association errors loudly" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+    out = PSY.to_openapi(sys; unit_system = :device_base)
+    duplicate_row = deepcopy(first(out.trading_hub_associations))
+    push!(out.trading_hub_associations, duplicate_row)
+    @test_throws ArgumentError PSY.from_openapi(System, out)
+end
+
+@testset "OpenAPI document round trip: VirtualParticipant settlement point, hub association, hub bid" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+
+    vp_hub = VirtualParticipant(; name = "vp_hub", available = true,
+        max_supply = 100.0, max_demand = 50.0, operation_cost = MarketBidCost(nothing))
+    add_component!(sys, vp_hub)
+    add_trading_hub!(sys, vp_hub, hub)
+
+    dates = collect(DateTime("2026-01-01T00:00:00"):Hour(1):DateTime("2026-01-01T01:00:00"))
+    data = PiecewiseStepData.(
+        [[0.0, 50.0, 100.0], [0.0, 50.0, 100.0]],
+        [[25.0, 30.0], [26.0, 31.0]],
+    )
+    ta = TimeSeries.TimeArray(dates, data)
+    hub_ts = SingleTimeSeries(; name = get_name(hub), data = ta)
+    set_hub_bid!(sys, vp_hub, hub, hub_ts, IS.NaturalUnit())
+
+    vp_nodal = VirtualParticipant(; name = "vp_nodal", available = true,
+        settlement_point = b2, max_supply = 10.0, max_demand = 10.0,
+        operation_cost = MarketBidCost(nothing))
+    add_component!(sys, vp_nodal)
+
+    mktempdir() do dir
+        to_file(sys, dir; force = true)
+        sys2 = from_file(System, dir)
+
+        hub2 = only(get_components(TradingHub, sys2))
+        vp_hub2 = get_component(VirtualParticipant, sys2, "vp_hub")
+        @test get_name.(get_trading_hubs(vp_hub2)) == ["western_hub"]
+        @test has_trading_hub(vp_hub2, hub2)
+        hub_ts2 = get_time_series(SingleTimeSeries, vp_hub2, get_name(hub2))
+        @test hub_ts2 isa SingleTimeSeries
+        @test TimeSeries.values(get_data(hub_ts2)) == TimeSeries.values(ta)
+
+        vp_nodal2 = get_component(VirtualParticipant, sys2, "vp_nodal")
+        @test get_name(get_settlement_point(vp_nodal2)) == "b2"
+        @test isempty(get_trading_hubs(vp_nodal2))
+    end
+end
+
+@testset "OpenAPI document round trip: PointToPointBid bus-to-hub terminals, FIXED curve style" begin
+    sys, b1, b2, hub = _market_hub_fixture()
+
+    ptp = PointToPointBid(; name = "utc1", available = true, from = b1, to = hub,
+        max_active_power = 50.0,
+        spread_bid = MarketBidCost(; curve_style = CurveStyles.FIXED),
+        price_limits = (min = -50.0, max = 50.0), linked_crr = "crr1")
+    add_component!(sys, ptp)
+
+    mktempdir() do dir
+        to_file(sys, dir; force = true)
+        sys2 = from_file(System, dir)
+
+        ptp2 = get_component(PointToPointBid, sys2, "utc1")
+        @test get_name(get_from(ptp2)) == "b1"
+        @test get_name(get_to(ptp2)) == "western_hub"
+        @test get_max_active_power(ptp2) == 50.0
+        @test get_price_limits(ptp2) == (min = -50.0, max = 50.0)
+        @test get_curve_style(get_spread_bid(ptp2)) == CurveStyles.FIXED
+        @test get_linked_crr(ptp2) == "crr1"
+    end
+end
+
 @testset "OpenAPI export: supplemental attribute converters" begin
     # The exporters read their own id back from `refs` via `component_id`, exactly like
     # the generated component exporters, so each attribute registers first.
@@ -1021,6 +1101,7 @@ end
             "service_associations" => [
                 Dict{String, Any}("service_id" => 8, "entity_id" => 7),
             ],
+            "trading_hub_associations" => [],
             "time_series_associations" => [],
             "ext" => Dict{String, Any}(),
             "time_series_storage_file" => nothing,

--- a/test/test_openapi_export.jl
+++ b/test/test_openapi_export.jl
@@ -1578,3 +1578,27 @@ end
     push!(doc.combined_cycle_associations, duplicate_row)
     @test_throws ErrorException PSY.from_openapi(System, doc)
 end
+
+@testset "OpenAPI document round trip: feature-keyed time series" begin
+    sys = System(100.0)
+    bus = _export_bus(; number = 1)
+    add_component!(sys, bus)
+    zone = LoadZone(; name = "lz1", peak_active_power = 1.0, peak_reactive_power = 0.0)
+    add_component!(sys, zone)
+    stamps = collect(range(DateTime(2026, 1, 1); step = Hour(1), length = 3))
+    for (number, value) in ((1, 0.25), (2, 0.75))
+        ts = SingleTimeSeries(; name = "factor", data = TimeSeries.TimeArray(stamps, fill(value, 3)))
+        add_time_series!(sys, zone, ts; features = Dict("bus" => number))
+    end
+    mktempdir() do dir
+        to_file(sys, dir; force = true)
+        sys2 = from_file(System, dir)
+        zone2 = get_component(LoadZone, sys2, "lz1")
+        @test get_time_series_values(
+            SingleTimeSeries, zone2, "factor"; features = Dict("bus" => 1),
+        ) == fill(0.25, 3)
+        @test get_time_series_values(
+            SingleTimeSeries, zone2, "factor"; features = Dict("bus" => 2),
+        ) == fill(0.75, 3)
+    end
+end

--- a/test/test_openapi_file_io.jl
+++ b/test/test_openapi_file_io.jl
@@ -8,7 +8,7 @@ _close_sidecar_store!(sys::System) =
     sys = _file_io_fixture()
     mktempdir() do dir
         bundle = joinpath(dir, "case")
-        to_file(sys, bundle; unit_system = :device_base)
+        to_file(sys, bundle; power_units = :component_base)
 
         # All members present, and nothing else. The InfraStore sidecar is a pair: the
         # arrays in `.h5` and its catalog in the `.sqlite` sibling.
@@ -46,7 +46,7 @@ end
     sys = _file_io_fixture()
     mktempdir() do dir
         bundle = joinpath(dir, "case")
-        to_file(sys, bundle; unit_system = :device_base)
+        to_file(sys, bundle; power_units = :component_base)
 
         sys2 = from_file(System, bundle; time_series_read_only = true)
 
@@ -70,7 +70,7 @@ end
     sys = _file_io_fixture(; with_time_series = false)
     mktempdir() do dir
         bundle = joinpath(dir, "case")
-        to_file(sys, bundle; unit_system = :device_base)
+        to_file(sys, bundle; power_units = :component_base)
 
         @test readdir(bundle) == ["system.json"]
         # The document must say so rather than name a file that is not there.
@@ -88,10 +88,10 @@ end
     # Writing twice without force must not silently clobber the first bundle.
     mktempdir() do dir
         bundle = joinpath(dir, "case")
-        to_file(sys, bundle; unit_system = :device_base)
-        @test_throws IS.DataFormatError to_file(sys, bundle; unit_system = :device_base)
+        to_file(sys, bundle; power_units = :component_base)
+        @test_throws IS.DataFormatError to_file(sys, bundle; power_units = :component_base)
         # ... and force makes it succeed.
-        @test isnothing(to_file(sys, bundle; unit_system = :device_base, force = true))
+        @test isnothing(to_file(sys, bundle; power_units = :component_base, force = true))
     end
 
     # A directory that is not a bundle.
@@ -103,7 +103,7 @@ end
     # quietly missing every time series the document declared.
     mktempdir() do dir
         bundle = joinpath(dir, "case")
-        to_file(_file_io_fixture(), bundle; unit_system = :device_base)
+        to_file(_file_io_fixture(), bundle; power_units = :component_base)
         rm(joinpath(bundle, "time_series.h5"))
         @test_throws IS.DataFormatError from_file(System, bundle)
     end
@@ -114,7 +114,7 @@ end
     # exactly one thing. A private attribute counter previously issued attribute id 1
     # alongside component id 1.
     sys = _file_io_fixture(; with_time_series = false)
-    doc = to_openapi(sys; unit_system = :device_base)
+    doc = to_openapi(sys; power_units = :component_base)
 
     component_ids = Int[]
     for type_name in PSY.PD.component_type_names(doc)
@@ -153,10 +153,15 @@ end
 
     # And back out again, unchanged. A component's document id is its IS component id, which
     # import set from the document, so bus1 is id 3 on the way out as well.
-    exported = to_openapi(sys; unit_system = :natural_units)
+    exported = to_openapi(sys; power_units = :natural_units)
     @test PSY.PD.get_ext(exported, 3) == extras
     @test isempty(PSY.PD.get_ext(exported, 4))
 end
+
+"""The `power_units` stamp on the sole exported `ThermalStandard` blob, the regression guard
+for [`to_openapi`](@ref)'s uniform per-export stamp (no document-level `unit_system` exists to
+assert against instead)."""
+_gen_power_units(doc) = only(PSY.PD.get_components(doc, "ThermalStandard")).power_units
 
 @testset "export needs no ledger: a hand-built System serializes" begin
     # The unit-system assertions use the time-series-free fixture so that `to_openapi` needs
@@ -168,19 +173,19 @@ end
     @test !haskey(get_ext(sys), "_openapi_ledger")
 
     # The default path works with no ledger present. This is the regression guard.
-    @test PSY.PD.get_unit_system(to_openapi(sys)) == "COMPONENT_BASE"
+    @test _gen_power_units(to_openapi(sys)) == "COMPONENT_BASE"
     @test isempty(get_ext(sys))
 
     # Both remaining conventions are reachable on the same ledger-free System, and they are
     # exactly the document schema's two legal values.
     for (sym, declared) in
-        ((:device_base, "COMPONENT_BASE"), (:natural_units, "NATURAL_UNITS"))
-        @test PSY.PD.get_unit_system(to_openapi(sys; unit_system = sym)) == declared
+        ((:component_base, "COMPONENT_BASE"), (:natural_units, "NATURAL_UNITS"))
+        @test _gen_power_units(to_openapi(sys; power_units = sym)) == declared
     end
 
     # `:original` is gone rather than quietly reinterpreted: a System records no unit system
     # of its own, so there is nothing left to reproduce it from.
-    @test_throws ErrorException to_openapi(sys; unit_system = :original)
+    @test_throws ErrorException to_openapi(sys; power_units = :original)
 
     # A hand-built System with time series writes a bundle, reads back, and re-exports.
     with_ts = _file_io_fixture()
@@ -204,9 +209,7 @@ end
         again = joinpath(dir, "handbuilt2")
         to_file(sys2, again)
         @test isfile(joinpath(again, "system.json"))
-        @test PSY.PD.get_unit_system(
-            PSY.PD.read_document(joinpath(again, "system.json")),
-        ) ==
+        @test _gen_power_units(PSY.PD.read_document(joinpath(again, "system.json"))) ==
               "COMPONENT_BASE"
     end
 end
@@ -229,7 +232,7 @@ end
         IS.NonSequentialTimeSeries("irregular", TimeSeries.TimeArray(stamps, values)),
     )
     # The kind is in the key's type parameter now, not in a separate key type.
-    @test IS.get_time_series_type(first(IS.list_metadata(gen))) <:
+    @test IS.get_time_series_type(first(IS.list_time_series_metadata(gen))) <:
           IS.NonSequentialTimeSeries
 
     mktempdir() do dir
@@ -268,7 +271,7 @@ end
         # from the adopted sidecar exactly.
         sys2 = from_file(System, bundle)
         gen2 = get_component(ThermalStandard, sys2, "g1")
-        key2 = IS.get_time_series_key(only(IS.list_metadata(gen2)))
+        key2 = IS.get_time_series_key(only(IS.list_time_series_metadata(gen2)))
         @test key2 isa IS.TimeSeriesKey{<:IS.NonSequentialTimeSeries}
         @test IS.get_timestamps(IS.get_time_series(gen2, key2)) == stamps
         @test IS.get_time_series_values(gen2, key2) == values

--- a/test/test_openapi_ptdp_end_to_end.jl
+++ b/test/test_openapi_ptdp_end_to_end.jl
@@ -155,7 +155,7 @@ function _ptdp_e2e_system_component_counts(sys::System)
 end
 
 """
-Give one `ThermalStandard` in `sys` a `MarketBidTimeSeriesCost` (`no_load_cost`, `shut_down`,
+Give one `ThermalStandard` in `sys` a `MarketBidTimeSeriesCost` (`minimum_energy_offer`, `shut_down`,
 `start_up`, and both offer curves all time-series-backed, via `make_market_bid_ts_curve`) and
 another a `FuelCurve` with `fuel_cost_time_series` set instead of a fixed `fuel_cost`. Both
 generators' new series are staged onto `sys`'s own (adopted) time series store, exactly like
@@ -208,7 +208,7 @@ function _ptdp_e2e_attach_ts_costs!(sys::System)
     fuel_key = add_time_series!(sys, fuel_gen, fuel_ts)
 
     market_bid_cost = MarketBidTimeSeriesCost(;
-        no_load_cost = TimeSeriesLinearCurve(no_load_key),
+        minimum_energy_offer = TimeSeriesLinearCurve(no_load_key),
         start_up = start_up_key,
         shut_down = TimeSeriesLinearCurve(shut_down_key),
         incremental_offer_curves = make_market_bid_ts_curve(inc_key),
@@ -237,7 +237,8 @@ function _ptdp_e2e_attach_ts_costs!(sys::System)
 
     keys = (
         incremental_offer_curves = inc_key, decremental_offer_curves = dec_key,
-        no_load_cost = no_load_key, shut_down = shut_down_key, start_up = start_up_key,
+        minimum_energy_offer = no_load_key, shut_down = shut_down_key,
+        start_up = start_up_key,
     )
     resolution = Dates.Millisecond(Dates.Hour(1))
     new_staged = Dict(
@@ -264,7 +265,8 @@ function _ptdp_e2e_check_ts_costs(
     cost = get_operation_cost(market_bid_gen)
     @test cost isa MarketBidTimeSeriesCost
     @test get_start_up(cost) == keys.start_up
-    @test IS.get_time_series_key(get_no_load_cost(cost)) == keys.no_load_cost
+    @test IS.get_time_series_key(get_minimum_energy_offer(cost)) ==
+          keys.minimum_energy_offer
     @test IS.get_time_series_key(get_shut_down(cost)) == keys.shut_down
     @test IS.get_time_series_key(get_value_curve(get_incremental_offer_curves(cost))) ==
           keys.incremental_offer_curves
@@ -525,8 +527,8 @@ end
 
             # (g) one RTS thermal gets a time-series-backed `MarketBidTimeSeriesCost`, another
             # a `FuelCurve` with `fuel_cost_time_series` — proof that the association-id-bearing
-            # cost converters (Task 11) round-trip through the full document machinery, not
-            # just direct `convert_cost`/`convert_cost_to_openapi` calls.
+            # cost converters round-trip through the full document machinery, not just
+            # direct `convert_cost`/`convert_cost_to_openapi` calls.
             market_bid_gen_name, ts_cost_keys, fuel_gen_name, fuel_ts_key, new_staged =
                 _ptdp_e2e_attach_ts_costs!(sys2)
             _ptdp_e2e_check_ts_costs(
@@ -588,8 +590,8 @@ end
             @test TimeSeries.values(IS.get_time_array(attr_ts3)) == attr_series_values
 
             # The time-series-backed costs from (g) above, surviving PSY's own
-            # to_openapi/from_openapi round trip — the actual proof for Task 11: every key
-            # (`==`, including `association_id`) comes back exactly as set on `sys2`.
+            # to_openapi/from_openapi round trip: every key (`==`, including
+            # `association_id`) comes back exactly as set on `sys2`.
             _ptdp_e2e_check_ts_costs(
                 sys3, market_bid_gen_name, ts_cost_keys, fuel_gen_name, fuel_ts_key,
             )

--- a/test/test_openapi_ptdp_end_to_end.jl
+++ b/test/test_openapi_ptdp_end_to_end.jl
@@ -428,7 +428,7 @@ end
         attr_id = PSY.PD.next_id!(doc)
         PSY.PD.add_supplemental_attribute!(
             doc,
-            PSY.PC.GeographicInfo(; id = attr_id, geo_json = geo_json),
+            PSY.IC.GeographicInfo(; id = attr_id, geo_json = geo_json),
             target_id,
         )
 

--- a/test/test_openapi_refs.jl
+++ b/test/test_openapi_refs.jl
@@ -1,5 +1,5 @@
 @testset "OpenAPIRefs: setindex!/getindex hit and miss" begin
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS")
+    refs = PSY.OpenAPIRefs()
     area = Area(; name = "area1", peak_active_power = 0.0, peak_reactive_power = 0.0)
     refs[1] = area
     @test refs[1] === area
@@ -9,7 +9,7 @@
 end
 
 @testset "OpenAPIRefs: duplicate id rejected" begin
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS")
+    refs = PSY.OpenAPIRefs()
     area1 = Area(; name = "a1", peak_active_power = 0.0, peak_reactive_power = 0.0)
     area2 = Area(; name = "a2", peak_active_power = 0.0, peak_reactive_power = 0.0)
     refs[1] = area1
@@ -18,7 +18,7 @@ end
 end
 
 @testset "OpenAPIRefs: component -> id reverse lookup" begin
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS")
+    refs = PSY.OpenAPIRefs()
     area = Area(; name = "a1", peak_active_power = 0.0, peak_reactive_power = 0.0)
     other = Area(; name = "a2", peak_active_power = 0.0, peak_reactive_power = 0.0)
     refs[7] = area

--- a/test/test_openapi_sqlite_load.jl
+++ b/test/test_openapi_sqlite_load.jl
@@ -70,7 +70,7 @@ end
 @testset "load_supplemental_attribute_associations!: shared attribute is one object" begin
     f = _sqlite_load_fixture()
 
-    geo_po = PSY.PC.GeographicInfo(;
+    geo_po = PSY.IC.GeographicInfo(;
         id = 100,
         geo_json = Dict{String, Any}("type" => "Point", "coordinates" => [1.0, 2.0]),
     )
@@ -127,7 +127,7 @@ end
 end
 
 @testset "load_supplemental_attribute_associations!: loud errors" begin
-    geo_po = PSY.PC.GeographicInfo(;
+    geo_po = PSY.IC.GeographicInfo(;
         id = 100,
         geo_json = Dict{String, Any}("type" => "Point", "coordinates" => [1.0, 2.0]),
     )

--- a/test/test_openapi_sqlite_load.jl
+++ b/test/test_openapi_sqlite_load.jl
@@ -15,7 +15,7 @@ subset of `make_openapi_test_doc()`'s components these tests attach attributes/t
 to or use for service membership — registered under the SAME ids the document declares."""
 function _sqlite_load_fixture()
     sys = System(100.0)
-    refs = PSY.OpenAPIRefs("NATURAL_UNITS", 100.0)
+    refs = PSY.OpenAPIRefs(100.0)
 
     bus1 = ACBus(;
         number = 1, name = "bus1", available = true, bustype = ACBusTypes.REF,

--- a/test/test_outages.jl
+++ b/test/test_outages.jl
@@ -355,7 +355,7 @@ end
     doc = PSY.PD.read_document(joinpath(dir, "system.json"))
 
     geo_json = Dict{String, Any}("type" => "Point", "coordinates" => [0.0, 0.0])
-    geo = PSY.PC.GeographicInfo(; id = PSY.PD.next_id!(doc), geo_json = geo_json)
+    geo = PSY.IC.GeographicInfo(; id = PSY.PD.next_id!(doc), geo_json = geo_json)
     # A load carries none of the outage/GeographicInfo attributes the fixture attaches only
     # to the two generators and their buses, so it is unambiguously bare beforehand.
     load_id = Int(first(PSY.PD.get_components(doc, "PowerLoad")).id)


### PR DESCRIPTION
PowerSystems reads and writes the 0.1.0 wire contract: per-component `power_units` selection on import (erroring loudly on a missing declaration), per-component stamping on export (`power_units = :component_base | :natural_units` kwarg), blob-anchored base_power on import, the `variable_operation_cost` rename (reserves' offer-curve `variable` untouched), and `from_openapi(System, doc; base_power = 100.0)` since the document no longer carries a base. Follows the PowerOpenAPIModels package split (Sienna-Platform/PowerOpenAPIModels#11): domain-neutral shapes and the document registry resolve from `InfrastructureCoreOpenAPIModels`.

Verification: targeted serde suites — converters 298/298, document 500/500, refs 10/10, file_io 62/62, export 501/505. The four open export failures share one cause: the in-progress TradingHub supplemental-attribute converter registration, tracked with the market-components work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYWx3EqRR3kUCf1efCAxHn