### PR TITLE
Type the HVDC loss fields as LossCurve

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,7 @@ InfraStore = "6aee0376-896a-4a59-96ff-12f221c99746"
 # InfrastructureTimeSeriesOpenAPIModels, uncommitted — the pushed IS4 branch still requires
 # the old (now-unregistered) PowerTimeSeriesOpenAPIModels and fails to resolve. Revert to the
 # git rev once IS4 is pushed.
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/loss-curve-units-v2"}
 # LOCAL PATH CO-DEV PINS (temporary): the InfrastructureCore/InfrastructureTimeSeries package
 # split exists only on local disk, not pushed to jd/schemas-0.1.0 yet. Revert to the git pins
 # once pushed/merged.

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -114,6 +114,7 @@ export InputOutputCurve, IncrementalCurve, AverageRateCurve
 export LinearCurve, QuadraticCurve
 export PiecewisePointCurve, PiecewiseIncrementalCurve, PiecewiseAverageCurve
 export ProductionVariableCostCurve, CostCurve, FuelCurve
+export LossCurve, AnyLossCurve
 export get_function_data, get_initial_input, get_input_at_zero
 export get_value_curve, get_power_units
 
@@ -925,6 +926,8 @@ import InfrastructureSystems:
     AverageRateCurve,
     LinearCurve,
     QuadraticCurve,
+    LossCurve,
+    AnyLossCurve,
     PiecewisePointCurve,
     PiecewiseIncrementalCurve,
     PiecewiseAverageCurve,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,6 +1,12 @@
 # BEGIN 4.0.0  deprecations
 export TwoTerminalHVDCLine
 
+# These shims predate `loss` being a `LossCurve`, and their whole purpose is to accept the
+# old spellings, so a bare `ValueCurve` is still taken here and wrapped on the natural-units
+# basis -- the basis the old field's MW-denominated docstring always described.
+_deprecated_hvdc_loss(loss::AnyLossCurve) = loss
+_deprecated_hvdc_loss(curve::ValueCurve) = LossCurve(curve, NaturalUnit())
+
 """
 Deprecated method for the old TwoTerminalHVDCLine that returns the new TwoTerminalGenericHVDCLine.
 This constructor is used for some backward compatibility and will be removed in a future version.
@@ -19,7 +25,7 @@ function TwoTerminalHVDCLine(
     ext,
     internal,
 )
-    new_loss = LinearCurve(loss.l0, loss.l1)
+    new_loss = LossCurve(LinearCurve(loss.l0, loss.l1), NaturalUnit())
     @warn(
         "The TwoTerminalHVDCLine constructor is deprecated. Use TwoTerminalGenericHVDCLine instead. \
          This constructor will be removed in a future version.",)
@@ -59,7 +65,7 @@ function TwoTerminalHVDCLine(
     @warn(
         "The TwoTerminalHVDCLine constructor is deprecated. Use TwoTerminalGenericHVDCLine instead. \
          This constructor will be removed in a future version.",)
-    new_loss = LinearCurve(loss.l0, loss.l1)
+    new_loss = LossCurve(LinearCurve(loss.l0, loss.l1), NaturalUnit())
     TwoTerminalGenericHVDCLine(;
         name = name,
         available = available,
@@ -105,7 +111,7 @@ function TwoTerminalHVDCLine(
         active_power_limits_to = active_power_limits_to,
         reactive_power_limits_from = reactive_power_limits_from,
         reactive_power_limits_to = reactive_power_limits_to,
-        loss = loss,
+        loss = _deprecated_hvdc_loss(loss),
         services = services,
         ext = ext,
         internal = InfrastructureSystemsInternal(),
@@ -141,7 +147,7 @@ function TwoTerminalHVDCLine(
         active_power_limits_to = active_power_limits_to,
         reactive_power_limits_from = reactive_power_limits_from,
         reactive_power_limits_to = reactive_power_limits_to,
-        loss = loss,
+        loss = _deprecated_hvdc_loss(loss),
         services = services,
         ext = ext,
         internal = InfrastructureSystemsInternal(),
@@ -178,7 +184,7 @@ function TwoTerminalHVDCLine(;
         active_power_limits_to = active_power_limits_to,
         reactive_power_limits_from = reactive_power_limits_from,
         reactive_power_limits_to = reactive_power_limits_to,
-        loss = loss,
+        loss = _deprecated_hvdc_loss(loss),
         services = services,
         ext = ext,
         internal = internal,

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -1540,9 +1540,9 @@
                 {
                     "name": "loss",
                     "comment": "Loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, PiecewiseIncrementalCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "null_value": "LossCurve(LinearCurve(0.0), NaturalUnit())",
+                    "data_type": "Union{AnyLossCurve{LinearCurve}, AnyLossCurve{PiecewiseIncrementalCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0), NaturalUnit())"
                 },
                 {
                     "name": "services",
@@ -1704,9 +1704,9 @@
                 {
                     "name": "converter_loss_from",
                     "comment": "Loss model coefficients in the `from` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, QuadraticCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "null_value": "LossCurve(LinearCurve(0.0), NaturalUnit())",
+                    "data_type": "Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0), NaturalUnit())"
                 },
                 {
                     "name": "max_dc_current_from",
@@ -1806,9 +1806,9 @@
                 {
                     "name": "converter_loss_to",
                     "comment": "Loss model coefficients in the `to` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, QuadraticCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "null_value": "LossCurve(LinearCurve(0.0), NaturalUnit())",
+                    "data_type": "Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0), NaturalUnit())"
                 },
                 {
                     "name": "max_dc_current_to",
@@ -2204,9 +2204,9 @@
                 {
                     "name": "loss",
                     "comment": "A generic loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, PiecewiseIncrementalCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "null_value": "LossCurve(LinearCurve(0.0), NaturalUnit())",
+                    "data_type": "Union{AnyLossCurve{LinearCurve}, AnyLossCurve{PiecewiseIncrementalCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0), NaturalUnit())"
                 },
                 {
                     "name": "services",
@@ -4375,9 +4375,9 @@
                 {
                     "name": "loss_function",
                     "comment": "Linear or quadratic loss function with respect to the converter current",
-                    "null_value": "LinearCurve(0.0)",
-                    "data_type": "Union{LinearCurve, QuadraticCurve}",
-                    "default": "LinearCurve(0.0)"
+                    "null_value": "LossCurve(LinearCurve(0.0), NaturalUnit())",
+                    "data_type": "Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}",
+                    "default": "LossCurve(LinearCurve(0.0), NaturalUnit())"
                 },
                 {
                     "name": "dc_control",

--- a/src/models/generated/InterconnectingConverter.jl
+++ b/src/models/generated/InterconnectingConverter.jl
@@ -17,7 +17,7 @@ This file is auto-generated. Do not edit.
         reactive_power_limits::Union{Nothing, MinMax}
         dc_current::Float64
         max_dc_current::Float64
-        loss_function::Union{LinearCurve, QuadraticCurve}
+        loss_function::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}
         dc_control::VSCDCControlModes
         ac_control::VSCACControlModes
         dc_setpoint::Float64
@@ -47,7 +47,7 @@ Interconnecting Power Converter (IPC) for transforming power from an ACBus to a 
 - `reactive_power_limits::Union{Nothing, MinMax}`: (default: `nothing`) Minimum and maximum reactive power limits. Set to `Nothing` if not applicable
 - `dc_current::Float64`: (default: `0.0`) DC current on the converter, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)
 - `max_dc_current::Float64`: (default: `1e8`) Maximum stable DC current limit, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)
-- `loss_function::Union{LinearCurve, QuadraticCurve}`: (default: `LinearCurve(0.0)`) Linear or quadratic loss function with respect to the converter current
+- `loss_function::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}`: (default: `LossCurve(LinearCurve(0.0), NaturalUnit())`) Linear or quadratic loss function with respect to the converter current
 - `dc_control::VSCDCControlModes`: (default: `VSCDCControlModes.DC_VOLTAGE`) DC-side control mode of the converter; see [`VSCDCControlModes`](@ref).
 - `ac_control::VSCACControlModes`: (default: `VSCACControlModes.AC_REACTIVE_POWER`) AC-side control mode of the converter; see [`VSCACControlModes`](@ref).
 - `dc_setpoint::Float64`: (default: `0.0`) DC-voltage target (when dc_voltage_control is true) or active-power order (when false), in per unit.
@@ -86,7 +86,7 @@ mutable struct InterconnectingConverter <: StaticInjection
     "Maximum stable DC current limit, in per unit power-equivalent on the converter `base_power` (I is approximately P at 1.0 pu DC voltage)"
     max_dc_current::Float64
     "Linear or quadratic loss function with respect to the converter current"
-    loss_function::Union{LinearCurve, QuadraticCurve}
+    loss_function::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}
     "DC-side control mode of the converter; see [`VSCDCControlModes`](@ref)."
     dc_control::VSCDCControlModes
     "AC-side control mode of the converter; see [`VSCACControlModes`](@ref)."
@@ -115,11 +115,11 @@ mutable struct InterconnectingConverter <: StaticInjection
     internal::InfrastructureSystemsInternal
 end
 
-function InterconnectingConverter(name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits=nothing, dc_current=0.0, max_dc_current=1e8, loss_function=LinearCurve(0.0), dc_control=VSCDCControlModes.DC_VOLTAGE, ac_control=VSCACControlModes.AC_REACTIVE_POWER, dc_setpoint=0.0, ac_setpoint=1.0, dc_voltage_droop=0.0, remote_bus_control=nothing, rmpct=100.0, power_factor_weighting_fraction=1.0, voltage_limits=(min=0.0, max=999.9), services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
+function InterconnectingConverter(name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits=nothing, dc_current=0.0, max_dc_current=1e8, loss_function=LossCurve(LinearCurve(0.0), NaturalUnit()), dc_control=VSCDCControlModes.DC_VOLTAGE, ac_control=VSCACControlModes.AC_REACTIVE_POWER, dc_setpoint=0.0, ac_setpoint=1.0, dc_voltage_droop=0.0, remote_bus_control=nothing, rmpct=100.0, power_factor_weighting_fraction=1.0, voltage_limits=(min=0.0, max=999.9), services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), )
     InterconnectingConverter(name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits, dc_current, max_dc_current, loss_function, dc_control, ac_control, dc_setpoint, ac_setpoint, dc_voltage_droop, remote_bus_control, rmpct, power_factor_weighting_fraction, voltage_limits, services, dynamic_injector, ext, InfrastructureSystemsInternal(), )
 end
 
-function InterconnectingConverter(; name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits=nothing, dc_current=0.0, max_dc_current=1e8, loss_function=LinearCurve(0.0), dc_control=VSCDCControlModes.DC_VOLTAGE, ac_control=VSCACControlModes.AC_REACTIVE_POWER, dc_setpoint=0.0, ac_setpoint=1.0, dc_voltage_droop=0.0, remote_bus_control=nothing, rmpct=100.0, power_factor_weighting_fraction=1.0, voltage_limits=(min=0.0, max=999.9), services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+function InterconnectingConverter(; name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits=nothing, dc_current=0.0, max_dc_current=1e8, loss_function=LossCurve(LinearCurve(0.0), NaturalUnit()), dc_control=VSCDCControlModes.DC_VOLTAGE, ac_control=VSCACControlModes.AC_REACTIVE_POWER, dc_setpoint=0.0, ac_setpoint=1.0, dc_voltage_droop=0.0, remote_bus_control=nothing, rmpct=100.0, power_factor_weighting_fraction=1.0, voltage_limits=(min=0.0, max=999.9), services=Device[], dynamic_injector=nothing, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
     InterconnectingConverter(name, available, bus, dc_bus, active_power, rating, active_power_limits, base_power, reactive_power_limits, dc_current, max_dc_current, loss_function, dc_control, ac_control, dc_setpoint, ac_setpoint, dc_voltage_droop, remote_bus_control, rmpct, power_factor_weighting_fraction, voltage_limits, services, dynamic_injector, ext, internal, )
 end
 
@@ -137,7 +137,7 @@ function InterconnectingConverter(::Nothing)
         reactive_power_limits=nothing,
         dc_current=0.0,
         max_dc_current=0.0,
-        loss_function=LinearCurve(0.0),
+        loss_function=LossCurve(LinearCurve(0.0), NaturalUnit()),
         dc_control=VSCDCControlModes.DC_VOLTAGE,
         ac_control=VSCACControlModes.AC_REACTIVE_POWER,
         dc_setpoint=0.0,

--- a/src/models/generated/TwoTerminalGenericHVDCLine.jl
+++ b/src/models/generated/TwoTerminalGenericHVDCLine.jl
@@ -14,7 +14,7 @@ This file is auto-generated. Do not edit.
         active_power_limits_to::MinMax
         reactive_power_limits_from::MinMax
         reactive_power_limits_to::MinMax
-        loss::Union{LinearCurve, PiecewiseIncrementalCurve}
+        loss::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{PiecewiseIncrementalCurve}}
         services::Vector{Service}
         base_power::Float64
         ext::Dict{String, Any}
@@ -34,7 +34,7 @@ This model is appropriate for operational simulations with a linearized DC power
 - `active_power_limits_to::MinMax`: Minimum and maximum active power flows to the TO node (MW)
 - `reactive_power_limits_from::MinMax`: Minimum and maximum reactive power limits to the FROM node (MVAR)
 - `reactive_power_limits_to::MinMax`: Minimum and maximum reactive power limits to the TO node (MVAR)
-- `loss::Union{LinearCurve, PiecewiseIncrementalCurve}`: (default: `LinearCurve(0.0)`) Loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.
+- `loss::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{PiecewiseIncrementalCurve}}`: (default: `LossCurve(LinearCurve(0.0), NaturalUnit())`) Loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `base_power::Float64`: (default: `100.0`) System base power for per-unitization of this component's per-unit fields, recorded per component in lieu of a system-level table (MVA), validation range: `(0.0001, nothing)`
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
@@ -58,7 +58,7 @@ mutable struct TwoTerminalGenericHVDCLine <: TwoTerminalHVDC
     "Minimum and maximum reactive power limits to the TO node (MVAR)"
     reactive_power_limits_to::MinMax
     "Loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments."
-    loss::Union{LinearCurve, PiecewiseIncrementalCurve}
+    loss::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{PiecewiseIncrementalCurve}}
     "Services that this device contributes to"
     services::Vector{Service}
     "System base power for per-unitization of this component's per-unit fields, recorded per component in lieu of a system-level table (MVA)"
@@ -69,11 +69,11 @@ mutable struct TwoTerminalGenericHVDCLine <: TwoTerminalHVDC
     internal::InfrastructureSystemsInternal
 end
 
-function TwoTerminalGenericHVDCLine(name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss=LinearCurve(0.0), services=Device[], base_power=100.0, ext=Dict{String, Any}(), )
+function TwoTerminalGenericHVDCLine(name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss=LossCurve(LinearCurve(0.0), NaturalUnit()), services=Device[], base_power=100.0, ext=Dict{String, Any}(), )
     TwoTerminalGenericHVDCLine(name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss, services, base_power, ext, InfrastructureSystemsInternal(), )
 end
 
-function TwoTerminalGenericHVDCLine(; name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss=LinearCurve(0.0), services=Device[], base_power=100.0, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+function TwoTerminalGenericHVDCLine(; name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss=LossCurve(LinearCurve(0.0), NaturalUnit()), services=Device[], base_power=100.0, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
     TwoTerminalGenericHVDCLine(name, available, active_power_flow, arc, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss, services, base_power, ext, internal, )
 end
 
@@ -88,7 +88,7 @@ function TwoTerminalGenericHVDCLine(::Nothing)
         active_power_limits_to=(min=0.0, max=0.0),
         reactive_power_limits_from=(min=0.0, max=0.0),
         reactive_power_limits_to=(min=0.0, max=0.0),
-        loss=LinearCurve(0.0),
+        loss=LossCurve(LinearCurve(0.0), NaturalUnit()),
         services=Device[],
         base_power=100.0,
         ext=Dict{String, Any}(),

--- a/src/models/generated/TwoTerminalLCCLine.jl
+++ b/src/models/generated/TwoTerminalLCCLine.jl
@@ -43,7 +43,7 @@ This file is auto-generated. Do not edit.
         active_power_limits_to::MinMax
         reactive_power_limits_from::MinMax
         reactive_power_limits_to::MinMax
-        loss::Union{LinearCurve, PiecewiseIncrementalCurve}
+        loss::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{PiecewiseIncrementalCurve}}
         services::Vector{Service}
         base_power::Float64
         ext::Dict{String, Any}
@@ -92,7 +92,7 @@ As implemented in PSS/E.
 - `active_power_limits_to::MinMax`: (default: `(min=0.0, max=0.0)`) Minimum and maximum active power flows to the TO node (MW)
 - `reactive_power_limits_from::MinMax`: (default: `(min=0.0, max=0.0)`) Minimum and maximum reactive power limits to the FROM node (MVAR)
 - `reactive_power_limits_to::MinMax`: (default: `(min=0.0, max=0.0)`) Minimum and maximum reactive power limits to the TO node (MVAR)
-- `loss::Union{LinearCurve, PiecewiseIncrementalCurve}`: (default: `LinearCurve(0.0)`) A generic loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.
+- `loss::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{PiecewiseIncrementalCurve}}`: (default: `LossCurve(LinearCurve(0.0), NaturalUnit())`) A generic loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments.
 - `services::Vector{Service}`: (default: `Device[]`) Services that this device contributes to
 - `base_power::Float64`: (default: `100.0`) System base power for per-unitization of this component's per-unit fields, recorded per component in lieu of a system-level table (MVA), validation range: `(0.0001, nothing)`
 - `ext::Dict{String, Any}`: (default: `Dict{String, Any}()`) An [*ext*ra dictionary](@ref additional_fields) for users to add metadata that are not used in simulation.
@@ -174,7 +174,7 @@ mutable struct TwoTerminalLCCLine <: TwoTerminalHVDC
     "Minimum and maximum reactive power limits to the TO node (MVAR)"
     reactive_power_limits_to::MinMax
     "A generic loss model coefficients. It accepts a linear model with a constant loss (MW) and a proportional loss rate (MW of loss per MW of flow). It also accepts a Piecewise loss, with N segments to specify different proportional losses for different segments."
-    loss::Union{LinearCurve, PiecewiseIncrementalCurve}
+    loss::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{PiecewiseIncrementalCurve}}
     "Services that this device contributes to"
     services::Vector{Service}
     "System base power for per-unitization of this component's per-unit fields, recorded per component in lieu of a system-level table (MVA)"
@@ -185,11 +185,11 @@ mutable struct TwoTerminalLCCLine <: TwoTerminalHVDC
     internal::InfrastructureSystemsInternal
 end
 
-function TwoTerminalLCCLine(name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode=true, switch_mode_voltage=0.0, compounding_resistance=0.0, min_compounding_voltage=0.0, rectifier_transformer_ratio=1.0, rectifier_tap_setting=1.0, rectifier_tap_limits=(min=0.51, max=1.5), rectifier_tap_step=0.00625, rectifier_delay_angle=0.0, rectifier_capacitor_reactance=0.0, inverter_transformer_ratio=1.0, inverter_tap_setting=1.0, inverter_tap_limits=(min=0.51, max=1.5), inverter_tap_step=0.00625, inverter_extinction_angle=0.0, inverter_capacitor_reactance=0.0, active_power_limits_from=(min=0.0, max=0.0), active_power_limits_to=(min=0.0, max=0.0), reactive_power_limits_from=(min=0.0, max=0.0), reactive_power_limits_to=(min=0.0, max=0.0), loss=LinearCurve(0.0), services=Device[], base_power=100.0, ext=Dict{String, Any}(), )
+function TwoTerminalLCCLine(name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode=true, switch_mode_voltage=0.0, compounding_resistance=0.0, min_compounding_voltage=0.0, rectifier_transformer_ratio=1.0, rectifier_tap_setting=1.0, rectifier_tap_limits=(min=0.51, max=1.5), rectifier_tap_step=0.00625, rectifier_delay_angle=0.0, rectifier_capacitor_reactance=0.0, inverter_transformer_ratio=1.0, inverter_tap_setting=1.0, inverter_tap_limits=(min=0.51, max=1.5), inverter_tap_step=0.00625, inverter_extinction_angle=0.0, inverter_capacitor_reactance=0.0, active_power_limits_from=(min=0.0, max=0.0), active_power_limits_to=(min=0.0, max=0.0), reactive_power_limits_from=(min=0.0, max=0.0), reactive_power_limits_to=(min=0.0, max=0.0), loss=LossCurve(LinearCurve(0.0), NaturalUnit()), services=Device[], base_power=100.0, ext=Dict{String, Any}(), )
     TwoTerminalLCCLine(name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode, switch_mode_voltage, compounding_resistance, min_compounding_voltage, rectifier_transformer_ratio, rectifier_tap_setting, rectifier_tap_limits, rectifier_tap_step, rectifier_delay_angle, rectifier_capacitor_reactance, inverter_transformer_ratio, inverter_tap_setting, inverter_tap_limits, inverter_tap_step, inverter_extinction_angle, inverter_capacitor_reactance, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss, services, base_power, ext, InfrastructureSystemsInternal(), )
 end
 
-function TwoTerminalLCCLine(; name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode=true, switch_mode_voltage=0.0, compounding_resistance=0.0, min_compounding_voltage=0.0, rectifier_transformer_ratio=1.0, rectifier_tap_setting=1.0, rectifier_tap_limits=(min=0.51, max=1.5), rectifier_tap_step=0.00625, rectifier_delay_angle=0.0, rectifier_capacitor_reactance=0.0, inverter_transformer_ratio=1.0, inverter_tap_setting=1.0, inverter_tap_limits=(min=0.51, max=1.5), inverter_tap_step=0.00625, inverter_extinction_angle=0.0, inverter_capacitor_reactance=0.0, active_power_limits_from=(min=0.0, max=0.0), active_power_limits_to=(min=0.0, max=0.0), reactive_power_limits_from=(min=0.0, max=0.0), reactive_power_limits_to=(min=0.0, max=0.0), loss=LinearCurve(0.0), services=Device[], base_power=100.0, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+function TwoTerminalLCCLine(; name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode=true, switch_mode_voltage=0.0, compounding_resistance=0.0, min_compounding_voltage=0.0, rectifier_transformer_ratio=1.0, rectifier_tap_setting=1.0, rectifier_tap_limits=(min=0.51, max=1.5), rectifier_tap_step=0.00625, rectifier_delay_angle=0.0, rectifier_capacitor_reactance=0.0, inverter_transformer_ratio=1.0, inverter_tap_setting=1.0, inverter_tap_limits=(min=0.51, max=1.5), inverter_tap_step=0.00625, inverter_extinction_angle=0.0, inverter_capacitor_reactance=0.0, active_power_limits_from=(min=0.0, max=0.0), active_power_limits_to=(min=0.0, max=0.0), reactive_power_limits_from=(min=0.0, max=0.0), reactive_power_limits_to=(min=0.0, max=0.0), loss=LossCurve(LinearCurve(0.0), NaturalUnit()), services=Device[], base_power=100.0, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
     TwoTerminalLCCLine(name, available, arc, active_power_flow, r, transfer_setpoint, scheduled_dc_voltage, rectifier_bridges, rectifier_delay_angle_limits, rectifier_rc, rectifier_xc, rectifier_base_voltage, inverter_bridges, inverter_extinction_angle_limits, inverter_rc, inverter_xc, inverter_base_voltage, power_mode, switch_mode_voltage, compounding_resistance, min_compounding_voltage, rectifier_transformer_ratio, rectifier_tap_setting, rectifier_tap_limits, rectifier_tap_step, rectifier_delay_angle, rectifier_capacitor_reactance, inverter_transformer_ratio, inverter_tap_setting, inverter_tap_limits, inverter_tap_step, inverter_extinction_angle, inverter_capacitor_reactance, active_power_limits_from, active_power_limits_to, reactive_power_limits_from, reactive_power_limits_to, loss, services, base_power, ext, internal, )
 end
 
@@ -233,7 +233,7 @@ function TwoTerminalLCCLine(::Nothing)
         active_power_limits_to=(min=0.0, max=0.0),
         reactive_power_limits_from=(min=0.0, max=0.0),
         reactive_power_limits_to=(min=0.0, max=0.0),
-        loss=LinearCurve(0.0),
+        loss=LossCurve(LinearCurve(0.0), NaturalUnit()),
         services=Device[],
         base_power=100.0,
         ext=Dict{String, Any}(),

--- a/src/models/generated/TwoTerminalVSCLine.jl
+++ b/src/models/generated/TwoTerminalVSCLine.jl
@@ -21,7 +21,7 @@ This file is auto-generated. Do not edit.
         dc_setpoint_from::Float64
         ac_setpoint_from::Float64
         rated_ac_voltage_from::Float64
-        converter_loss_from::Union{LinearCurve, QuadraticCurve}
+        converter_loss_from::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}
         max_dc_current_from::Float64
         rating_from::Float64
         reactive_power_limits_from::MinMax
@@ -34,7 +34,7 @@ This file is auto-generated. Do not edit.
         dc_setpoint_to::Float64
         ac_setpoint_to::Float64
         rated_ac_voltage_to::Float64
-        converter_loss_to::Union{LinearCurve, QuadraticCurve}
+        converter_loss_to::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}
         max_dc_current_to::Float64
         rating_to::Float64
         reactive_power_limits_to::MinMax
@@ -72,7 +72,7 @@ This model is appropriate for operational simulations with a linearized DC power
 - `dc_setpoint_from::Float64`: (default: `0.0`) Converter DC setpoint on the `from` bus converter, in per-unit. For a DC-voltage-controlling mode (`dc_control_from` is `DC_VOLTAGE` or `DC_VOLTAGE_DROOP`) this is the DC-side voltage in per-unit of `rated_dc_voltage`. For `DC_POWER` this is the active-power demand in per-unit ([`SYSTEM_BASE`](@ref per_unit)); positive means the converter supplies power to the AC network at the `from` bus, negative means it withdraws.
 - `ac_setpoint_from::Float64`: (default: `1.0`) Converter AC setpoint in the `from` bus converter. When `ac_control_from` is `AC_VOLTAGE` this is the AC voltage on the AC side of the converter, in per-unit of `rated_ac_voltage_from`. When `ac_control_from` is `AC_REACTIVE_POWER`, this value is the power factor setpoint.
 - `rated_ac_voltage_from::Float64`: (default: `0.0`) Rated (base) AC voltage at the `from` converter's AC terminal in kV. Used as the AC voltage base for interpreting `ac_setpoint_from` when `ac_control_from` is `AC_VOLTAGE`; `0.0` means unspecified (the setpoint is taken as per-unit directly).
-- `converter_loss_from::Union{LinearCurve, QuadraticCurve}`: (default: `LinearCurve(0.0)`) Loss model coefficients in the `from` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.
+- `converter_loss_from::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}`: (default: `LossCurve(LinearCurve(0.0), NaturalUnit())`) Loss model coefficients in the `from` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.
 - `max_dc_current_from::Float64`: (default: `1e8`) Maximum stable dc current limits (A).
 - `rating_from::Float64`: (default: `1e8`) Converter rating in MVA in the `from` bus.
 - `reactive_power_limits_from::MinMax`: (default: `(min=0.0, max=0.0)`) Limits on the Reactive Power at the `from` side.
@@ -85,7 +85,7 @@ This model is appropriate for operational simulations with a linearized DC power
 - `dc_setpoint_to::Float64`: (default: `0.0`) Converter DC setpoint on the `to` bus converter, in per-unit. For a DC-voltage-controlling mode (`dc_control_to` is `DC_VOLTAGE` or `DC_VOLTAGE_DROOP`) this is the DC-side voltage in per-unit of `rated_dc_voltage`. For `DC_POWER` this is the active-power demand in per-unit ([`SYSTEM_BASE`](@ref per_unit)); positive means the converter supplies power to the AC network at the `to` bus, negative means it withdraws.
 - `ac_setpoint_to::Float64`: (default: `1.0`) Converter AC setpoint in the `to` bus converter. When `ac_control_to` is `AC_VOLTAGE` this is the AC voltage on the AC side of the converter, in per-unit of `rated_ac_voltage_to`. When `ac_control_to` is `AC_REACTIVE_POWER`, this value is the power factor setpoint.
 - `rated_ac_voltage_to::Float64`: (default: `0.0`) Rated (base) AC voltage at the `to` converter's AC terminal in kV. Used as the AC voltage base for interpreting `ac_setpoint_to` when `ac_control_to` is `AC_VOLTAGE`; `0.0` means unspecified (the setpoint is taken as per-unit directly).
-- `converter_loss_to::Union{LinearCurve, QuadraticCurve}`: (default: `LinearCurve(0.0)`) Loss model coefficients in the `to` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.
+- `converter_loss_to::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}`: (default: `LossCurve(LinearCurve(0.0), NaturalUnit())`) Loss model coefficients in the `to` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends.
 - `max_dc_current_to::Float64`: (default: `1e8`) Maximum stable dc current limits (A).
 - `rating_to::Float64`: (default: `1e8`) Converter rating in MVA in the `to` bus.
 - `reactive_power_limits_to::MinMax`: (default: `(min=0.0, max=0.0)`) Limits on the Reactive Power at the `to` side.
@@ -134,7 +134,7 @@ mutable struct TwoTerminalVSCLine <: TwoTerminalHVDC
     "Rated (base) AC voltage at the `from` converter's AC terminal in kV. Used as the AC voltage base for interpreting `ac_setpoint_from` when `ac_control_from` is `AC_VOLTAGE`; `0.0` means unspecified (the setpoint is taken as per-unit directly)."
     rated_ac_voltage_from::Float64
     "Loss model coefficients in the `from` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends."
-    converter_loss_from::Union{LinearCurve, QuadraticCurve}
+    converter_loss_from::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}
     "Maximum stable dc current limits (A)."
     max_dc_current_from::Float64
     "Converter rating in MVA in the `from` bus."
@@ -160,7 +160,7 @@ mutable struct TwoTerminalVSCLine <: TwoTerminalHVDC
     "Rated (base) AC voltage at the `to` converter's AC terminal in kV. Used as the AC voltage base for interpreting `ac_setpoint_to` when `ac_control_to` is `AC_VOLTAGE`; `0.0` means unspecified (the setpoint is taken as per-unit directly)."
     rated_ac_voltage_to::Float64
     "Loss model coefficients in the `to` bus converter. It accepts a linear model or quadratic. Same converter data is used in both ends."
-    converter_loss_to::Union{LinearCurve, QuadraticCurve}
+    converter_loss_to::Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}
     "Maximum stable dc current limits (A)."
     max_dc_current_to::Float64
     "Converter rating in MVA in the `to` bus."
@@ -193,11 +193,11 @@ mutable struct TwoTerminalVSCLine <: TwoTerminalHVDC
     internal::InfrastructureSystemsInternal
 end
 
-function TwoTerminalVSCLine(name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g=0.0, dc_current=0.0, reactive_power_from=0.0, dc_control_from=VSCDCControlModes.DC_VOLTAGE, ac_control_from=VSCACControlModes.AC_VOLTAGE, dc_setpoint_from=0.0, ac_setpoint_from=1.0, rated_ac_voltage_from=0.0, converter_loss_from=LinearCurve(0.0), max_dc_current_from=1e8, rating_from=1e8, reactive_power_limits_from=(min=0.0, max=0.0), power_factor_weighting_fraction_from=1.0, voltage_limits_from=(min=0.0, max=999.9), dc_voltage_droop_from=0.0, reactive_power_to=0.0, dc_control_to=VSCDCControlModes.DC_VOLTAGE, ac_control_to=VSCACControlModes.AC_VOLTAGE, dc_setpoint_to=0.0, ac_setpoint_to=1.0, rated_ac_voltage_to=0.0, converter_loss_to=LinearCurve(0.0), max_dc_current_to=1e8, rating_to=1e8, reactive_power_limits_to=(min=0.0, max=0.0), power_factor_weighting_fraction_to=1.0, voltage_limits_to=(min=0.0, max=999.9), dc_voltage_droop_to=0.0, rated_dc_voltage=0.0, remote_bus_control_from=nothing, remote_bus_control_to=nothing, rmpct_from=100.0, rmpct_to=100.0, services=Device[], base_power=100.0, ext=Dict{String, Any}(), )
+function TwoTerminalVSCLine(name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g=0.0, dc_current=0.0, reactive_power_from=0.0, dc_control_from=VSCDCControlModes.DC_VOLTAGE, ac_control_from=VSCACControlModes.AC_VOLTAGE, dc_setpoint_from=0.0, ac_setpoint_from=1.0, rated_ac_voltage_from=0.0, converter_loss_from=LossCurve(LinearCurve(0.0), NaturalUnit()), max_dc_current_from=1e8, rating_from=1e8, reactive_power_limits_from=(min=0.0, max=0.0), power_factor_weighting_fraction_from=1.0, voltage_limits_from=(min=0.0, max=999.9), dc_voltage_droop_from=0.0, reactive_power_to=0.0, dc_control_to=VSCDCControlModes.DC_VOLTAGE, ac_control_to=VSCACControlModes.AC_VOLTAGE, dc_setpoint_to=0.0, ac_setpoint_to=1.0, rated_ac_voltage_to=0.0, converter_loss_to=LossCurve(LinearCurve(0.0), NaturalUnit()), max_dc_current_to=1e8, rating_to=1e8, reactive_power_limits_to=(min=0.0, max=0.0), power_factor_weighting_fraction_to=1.0, voltage_limits_to=(min=0.0, max=999.9), dc_voltage_droop_to=0.0, rated_dc_voltage=0.0, remote_bus_control_from=nothing, remote_bus_control_to=nothing, rmpct_from=100.0, rmpct_to=100.0, services=Device[], base_power=100.0, ext=Dict{String, Any}(), )
     TwoTerminalVSCLine(name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g, dc_current, reactive_power_from, dc_control_from, ac_control_from, dc_setpoint_from, ac_setpoint_from, rated_ac_voltage_from, converter_loss_from, max_dc_current_from, rating_from, reactive_power_limits_from, power_factor_weighting_fraction_from, voltage_limits_from, dc_voltage_droop_from, reactive_power_to, dc_control_to, ac_control_to, dc_setpoint_to, ac_setpoint_to, rated_ac_voltage_to, converter_loss_to, max_dc_current_to, rating_to, reactive_power_limits_to, power_factor_weighting_fraction_to, voltage_limits_to, dc_voltage_droop_to, rated_dc_voltage, remote_bus_control_from, remote_bus_control_to, rmpct_from, rmpct_to, services, base_power, ext, InfrastructureSystemsInternal(), )
 end
 
-function TwoTerminalVSCLine(; name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g=0.0, dc_current=0.0, reactive_power_from=0.0, dc_control_from=VSCDCControlModes.DC_VOLTAGE, ac_control_from=VSCACControlModes.AC_VOLTAGE, dc_setpoint_from=0.0, ac_setpoint_from=1.0, rated_ac_voltage_from=0.0, converter_loss_from=LinearCurve(0.0), max_dc_current_from=1e8, rating_from=1e8, reactive_power_limits_from=(min=0.0, max=0.0), power_factor_weighting_fraction_from=1.0, voltage_limits_from=(min=0.0, max=999.9), dc_voltage_droop_from=0.0, reactive_power_to=0.0, dc_control_to=VSCDCControlModes.DC_VOLTAGE, ac_control_to=VSCACControlModes.AC_VOLTAGE, dc_setpoint_to=0.0, ac_setpoint_to=1.0, rated_ac_voltage_to=0.0, converter_loss_to=LinearCurve(0.0), max_dc_current_to=1e8, rating_to=1e8, reactive_power_limits_to=(min=0.0, max=0.0), power_factor_weighting_fraction_to=1.0, voltage_limits_to=(min=0.0, max=999.9), dc_voltage_droop_to=0.0, rated_dc_voltage=0.0, remote_bus_control_from=nothing, remote_bus_control_to=nothing, rmpct_from=100.0, rmpct_to=100.0, services=Device[], base_power=100.0, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+function TwoTerminalVSCLine(; name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g=0.0, dc_current=0.0, reactive_power_from=0.0, dc_control_from=VSCDCControlModes.DC_VOLTAGE, ac_control_from=VSCACControlModes.AC_VOLTAGE, dc_setpoint_from=0.0, ac_setpoint_from=1.0, rated_ac_voltage_from=0.0, converter_loss_from=LossCurve(LinearCurve(0.0), NaturalUnit()), max_dc_current_from=1e8, rating_from=1e8, reactive_power_limits_from=(min=0.0, max=0.0), power_factor_weighting_fraction_from=1.0, voltage_limits_from=(min=0.0, max=999.9), dc_voltage_droop_from=0.0, reactive_power_to=0.0, dc_control_to=VSCDCControlModes.DC_VOLTAGE, ac_control_to=VSCACControlModes.AC_VOLTAGE, dc_setpoint_to=0.0, ac_setpoint_to=1.0, rated_ac_voltage_to=0.0, converter_loss_to=LossCurve(LinearCurve(0.0), NaturalUnit()), max_dc_current_to=1e8, rating_to=1e8, reactive_power_limits_to=(min=0.0, max=0.0), power_factor_weighting_fraction_to=1.0, voltage_limits_to=(min=0.0, max=999.9), dc_voltage_droop_to=0.0, rated_dc_voltage=0.0, remote_bus_control_from=nothing, remote_bus_control_to=nothing, rmpct_from=100.0, rmpct_to=100.0, services=Device[], base_power=100.0, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
     TwoTerminalVSCLine(name, available, arc, active_power_flow, rating, active_power_limits_from, active_power_limits_to, g, dc_current, reactive_power_from, dc_control_from, ac_control_from, dc_setpoint_from, ac_setpoint_from, rated_ac_voltage_from, converter_loss_from, max_dc_current_from, rating_from, reactive_power_limits_from, power_factor_weighting_fraction_from, voltage_limits_from, dc_voltage_droop_from, reactive_power_to, dc_control_to, ac_control_to, dc_setpoint_to, ac_setpoint_to, rated_ac_voltage_to, converter_loss_to, max_dc_current_to, rating_to, reactive_power_limits_to, power_factor_weighting_fraction_to, voltage_limits_to, dc_voltage_droop_to, rated_dc_voltage, remote_bus_control_from, remote_bus_control_to, rmpct_from, rmpct_to, services, base_power, ext, internal, )
 end
 
@@ -219,7 +219,7 @@ function TwoTerminalVSCLine(::Nothing)
         dc_setpoint_from=0.0,
         ac_setpoint_from=0.0,
         rated_ac_voltage_from=0.0,
-        converter_loss_from=LinearCurve(0.0),
+        converter_loss_from=LossCurve(LinearCurve(0.0), NaturalUnit()),
         max_dc_current_from=0.0,
         rating_from=0.0,
         reactive_power_limits_from=(min=0.0, max=0.0),
@@ -232,7 +232,7 @@ function TwoTerminalVSCLine(::Nothing)
         dc_setpoint_to=0.0,
         ac_setpoint_to=0.0,
         rated_ac_voltage_to=0.0,
-        converter_loss_to=LinearCurve(0.0),
+        converter_loss_to=LossCurve(LinearCurve(0.0), NaturalUnit()),
         max_dc_current_to=0.0,
         rating_to=0.0,
         reactive_power_limits_to=(min=0.0, max=0.0),

--- a/src/openapi/cost_conversion.jl
+++ b/src/openapi/cost_conversion.jl
@@ -536,3 +536,39 @@ end
 """Convert a reserve's `variable` field; `nothing` means no demand curve is defined."""
 convert_reserve_variable(po::Union{Nothing, PC.CostCurve}) =
     _offer_curve(po, "a reserve demand curve")
+
+# ── LossCurve ⇄ OpenAPI ────────────────────────────────────────────────────────
+# The OpenAPI schemas have no `LossCurve`: a document's loss field is a bare
+# `ValueCurve` (`$ref: InputOutputCurve` / `TwoTerminalLoss`) with nowhere to record a
+# power basis. PSY's loss fields are `LossCurve`s, which carry one, so the two
+# directions are asymmetric until the schemas gain the type.
+
+"""
+Wrap a document's bare loss curve as a `LossCurve` on the natural-units basis.
+
+The document carries no basis for a loss field, so one is supplied here rather than
+guessed per call site: `NaturalUnit` is what every current producer writes and what the
+schema's own `UnitSystem` default names. When the schemas gain a `LossCurve` with an
+explicit `power_units`, this reads it instead of synthesizing it.
+"""
+loss_curve_from_openapi(curve::ValueCurve) = LossCurve(curve, NaturalUnit())
+
+"""
+Unwrap a `LossCurve` to the bare curve the document holds, refusing any basis the
+document cannot represent.
+
+Export errors on a non-natural basis rather than silently dropping it — the same posture
+`admittance_units`/`voltage_units` already take on these HVDC types, where only the
+implemented basis passes and anything else is an error rather than a guess. Without the
+guard a `LossCurve` on a relative basis would round-trip back as `NaturalUnit`, changing
+its meaning with no diagnostic.
+"""
+function loss_curve_to_openapi(loss::AnyLossCurve)
+    units = get_power_units(loss)
+    units isa NaturalUnit || error(
+        "cannot export a LossCurve in $units: the OpenAPI schemas have no LossCurve, so " *
+        "a document records no power basis for a loss field and the unit system would be " *
+        "silently dropped. Convert the curve to NaturalUnit before exporting.",
+    )
+    return get_value_curve(loss)
+end

--- a/src/openapi/export_handwritten.jl
+++ b/src/openapi/export_handwritten.jl
@@ -336,7 +336,9 @@ function to_openapi(conv::InterconnectingConverter, refs::OpenAPIRefs, ::DeviceB
         reactive_power_limits = _minmax_po_optional(get_reactive_power_limits(conv, DU)),
         dc_current = get_dc_current(conv, DU),
         max_dc_current = get_max_dc_current(conv, DU),
-        loss_function = convert_cost_to_openapi(loss_curve_to_openapi(get_loss_function(conv))),
+        loss_function = convert_cost_to_openapi(
+            loss_curve_to_openapi(get_loss_function(conv)),
+        ),
         dc_control = string(get_dc_control(conv)),
         ac_control = string(get_ac_control(conv)),
         voltage_setpoint_units = "COMPONENT_BASE",
@@ -368,7 +370,9 @@ function to_openapi(conv::InterconnectingConverter, refs::OpenAPIRefs, ::Natural
         ),
         dc_current = get_dc_current(conv, DU) * dbp,
         max_dc_current = get_max_dc_current(conv, DU) * dbp,
-        loss_function = convert_cost_to_openapi(loss_curve_to_openapi(get_loss_function(conv))),
+        loss_function = convert_cost_to_openapi(
+            loss_curve_to_openapi(get_loss_function(conv)),
+        ),
         dc_control = string(get_dc_control(conv)),
         ac_control = string(get_ac_control(conv)),
         voltage_setpoint_units = "COMPONENT_BASE",
@@ -1079,7 +1083,9 @@ function _two_terminal_vsc_line_to_openapi(vsc::TwoTerminalVSCLine, refs::OpenAP
             vsc, get_ac_setpoint_from(vsc), Val(ac_control_from),
         ),
         rated_ac_voltage_from = get_rated_ac_voltage_from(vsc),
-        converter_loss_from = convert_cost_to_openapi(loss_curve_to_openapi(get_converter_loss_from(vsc))),
+        converter_loss_from = convert_cost_to_openapi(
+            loss_curve_to_openapi(get_converter_loss_from(vsc)),
+        ),
         max_dc_current_from = get_max_dc_current_from(vsc),
         rating_from = _vsc_power_to_openapi(get_rating_from(vsc, SU), base_power, unit),
         reactive_power_limits_from = _vsc_minmax_to_openapi(
@@ -1103,7 +1109,9 @@ function _two_terminal_vsc_line_to_openapi(vsc::TwoTerminalVSCLine, refs::OpenAP
             vsc, get_ac_setpoint_to(vsc), Val(ac_control_to),
         ),
         rated_ac_voltage_to = get_rated_ac_voltage_to(vsc),
-        converter_loss_to = convert_cost_to_openapi(loss_curve_to_openapi(get_converter_loss_to(vsc))),
+        converter_loss_to = convert_cost_to_openapi(
+            loss_curve_to_openapi(get_converter_loss_to(vsc)),
+        ),
         max_dc_current_to = get_max_dc_current_to(vsc),
         rating_to = _vsc_power_to_openapi(get_rating_to(vsc, SU), base_power, unit),
         reactive_power_limits_to = _vsc_minmax_to_openapi(

--- a/src/openapi/export_handwritten.jl
+++ b/src/openapi/export_handwritten.jl
@@ -336,7 +336,7 @@ function to_openapi(conv::InterconnectingConverter, refs::OpenAPIRefs, ::DeviceB
         reactive_power_limits = _minmax_po_optional(get_reactive_power_limits(conv, DU)),
         dc_current = get_dc_current(conv, DU),
         max_dc_current = get_max_dc_current(conv, DU),
-        loss_function = convert_cost_to_openapi(get_loss_function(conv)),
+        loss_function = convert_cost_to_openapi(loss_curve_to_openapi(get_loss_function(conv))),
         dc_control = string(get_dc_control(conv)),
         ac_control = string(get_ac_control(conv)),
         voltage_setpoint_units = "COMPONENT_BASE",
@@ -368,7 +368,7 @@ function to_openapi(conv::InterconnectingConverter, refs::OpenAPIRefs, ::Natural
         ),
         dc_current = get_dc_current(conv, DU) * dbp,
         max_dc_current = get_max_dc_current(conv, DU) * dbp,
-        loss_function = convert_cost_to_openapi(get_loss_function(conv)),
+        loss_function = convert_cost_to_openapi(loss_curve_to_openapi(get_loss_function(conv))),
         dc_control = string(get_dc_control(conv)),
         ac_control = string(get_ac_control(conv)),
         voltage_setpoint_units = "COMPONENT_BASE",
@@ -776,8 +776,8 @@ end
 # type allows both (a `System` built directly, not round-tripped, may hold either), so export
 # supports both rather than narrowing to what import currently reads.
 
-_hvdc_loss_to_openapi(curve::Union{InputOutputCurve, IncrementalCurve}) =
-    PC.TwoTerminalLoss(convert_cost_to_openapi(curve))
+_hvdc_loss_to_openapi(loss::AnyLossCurve) =
+    PC.TwoTerminalLoss(convert_cost_to_openapi(loss_curve_to_openapi(loss)))
 
 function to_openapi(
     hvdc::TwoTerminalGenericHVDCLine,
@@ -1079,7 +1079,7 @@ function _two_terminal_vsc_line_to_openapi(vsc::TwoTerminalVSCLine, refs::OpenAP
             vsc, get_ac_setpoint_from(vsc), Val(ac_control_from),
         ),
         rated_ac_voltage_from = get_rated_ac_voltage_from(vsc),
-        converter_loss_from = convert_cost_to_openapi(get_converter_loss_from(vsc)),
+        converter_loss_from = convert_cost_to_openapi(loss_curve_to_openapi(get_converter_loss_from(vsc))),
         max_dc_current_from = get_max_dc_current_from(vsc),
         rating_from = _vsc_power_to_openapi(get_rating_from(vsc, SU), base_power, unit),
         reactive_power_limits_from = _vsc_minmax_to_openapi(
@@ -1103,7 +1103,7 @@ function _two_terminal_vsc_line_to_openapi(vsc::TwoTerminalVSCLine, refs::OpenAP
             vsc, get_ac_setpoint_to(vsc), Val(ac_control_to),
         ),
         rated_ac_voltage_to = get_rated_ac_voltage_to(vsc),
-        converter_loss_to = convert_cost_to_openapi(get_converter_loss_to(vsc)),
+        converter_loss_to = convert_cost_to_openapi(loss_curve_to_openapi(get_converter_loss_to(vsc))),
         max_dc_current_to = get_max_dc_current_to(vsc),
         rating_to = _vsc_power_to_openapi(get_rating_to(vsc, SU), base_power, unit),
         reactive_power_limits_to = _vsc_minmax_to_openapi(

--- a/src/openapi/import_handwritten.jl
+++ b/src/openapi/import_handwritten.jl
@@ -951,7 +951,8 @@ _hvdc_loss_curve(c::PC.InputOutputCurve) =
     _linear_curve_from_function_data(_unwrap_oneof(c.function_data))
 _hvdc_loss_curve(c) = error("unmapped TwoTerminalLoss variant: $(typeof(c))")
 
-_hvdc_loss(l::PC.TwoTerminalLoss) = _hvdc_loss_curve(_unwrap_oneof(l))
+_hvdc_loss(l::PC.TwoTerminalLoss) =
+    loss_curve_from_openapi(_hvdc_loss_curve(_unwrap_oneof(l)))
 
 function from_openapi(
     po::PO.TwoTerminalGenericHVDCLine,
@@ -1278,8 +1279,10 @@ end
 piecewise document curve is named here rather than surfacing as a `MethodError` from the
 `TwoTerminalVSCLine` constructor.
 """
-_vsc_converter_loss(curve::InputOutputCurve{LinearFunctionData}) = curve
-_vsc_converter_loss(curve::InputOutputCurve{QuadraticFunctionData}) = curve
+_vsc_converter_loss(curve::InputOutputCurve{LinearFunctionData}) =
+    loss_curve_from_openapi(curve)
+_vsc_converter_loss(curve::InputOutputCurve{QuadraticFunctionData}) =
+    loss_curve_from_openapi(curve)
 _vsc_converter_loss(curve) = error(
     "TwoTerminalVSCLine converter_loss must be a LINEAR or QUADRATIC InputOutputCurve, got " *
     "InputOutputCurve{$(typeof(get_function_data(curve)))}",

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -43,7 +43,7 @@ PowerSystems = {path = ".."}
 # LOCAL PATH CO-DEV PIN (temporary): see ../Project.toml — IS4's local checkout already
 # migrated off PowerCoreOpenAPIModels/PowerTimeSeriesOpenAPIModels, uncommitted; the pushed
 # IS4 branch fails to resolve. Revert to the git rev once IS4 is pushed.
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/loss-curve-units-v2"}
 # LOCAL PATH CO-DEV PINS (temporary): the InfrastructureCore/InfrastructureTimeSeries package
 # split exists only on local disk, not pushed to jd/schemas-0.1.0 yet. Revert to the git pins
 # once pushed/merged.
@@ -61,7 +61,7 @@ PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerO
 # LOCAL PATH CO-DEV PIN (temporary): PSB's own local checkout already migrated off
 # PowerCoreOpenAPIModels/PowerTimeSeriesOpenAPIModels, uncommitted; the pushed
 # jd/power-units-rename branch fails to resolve. Revert to the git rev once it is pushed.
-PowerSystemCaseBuilder = {url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl", rev = "psy6"}
+PowerSystemCaseBuilder = {url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl", rev = "lk/loss-curve-type"}
 # LOCAL PATH CO-DEV PIN (temporary): PowerTableDataParser's own local checkout already
 # migrated off PowerCoreOpenAPIModels/PowerTimeSeriesOpenAPIModels, uncommitted; the pushed
 # jd/power-units-rename branch fails to resolve. Revert to the git rev once it is pushed.

--- a/test/test_openapi_converters.jl
+++ b/test/test_openapi_converters.jl
@@ -911,7 +911,7 @@ end
     @test get_active_power_flow(hvdc_natural, SU) == 0.5
     @test get_active_power_limits_from(hvdc_natural, SU) == (min = -1.0, max = 1.0)
     @test get_reactive_power_limits_to(hvdc_natural, SU) == (min = -0.5, max = 0.5)
-    @test get_loss(hvdc_natural) == LinearCurve(0.01, 0.0)
+    @test get_loss(hvdc_natural) == LossCurve(LinearCurve(0.01, 0.0), NaturalUnit())
     @test get_base_power(hvdc_natural) == 100.0
 
     # A blob omitting the now-required `base_power` errors loudly rather than falling back.
@@ -1262,7 +1262,8 @@ end
     @test get_rated_dc_voltage(natural) == 200.0
     @test isnothing(get_remote_bus_control_from(natural))
     @test get_remote_bus_control_to(natural) == 4
-    @test get_converter_loss_from(natural) == LinearCurve(1.2, 0.5)
+    @test get_converter_loss_from(natural) ==
+          LossCurve(LinearCurve(1.2, 0.5), NaturalUnit())
 
     vsc_po.id = 21
     vsc_po.name = "vsc2"
@@ -1335,7 +1336,8 @@ end
         ),
     )
     vsc = PSY.from_openapi(vsc_po, refs, NU)
-    @test get_converter_loss_to(vsc) == QuadraticCurve(0.01, 1.1, 0.4)
+    @test get_converter_loss_to(vsc) ==
+          LossCurve(QuadraticCurve(0.01, 1.1, 0.4), NaturalUnit())
 end
 
 @testset "OpenAPI converters: TwoTerminalVSCLine setpoint_voltage_units selects the basis" begin

--- a/test/test_openapi_export.jl
+++ b/test/test_openapi_export.jl
@@ -34,7 +34,7 @@ _export_vsc(
     ac_control_from = ac_control_from,
     dc_setpoint_from = 0.4, ac_setpoint_from = 0.95,
     rated_ac_voltage_from = rated_ac_voltage_from,
-    converter_loss_from = LinearCurve(1.2, 0.5),
+    converter_loss_from = LossCurve(LinearCurve(1.2, 0.5), NaturalUnit()),
     max_dc_current_from = 1000.0, rating_from = 2.0,
     reactive_power_limits_from = (min = -1.0, max = 1.0),
     power_factor_weighting_fraction_from = 0.5,
@@ -44,7 +44,7 @@ _export_vsc(
     ac_control_to = ac_control_to,
     dc_setpoint_to = 1.02, ac_setpoint_to = 0.98,
     rated_ac_voltage_to = rated_ac_voltage_to,
-    converter_loss_to = QuadraticCurve(0.01, 1.1, 0.4),
+    converter_loss_to = LossCurve(QuadraticCurve(0.01, 1.1, 0.4), NaturalUnit()),
     max_dc_current_to = 1000.0, rating_to = 2.0,
     reactive_power_limits_to = (min = -1.0, max = 1.0),
     power_factor_weighting_fraction_to = 0.5,
@@ -349,7 +349,7 @@ end
         active_power_limits_to = (min = -1.0, max = 1.0),
         reactive_power_limits_from = (min = -0.5, max = 0.5),
         reactive_power_limits_to = (min = -0.5, max = 0.5),
-        loss = LinearCurve(0.01, 0.0),
+        loss = LossCurve(LinearCurve(0.01, 0.0), NaturalUnit()),
     )
     sys = System(100.0)
     add_component!(sys, bus1)


### PR DESCRIPTION
Types the five curve-valued loss fields as `LossCurve` (InfrastructureSystems.jl#625), so a loss curve carries the power basis it is expressed in rather than leaving it implicit.

| Struct | Field |
|---|---|
| `TwoTerminalGenericHVDCLine` | `loss` |
| `TwoTerminalLCCLine` | `loss` |
| `TwoTerminalVSCLine` | `converter_loss_from`, `converter_loss_to` |
| `InterconnectingConverter` | `loss_function` |

Each keeps the curve shapes its `Union` already admitted, now wrapped — `Union{AnyLossCurve{LinearCurve}, AnyLossCurve{QuadraticCurve}}` and so on — defaulting to `LossCurve(LinearCurve(0.0), NaturalUnit())`. `power_units` has no default in IS by design, so the basis is named explicitly.

These are the **only** curve-typed loss fields in the descriptor. Pumped hydro expresses its losses as a scalar `efficiency::TurbinePump`, and `evaporative_loss` / `standing_loss` / `active_power_losses` are `Float64` — none are `ValueCurve`s, so none are candidates.

## The OpenAPI asymmetry

The OpenAPI schemas have no `LossCurve`: a document's loss field is a bare `ValueCurve` (`$ref: InputOutputCurve` / `TwoTerminalLoss`) with nowhere to record a basis. Until the schemas gain the type the two directions cannot be symmetric, so one helper pair in `cost_conversion.jl` carries the contract:

- **Import** synthesizes `NaturalUnit()` — the basis every current producer writes, and the one the schema's own `UnitSystem` default names.
- **Export refuses** any other basis rather than silently dropping it.

The guard matters: without it, a `LossCurve` on a relative basis would round-trip back as `NaturalUnit` with no diagnostic. Erroring instead of guessing mirrors the posture `admittance_units` / `voltage_units` already take on these same HVDC types, where only the implemented basis passes. Nothing currently produces a non-natural loss curve, so the error path should stay unreached; when the schemas gain `LossCurve`, the guard is deleted and export carries `power_units` for real.

## Notes for review

- Import funnels through `_hvdc_loss` and `_vsc_converter_loss`, so wrapping those two covers all eight call sites. Export funnels through `_hvdc_loss_to_openapi` plus four direct calls.
- `src/deprecated.jl` keeps working: `_deprecated_hvdc_loss` passes an `AnyLossCurve` through and wraps a bare `ValueCurve`. These shims exist to accept old spellings, so breaking the bare-curve form would defeat their purpose.
- The `_io_curve` sites in `test_openapi_converters.jl` are deliberately left bare — they build `PSY.PC.InputOutputCurve`, the document side, which has no `power_units`. That is the asymmetry working as intended.
- No other code in `src/` reads these fields, so the blast radius is the converters plus the deprecation shims.
- Three unrelated regenerated files (`TradingHub`, `PointToPointBid`, `VirtualParticipant`) were reverted to keep this focused. Regenerating them adds a two-arg `from_openapi(po, refs)` method missing from the versions committed with the market-component family — pre-existing drift, and `test/test_generate_structs.jl` documents that no freshness check catches it.

## Testing

Full suite, against a same-day baseline of clean `psy6`:

| | Pass | Fail | Error |
|---|---|---|---|
| baseline `psy6` | 12687 | 9 | 26 |
| this branch | 12688 | 8 | 26 |

**No failure is unique to this branch.** Every remaining one reproduces on clean `psy6` — chiefly `get_variable(::ThermalGenerationCost)` (the cost-field rename) and `MarketBidTimeSeriesCost` JSON round-trip (the IS4 thin-key rework). `test_printing.jl:78` fails on the baseline but not here, so that suite has some nondeterminism either way.

## Pins — revert all three once upstream merges

- `InfrastructureSystems` → `lk/loss-curve-units-v2` (IS#625, rebased onto current `IS4`)
- `PowerSystemCaseBuilder` → `lk/loss-curve-type` (PSCB#217) — **merge that first**

The PSCB pin was already stale at `jd/power-units-rename`. PSCB's `psy6` contains that commit fully and is five ahead of it, and this branch is based on `psy6`, so the move is forward, not a downgrade.

Unrelated but adjacent: psy6's `[sources]` comment claims IS4 "still requires the old (now-unregistered) `PowerTimeSeriesOpenAPIModels` and fails to resolve" and pins IS to `jd/openapi-package-split`. That merged into `IS4` earlier today, so the comment and pin are both stale — worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eHyC9XpEJSiH27VsFcQr4
