### PR TITLE
Explain the missing units argument in generated accessors

### DIFF
--- a/src/generate_structs.jl
+++ b/src/generate_structs.jl
@@ -15,6 +15,13 @@ const IS = InfrastructureSystems
 const MU = IS.Mustache
 import InfrastructureSystems: DataFormatError
 
+# Convertible fields also get fallback accessor methods for the calls that omit the
+# units — a one-argument getter, and setters taking an untagged number or an
+# all-untagged compound. They route to `_units_arg_required`/`_units_tag_required`
+# (hand-written, `src/models/components.jl`), which name the accessor, the field and
+# the units that would have worked. Without them, `get_active_power(gen)` and
+# `set_active_power!(gen, 1)` raise bare `MethodError`s that list signatures but never
+# say what a valid unit is.
 const STRUCT_TEMPLATE = """
 #=
 This file is auto-generated. Do not edit.
@@ -82,6 +89,8 @@ end
 {{accessor}}(value::{{struct_name}}, units) = InfrastructureSystems._strip_units(get_value(value, Val(:{{name}}), Val({{conversion_unit}}), units))
 {{#create_docstring}}\"\"\"Get [`{{struct_name}}`](@ref) `{{name}}` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`{{accessor}}`](@ref).\"\"\"{{/create_docstring}}
 {{accessor}}_unitful(value::{{struct_name}}, units) = get_value(value, Val(:{{name}}), Val({{conversion_unit}}), units)
+{{accessor}}(value::{{struct_name}}) = _units_arg_required({{accessor}}, value, :{{name}}, Val({{conversion_unit}}))
+{{accessor}}_unitful(value::{{struct_name}}) = _units_arg_required({{accessor}}_unitful, value, :{{name}}, Val({{conversion_unit}}))
 InfrastructureSystems.display_units_arg(::typeof({{accessor}}), ::{{units_type_sig}}){{#units_bound}} where {T <: {{units_bound}}}{{/units_bound}} = InfrastructureSystems.{{display_units}}
 InfrastructureSystems.display_units_arg(::typeof({{accessor}}_unitful), ::{{units_type_sig}}){{#units_bound}} where {T <: {{units_bound}}}{{/units_bound}} = InfrastructureSystems.{{display_units}}
 {{/needs_conversion}}
@@ -95,6 +104,8 @@ InfrastructureSystems.display_units_arg(::typeof({{accessor}}_unitful), ::{{unit
 {{#needs_conversion}}
 {{#create_docstring}}\"\"\"Set [`{{struct_name}}`](@ref) `{{name}}`.\"\"\"{{/create_docstring}}
 {{setter}}(value::{{struct_name}}, val) = value.{{name}} = set_value(value, Val(:{{name}}), val, Val({{conversion_unit}}))
+{{setter}}(value::{{struct_name}}, val::Real) = _units_tag_required({{setter}}, value, :{{name}}, Val({{conversion_unit}}), val)
+{{setter}}(value::{{struct_name}}, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required({{setter}}, value, :{{name}}, Val({{conversion_unit}}), val)
 {{/needs_conversion}}
 {{^needs_conversion}}
 {{#create_docstring}}\"\"\"Set [`{{struct_name}}`](@ref) `{{name}}`.\"\"\"{{/create_docstring}}

--- a/src/generate_structs.jl
+++ b/src/generate_structs.jl
@@ -104,8 +104,10 @@ InfrastructureSystems.display_units_arg(::typeof({{accessor}}_unitful), ::{{unit
 {{#needs_conversion}}
 {{#create_docstring}}\"\"\"Set [`{{struct_name}}`](@ref) `{{name}}`.\"\"\"{{/create_docstring}}
 {{setter}}(value::{{struct_name}}, val) = value.{{name}} = set_value(value, Val(:{{name}}), val, Val({{conversion_unit}}))
-{{setter}}(value::{{struct_name}}, val::Real) = _units_tag_required({{setter}}, value, :{{name}}, Val({{conversion_unit}}), val)
-{{setter}}(value::{{struct_name}}, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required({{setter}}, value, :{{name}}, Val({{conversion_unit}}), val)
+{{setter}}(value::{{struct_name}}, val::_UntaggedNumber) = _units_tag_required({{setter}}, value, :{{name}}, Val({{conversion_unit}}), val)
+{{#compound_untagged}}
+{{setter}}(value::{{struct_name}}, val::{{{compound_untagged}}}) = _units_tag_required({{setter}}, value, :{{name}}, Val({{conversion_unit}}), val)
+{{/compound_untagged}}
 {{/needs_conversion}}
 {{^needs_conversion}}
 {{#create_docstring}}\"\"\"Set [`{{struct_name}}`](@ref) `{{name}}`.\"\"\"{{/create_docstring}}
@@ -953,6 +955,27 @@ function compute_openapi_export_converter!(item, struct_names)
     return nothing
 end
 
+"""The element names of each compound field type, matching the `set_value` methods in
+`src/models/components.jl`. A convertible field of one of these types accepts a
+`NamedTuple` value; every other convertible field is scalar and does not."""
+const COMPOUND_FIELD_KEYS = Dict(
+    "MinMax" => "(:min, :max)",
+    "UpDown" => "(:up, :down)",
+    "FromTo" => "(:from, :to)",
+    "FromTo_ToFrom" => "(:from_to, :to_from)",
+    "StartUpShutDown" => "(:startup, :shutdown)",
+)
+
+"""The `NamedTuple` signature whose elements are all untagged numbers, for a convertible
+field of a compound type — the setter fallback that reports the missing units. Returns an
+empty string for a scalar field, so no `NamedTuple` method is emitted for one."""
+function compound_untagged_signature(data_type::AbstractString)
+    base_type = replace(data_type, r"^Union\{Nothing, *(.*)\}$" => s"\1")
+    keys = get(COMPOUND_FIELD_KEYS, base_type, nothing)
+    isnothing(keys) && return ""
+    return "NamedTuple{$keys, <:Tuple{Vararg{_UntaggedNumber}}}"
+end
+
 function read_json_data(filename::String)
     return open(filename) do io
         data = JSON.parse(io; dicttype = Dict{String, Any})
@@ -1070,6 +1093,9 @@ function generate_structs(directory, data::Vector; print_results = true)
                         "create_docstring" => create_docstring,
                         "needs_conversion" => get(param, "needs_conversion", false),
                         "conversion_unit" => conversion_unit,
+                        "compound_untagged" => compound_untagged_signature(
+                            param["data_type"],
+                        ),
                     ),
                 )
             end

--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -263,39 +263,45 @@ set_value(c::UnitsBearer, field, val::RelativeQuantity{<:Any, SystemBaseUnit}, c
         convert_units(_conversion_base(c, field), ustrip(val), _unit_category(cu), SU, DU),
     )
 
-# ---- Bare Float64 is rejected: callers must attach units explicitly ----
-set_value(::UnitsBearer, ::Any, ::Float64, ::Val) = throw(
+# ---- Bare numbers are rejected: callers must attach units explicitly ----
+# Generated setters intercept this one level up (`_units_tag_required`) so the
+# message can name the setter; this method catches the same mistake inside a
+# compound field's elements, where only the field is known. `Real` rather than
+# `Float64` so an integer literal gets the message instead of a `MethodError`.
+set_value(c::UnitsBearer, field, ::Real, cu::Val) = throw(
     ArgumentError(
-        "setter requires explicit units (e.g. `val * SU`, `val * DU`, `val * MW`)",
+        "Setting $(_field_description(c, field)) requires a units-tagged value: " *
+        "$(_tag_menu(cu)).",
     ),
 )
 
 # ---- Compound field types for setters ----
-_to_device_base(c::UnitsBearer, val, cu) = set_value(c, nothing, val, cu)
+# The field is threaded through so a bare element reports which field it belongs to.
+_to_device_base(c::UnitsBearer, field, val, cu) = set_value(c, field, val, cu)
 
 set_value(c::UnitsBearer, field, val::NamedTuple{(:min, :max)}, cu::Val) = (
-    min = _to_device_base(c, val.min, cu),
-    max = _to_device_base(c, val.max, cu),
+    min = _to_device_base(c, field, val.min, cu),
+    max = _to_device_base(c, field, val.max, cu),
 )
 
 set_value(c::UnitsBearer, field, val::NamedTuple{(:up, :down)}, cu::Val) = (
-    up = _to_device_base(c, val.up, cu),
-    down = _to_device_base(c, val.down, cu),
+    up = _to_device_base(c, field, val.up, cu),
+    down = _to_device_base(c, field, val.down, cu),
 )
 
 set_value(c::UnitsBearer, field, val::NamedTuple{(:from_to, :to_from)}, cu::Val) = (
-    from_to = _to_device_base(c, val.from_to, cu),
-    to_from = _to_device_base(c, val.to_from, cu),
+    from_to = _to_device_base(c, field, val.from_to, cu),
+    to_from = _to_device_base(c, field, val.to_from, cu),
 )
 
 set_value(c::UnitsBearer, field, val::NamedTuple{(:from, :to)}, cu::Val) = (
-    from = _to_device_base(c, val.from, cu),
-    to = _to_device_base(c, val.to, cu),
+    from = _to_device_base(c, field, val.from, cu),
+    to = _to_device_base(c, field, val.to, cu),
 )
 
 set_value(c::UnitsBearer, field, val::NamedTuple{(:startup, :shutdown)}, cu::Val) = (
-    startup = _to_device_base(c, val.startup, cu),
-    shutdown = _to_device_base(c, val.shutdown, cu),
+    startup = _to_device_base(c, field, val.startup, cu),
+    shutdown = _to_device_base(c, field, val.shutdown, cu),
 )
 
 # ---- Nothing passthrough ----
@@ -343,6 +349,12 @@ set_r!(t::TwoWindingTransformer, val) = set_r!(get_circuit(t), val)
 get_x(t::TwoWindingTransformer, units) = get_x(get_circuit(t), units)
 get_x_unitful(t::TwoWindingTransformer, units) = get_x_unitful(get_circuit(t), units)
 set_x!(t::TwoWindingTransformer, val) = set_x!(get_circuit(t), val)
+get_r(t::TwoWindingTransformer) = get_r(get_circuit(t))
+get_r_unitful(t::TwoWindingTransformer) = get_r_unitful(get_circuit(t))
+get_x(t::TwoWindingTransformer) = get_x(get_circuit(t))
+get_x_unitful(t::TwoWindingTransformer) = get_x_unitful(get_circuit(t))
+set_r!(t::TwoWindingTransformer, val::Real) = set_r!(get_circuit(t), val)
+set_x!(t::TwoWindingTransformer, val::Real) = set_x!(get_circuit(t), val)
 
 # Physical category implied by a field's conversion unit. The three power tokens
 # share a per-unit base and differ only in the natural unit they print as, so a
@@ -353,6 +365,93 @@ _unit_category(::Val{:mvar}) = REACTIVE_POWER
 _unit_category(::Val{:mva}) = APPARENT_POWER
 _unit_category(::Val{:ohm}) = IMPEDANCE
 _unit_category(::Val{:siemens}) = ADMITTANCE
+
+#######################################################
+# Explicit-units error messages
+#
+# Every convertible field's accessors are generated in pairs: the working
+# `(component, units)` getter and setter, plus a fallback method that lands here
+# when the units are missing. The fallbacks exist purely so the failure names the
+# accessor, the field and the units that would have worked — Julia's own
+# `MethodError` lists signatures but never says what a valid unit argument is.
+#######################################################
+
+# Natural unit to suggest for each conversion-unit token.
+_natural_unit_example(::Val{:mw}) = "MW"
+_natural_unit_example(::Val{:mvar}) = "MVAr"
+_natural_unit_example(::Val{:mva}) = "MVA"
+_natural_unit_example(::Val{:ohm}) = "OHMS"
+_natural_unit_example(::Val{:siemens}) = "SIEMENS"
+
+# Which field the message is about. `field` is a `Val` on the generated paths and
+# `nothing` where a hand-written caller did not supply one.
+_field_description(c, ::Val{T}) where {T} = "`$(nameof(typeof(c)))`'s `$T`"
+_field_description(c, ::Any) = "this `$(nameof(typeof(c)))` field"
+
+# The units a getter accepts. Setters take the same units as tags on the value,
+# except `NU`, which exists only as a getter target (there is no `val * NU`).
+_units_menu(conversion_unit::Val) =
+    "`DU` (per unit on the device base), `SU` (per unit on the system base), `NU` " *
+    "or the natural unit `$(_natural_unit_example(conversion_unit))`"
+
+_tag_menu(conversion_unit::Val) =
+    "pass `val * DU` (per unit on the device base), `val * SU` (per unit on the " *
+    "system base), or a natural unit such as `val * $(_natural_unit_example(conversion_unit))`"
+
+# The bare and unit-bearing getters point at each other, so the message always
+# names the companion the caller did not use.
+function _companion_getter_hint(getter)
+    name = string(getter)
+    endswith(name, "_unitful") && return "For a bare number instead of a unit-bearing " *
+           "quantity, use `$(chopsuffix(name, "_unitful"))(component, units)`."
+    return "For the unit-bearing value instead of a bare number, use " *
+           "`$(name)_unitful(component, units)`."
+end
+
+"""
+    _units_arg_required(getter, value, field, conversion_unit)
+
+Throw the explanatory error for a unit-bearing getter called without its `units`
+argument. Every convertible field's generated accessor has a one-argument method
+that lands here, so `get_active_power(gen)` reports what to pass instead of
+surfacing a bare `MethodError` that lists the two-argument signatures.
+"""
+function _units_arg_required(getter, value, field::Symbol, conversion_unit::Val)
+    throw(
+        ArgumentError(
+            "`$getter` requires an explicit units argument: " *
+            "`$getter(component, units)`. `$(nameof(typeof(value)))`'s `$field` is a " *
+            "per-unit quantity with no default unit system, so the units must be " *
+            "named at the call site: $(_units_menu(conversion_unit)). " *
+            "$(_companion_getter_hint(getter))",
+        ),
+    )
+end
+
+"""
+    _units_tag_required(setter, value, field, conversion_unit, val)
+
+Throw the explanatory error for a unit-bearing setter called with an untagged
+number. The getter counterpart is [`_units_arg_required`](@ref); both are reached
+from generated fallback methods, here one matching a bare `Real` (or a compound
+value whose elements are all bare) where a tagged value is required.
+"""
+function _units_tag_required(setter, value, field::Symbol, conversion_unit::Val, val)
+    compound_hint = if val isa NamedTuple
+        " A compound field takes one tagged value per element, e.g. " *
+        "`(" * join(("$k = $(getfield(val, k)) * DU" for k in keys(val)), ", ") * ")`."
+    else
+        ""
+    end
+    throw(
+        ArgumentError(
+            "`$setter` requires a units-tagged value: " *
+            "`$setter(component, val * units)`. `$(nameof(typeof(value)))`'s `$field` " *
+            "is a per-unit quantity with no default unit system, so the units must be " *
+            "named at the call site: $(_tag_menu(conversion_unit)).$compound_hint",
+        ),
+    )
+end
 
 # Base provider for the pairwise impedance fields of a ThreeWindingTransformer.
 # Convention: Z_ij is pu on base_power_ij referenced to the first-index circuit's

--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -266,9 +266,10 @@ set_value(c::UnitsBearer, field, val::RelativeQuantity{<:Any, SystemBaseUnit}, c
 # ---- Bare numbers are rejected: callers must attach units explicitly ----
 # Generated setters intercept this one level up (`_units_tag_required`) so the
 # message can name the setter; this method catches the same mistake inside a
-# compound field's elements, where only the field is known. `Real` rather than
-# `Float64` so an integer literal gets the message instead of a `MethodError`.
-set_value(c::UnitsBearer, field, ::Real, cu::Val) = throw(
+# compound field's elements, where only the field is known. `_UntaggedNumber`
+# rather than `Float64` so an integer literal (or a bare complex, on the two
+# `Complex` fields) gets the message instead of a `MethodError`.
+set_value(c::UnitsBearer, field, ::_UntaggedNumber, cu::Val) = throw(
     ArgumentError(
         "Setting $(_field_description(c, field)) requires a units-tagged value: " *
         "$(_tag_menu(cu)).",
@@ -433,8 +434,8 @@ end
 
 Throw the explanatory error for a unit-bearing setter called with an untagged
 number. The getter counterpart is [`_units_arg_required`](@ref); both are reached
-from generated fallback methods, here one matching a bare `Real` (or a compound
-value whose elements are all bare) where a tagged value is required.
+from generated fallback methods, here one matching an untagged number — or, on a
+compound field only, a `NamedTuple` whose elements are all untagged.
 """
 function _units_tag_required(setter, value, field::Symbol, conversion_unit::Val, val)
     compound_hint = if val isa NamedTuple

--- a/src/models/generated/Area.jl
+++ b/src/models/generated/Area.jl
@@ -94,12 +94,10 @@ get_internal(value::Area) = value.internal
 
 """Set [`Area`](@ref) `peak_active_power`."""
 set_peak_active_power!(value::Area, val) = value.peak_active_power = set_value(value, Val(:peak_active_power), val, Val(:mw))
-set_peak_active_power!(value::Area, val::Real) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
-set_peak_active_power!(value::Area, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
+set_peak_active_power!(value::Area, val::_UntaggedNumber) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
 """Set [`Area`](@ref) `peak_reactive_power`."""
 set_peak_reactive_power!(value::Area, val) = value.peak_reactive_power = set_value(value, Val(:peak_reactive_power), val, Val(:mvar))
-set_peak_reactive_power!(value::Area, val::Real) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
-set_peak_reactive_power!(value::Area, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
+set_peak_reactive_power!(value::Area, val::_UntaggedNumber) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
 """Set [`Area`](@ref) `load_response`."""
 set_load_response!(value::Area, val) = value.load_response = val
 """Set [`Area`](@ref) `ext`."""

--- a/src/models/generated/Area.jl
+++ b/src/models/generated/Area.jl
@@ -71,12 +71,16 @@ get_name(value::Area) = value.name
 get_peak_active_power(value::Area, units) = InfrastructureSystems._strip_units(get_value(value, Val(:peak_active_power), Val(:mw), units))
 """Get [`Area`](@ref) `peak_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_peak_active_power`](@ref)."""
 get_peak_active_power_unitful(value::Area, units) = get_value(value, Val(:peak_active_power), Val(:mw), units)
+get_peak_active_power(value::Area) = _units_arg_required(get_peak_active_power, value, :peak_active_power, Val(:mw))
+get_peak_active_power_unitful(value::Area) = _units_arg_required(get_peak_active_power_unitful, value, :peak_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_peak_active_power), ::Type{Area}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_peak_active_power_unitful), ::Type{Area}) = InfrastructureSystems.SU
 """Get [`Area`](@ref) `peak_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_peak_reactive_power_unitful`](@ref)."""
 get_peak_reactive_power(value::Area, units) = InfrastructureSystems._strip_units(get_value(value, Val(:peak_reactive_power), Val(:mvar), units))
 """Get [`Area`](@ref) `peak_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_peak_reactive_power`](@ref)."""
 get_peak_reactive_power_unitful(value::Area, units) = get_value(value, Val(:peak_reactive_power), Val(:mvar), units)
+get_peak_reactive_power(value::Area) = _units_arg_required(get_peak_reactive_power, value, :peak_reactive_power, Val(:mvar))
+get_peak_reactive_power_unitful(value::Area) = _units_arg_required(get_peak_reactive_power_unitful, value, :peak_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_peak_reactive_power), ::Type{Area}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_peak_reactive_power_unitful), ::Type{Area}) = InfrastructureSystems.SU
 """Get [`Area`](@ref) `load_response`."""
@@ -90,8 +94,12 @@ get_internal(value::Area) = value.internal
 
 """Set [`Area`](@ref) `peak_active_power`."""
 set_peak_active_power!(value::Area, val) = value.peak_active_power = set_value(value, Val(:peak_active_power), val, Val(:mw))
+set_peak_active_power!(value::Area, val::Real) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
+set_peak_active_power!(value::Area, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
 """Set [`Area`](@ref) `peak_reactive_power`."""
 set_peak_reactive_power!(value::Area, val) = value.peak_reactive_power = set_value(value, Val(:peak_reactive_power), val, Val(:mvar))
+set_peak_reactive_power!(value::Area, val::Real) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
+set_peak_reactive_power!(value::Area, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
 """Set [`Area`](@ref) `load_response`."""
 set_load_response!(value::Area, val) = value.load_response = val
 """Set [`Area`](@ref) `ext`."""

--- a/src/models/generated/AreaInterchange.jl
+++ b/src/models/generated/AreaInterchange.jl
@@ -115,16 +115,15 @@ get_internal(value::AreaInterchange) = value.internal
 set_available!(value::AreaInterchange, val) = value.available = val
 """Set [`AreaInterchange`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::AreaInterchange, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::AreaInterchange, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::AreaInterchange, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::AreaInterchange, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`AreaInterchange`](@ref) `from_area`."""
 set_from_area!(value::AreaInterchange, val) = value.from_area = val
 """Set [`AreaInterchange`](@ref) `to_area`."""
 set_to_area!(value::AreaInterchange, val) = value.to_area = val
 """Set [`AreaInterchange`](@ref) `flow_limits`."""
 set_flow_limits!(value::AreaInterchange, val) = value.flow_limits = set_value(value, Val(:flow_limits), val, Val(:mw))
-set_flow_limits!(value::AreaInterchange, val::Real) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
-set_flow_limits!(value::AreaInterchange, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
+set_flow_limits!(value::AreaInterchange, val::_UntaggedNumber) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
+set_flow_limits!(value::AreaInterchange, val::NamedTuple{(:from_to, :to_from), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
 """Set [`AreaInterchange`](@ref) `services`."""
 set_services!(value::AreaInterchange, val) = value.services = val
 """Set [`AreaInterchange`](@ref) `ext`."""

--- a/src/models/generated/AreaInterchange.jl
+++ b/src/models/generated/AreaInterchange.jl
@@ -86,6 +86,8 @@ get_available(value::AreaInterchange) = value.available
 get_active_power_flow(value::AreaInterchange, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`AreaInterchange`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::AreaInterchange, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::AreaInterchange) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::AreaInterchange) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{AreaInterchange}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{AreaInterchange}) = InfrastructureSystems.SU
 """Get [`AreaInterchange`](@ref) `from_area`."""
@@ -96,6 +98,8 @@ get_to_area(value::AreaInterchange) = value.to_area
 get_flow_limits(value::AreaInterchange, units) = InfrastructureSystems._strip_units(get_value(value, Val(:flow_limits), Val(:mw), units))
 """Get [`AreaInterchange`](@ref) `flow_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_flow_limits`](@ref)."""
 get_flow_limits_unitful(value::AreaInterchange, units) = get_value(value, Val(:flow_limits), Val(:mw), units)
+get_flow_limits(value::AreaInterchange) = _units_arg_required(get_flow_limits, value, :flow_limits, Val(:mw))
+get_flow_limits_unitful(value::AreaInterchange) = _units_arg_required(get_flow_limits_unitful, value, :flow_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_flow_limits), ::Type{AreaInterchange}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_flow_limits_unitful), ::Type{AreaInterchange}) = InfrastructureSystems.SU
 
@@ -111,12 +115,16 @@ get_internal(value::AreaInterchange) = value.internal
 set_available!(value::AreaInterchange, val) = value.available = val
 """Set [`AreaInterchange`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::AreaInterchange, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::AreaInterchange, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::AreaInterchange, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`AreaInterchange`](@ref) `from_area`."""
 set_from_area!(value::AreaInterchange, val) = value.from_area = val
 """Set [`AreaInterchange`](@ref) `to_area`."""
 set_to_area!(value::AreaInterchange, val) = value.to_area = val
 """Set [`AreaInterchange`](@ref) `flow_limits`."""
 set_flow_limits!(value::AreaInterchange, val) = value.flow_limits = set_value(value, Val(:flow_limits), val, Val(:mw))
+set_flow_limits!(value::AreaInterchange, val::Real) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
+set_flow_limits!(value::AreaInterchange, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
 """Set [`AreaInterchange`](@ref) `services`."""
 set_services!(value::AreaInterchange, val) = value.services = val
 """Set [`AreaInterchange`](@ref) `ext`."""

--- a/src/models/generated/DiscreteControlledACBranch.jl
+++ b/src/models/generated/DiscreteControlledACBranch.jl
@@ -161,26 +161,21 @@ get_internal(value::DiscreteControlledACBranch) = value.internal
 set_available!(value::DiscreteControlledACBranch, val) = value.available = val
 """Set [`DiscreteControlledACBranch`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::DiscreteControlledACBranch, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::DiscreteControlledACBranch, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`DiscreteControlledACBranch`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::DiscreteControlledACBranch, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
-set_reactive_power_flow!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
-set_reactive_power_flow!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::DiscreteControlledACBranch, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`DiscreteControlledACBranch`](@ref) `arc`."""
 set_arc!(value::DiscreteControlledACBranch, val) = value.arc = val
 """Set [`DiscreteControlledACBranch`](@ref) `r`."""
 set_r!(value::DiscreteControlledACBranch, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
-set_r!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
-set_r!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::DiscreteControlledACBranch, val::_UntaggedNumber) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`DiscreteControlledACBranch`](@ref) `x`."""
 set_x!(value::DiscreteControlledACBranch, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
-set_x!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
-set_x!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::DiscreteControlledACBranch, val::_UntaggedNumber) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`DiscreteControlledACBranch`](@ref) `rating`."""
 set_rating!(value::DiscreteControlledACBranch, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::DiscreteControlledACBranch, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`DiscreteControlledACBranch`](@ref) `discrete_branch_type`."""
 set_discrete_branch_type!(value::DiscreteControlledACBranch, val) = value.discrete_branch_type = val
 """Set [`DiscreteControlledACBranch`](@ref) `branch_status`."""

--- a/src/models/generated/DiscreteControlledACBranch.jl
+++ b/src/models/generated/DiscreteControlledACBranch.jl
@@ -106,12 +106,16 @@ get_available(value::DiscreteControlledACBranch) = value.available
 get_active_power_flow(value::DiscreteControlledACBranch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`DiscreteControlledACBranch`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::DiscreteControlledACBranch, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::DiscreteControlledACBranch) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::DiscreteControlledACBranch) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
 """Get [`DiscreteControlledACBranch`](@ref) `reactive_power_flow` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_flow_unitful`](@ref)."""
 get_reactive_power_flow(value::DiscreteControlledACBranch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_flow), Val(:mvar), units))
 """Get [`DiscreteControlledACBranch`](@ref) `reactive_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_flow`](@ref)."""
 get_reactive_power_flow_unitful(value::DiscreteControlledACBranch, units) = get_value(value, Val(:reactive_power_flow), Val(:mvar), units)
+get_reactive_power_flow(value::DiscreteControlledACBranch) = _units_arg_required(get_reactive_power_flow, value, :reactive_power_flow, Val(:mvar))
+get_reactive_power_flow_unitful(value::DiscreteControlledACBranch) = _units_arg_required(get_reactive_power_flow_unitful, value, :reactive_power_flow, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow_unitful), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
 """Get [`DiscreteControlledACBranch`](@ref) `arc`."""
@@ -120,18 +124,24 @@ get_arc(value::DiscreteControlledACBranch) = value.arc
 get_r(value::DiscreteControlledACBranch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r), Val(:ohm), units))
 """Get [`DiscreteControlledACBranch`](@ref) `r` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r`](@ref)."""
 get_r_unitful(value::DiscreteControlledACBranch, units) = get_value(value, Val(:r), Val(:ohm), units)
+get_r(value::DiscreteControlledACBranch) = _units_arg_required(get_r, value, :r, Val(:ohm))
+get_r_unitful(value::DiscreteControlledACBranch) = _units_arg_required(get_r_unitful, value, :r, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_r), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_r_unitful), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
 """Get [`DiscreteControlledACBranch`](@ref) `x` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_x_unitful`](@ref)."""
 get_x(value::DiscreteControlledACBranch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:x), Val(:ohm), units))
 """Get [`DiscreteControlledACBranch`](@ref) `x` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_x`](@ref)."""
 get_x_unitful(value::DiscreteControlledACBranch, units) = get_value(value, Val(:x), Val(:ohm), units)
+get_x(value::DiscreteControlledACBranch) = _units_arg_required(get_x, value, :x, Val(:ohm))
+get_x_unitful(value::DiscreteControlledACBranch) = _units_arg_required(get_x_unitful, value, :x, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_x), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_x_unitful), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.SU
 """Get [`DiscreteControlledACBranch`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::DiscreteControlledACBranch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`DiscreteControlledACBranch`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::DiscreteControlledACBranch, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::DiscreteControlledACBranch) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::DiscreteControlledACBranch) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{DiscreteControlledACBranch}) = InfrastructureSystems.DU
 """Get [`DiscreteControlledACBranch`](@ref) `discrete_branch_type`."""
@@ -151,16 +161,26 @@ get_internal(value::DiscreteControlledACBranch) = value.internal
 set_available!(value::DiscreteControlledACBranch, val) = value.available = val
 """Set [`DiscreteControlledACBranch`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::DiscreteControlledACBranch, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`DiscreteControlledACBranch`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::DiscreteControlledACBranch, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
+set_reactive_power_flow!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`DiscreteControlledACBranch`](@ref) `arc`."""
 set_arc!(value::DiscreteControlledACBranch, val) = value.arc = val
 """Set [`DiscreteControlledACBranch`](@ref) `r`."""
 set_r!(value::DiscreteControlledACBranch, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
+set_r!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`DiscreteControlledACBranch`](@ref) `x`."""
 set_x!(value::DiscreteControlledACBranch, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
+set_x!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`DiscreteControlledACBranch`](@ref) `rating`."""
 set_rating!(value::DiscreteControlledACBranch, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::DiscreteControlledACBranch, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::DiscreteControlledACBranch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`DiscreteControlledACBranch`](@ref) `discrete_branch_type`."""
 set_discrete_branch_type!(value::DiscreteControlledACBranch, val) = value.discrete_branch_type = val
 """Set [`DiscreteControlledACBranch`](@ref) `branch_status`."""

--- a/src/models/generated/EnergyReservoirStorage.jl
+++ b/src/models/generated/EnergyReservoirStorage.jl
@@ -284,38 +284,34 @@ set_prime_mover_type!(value::EnergyReservoirStorage, val) = value.prime_mover_ty
 set_storage_technology_type!(value::EnergyReservoirStorage, val) = value.storage_technology_type = val
 """Set [`EnergyReservoirStorage`](@ref) `storage_capacity`."""
 set_storage_capacity!(value::EnergyReservoirStorage, val) = value.storage_capacity = set_value(value, Val(:storage_capacity), val, Val(:mw))
-set_storage_capacity!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_storage_capacity!, value, :storage_capacity, Val(:mw), val)
-set_storage_capacity!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_storage_capacity!, value, :storage_capacity, Val(:mw), val)
+set_storage_capacity!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_storage_capacity!, value, :storage_capacity, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `storage_level_limits`."""
 set_storage_level_limits!(value::EnergyReservoirStorage, val) = value.storage_level_limits = val
 """Set [`EnergyReservoirStorage`](@ref) `initial_storage_capacity_level`."""
 set_initial_storage_capacity_level!(value::EnergyReservoirStorage, val) = value.initial_storage_capacity_level = val
 """Set [`EnergyReservoirStorage`](@ref) `rating`."""
 set_rating!(value::EnergyReservoirStorage, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`EnergyReservoirStorage`](@ref) `active_power`."""
 set_active_power!(value::EnergyReservoirStorage, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `input_active_power_limits`."""
 set_input_active_power_limits!(value::EnergyReservoirStorage, val) = value.input_active_power_limits = set_value(value, Val(:input_active_power_limits), val, Val(:mw))
-set_input_active_power_limits!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
-set_input_active_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
+set_input_active_power_limits!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
+set_input_active_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `output_active_power_limits`."""
 set_output_active_power_limits!(value::EnergyReservoirStorage, val) = value.output_active_power_limits = set_value(value, Val(:output_active_power_limits), val, Val(:mw))
-set_output_active_power_limits!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
-set_output_active_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
+set_output_active_power_limits!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
+set_output_active_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `efficiency`."""
 set_efficiency!(value::EnergyReservoirStorage, val) = value.efficiency = val
 """Set [`EnergyReservoirStorage`](@ref) `reactive_power`."""
 set_reactive_power!(value::EnergyReservoirStorage, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`EnergyReservoirStorage`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::EnergyReservoirStorage, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`EnergyReservoirStorage`](@ref) `operation_cost`."""
 set_operation_cost!(value::EnergyReservoirStorage, val) = value.operation_cost = val
 """Set [`EnergyReservoirStorage`](@ref) `conversion_factor`."""
@@ -326,14 +322,13 @@ set_storage_target!(value::EnergyReservoirStorage, val) = value.storage_target =
 set_cycle_limits!(value::EnergyReservoirStorage, val) = value.cycle_limits = val
 """Set [`EnergyReservoirStorage`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::EnergyReservoirStorage, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
-set_ramp_limits!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
-set_ramp_limits!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::EnergyReservoirStorage, val::NamedTuple{(:up, :down), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `self_discharge`."""
 set_self_discharge!(value::EnergyReservoirStorage, val) = value.self_discharge = val
 """Set [`EnergyReservoirStorage`](@ref) `standing_loss`."""
 set_standing_loss!(value::EnergyReservoirStorage, val) = value.standing_loss = set_value(value, Val(:standing_loss), val, Val(:mw))
-set_standing_loss!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_standing_loss!, value, :standing_loss, Val(:mw), val)
-set_standing_loss!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_standing_loss!, value, :standing_loss, Val(:mw), val)
+set_standing_loss!(value::EnergyReservoirStorage, val::_UntaggedNumber) = _units_tag_required(set_standing_loss!, value, :standing_loss, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `services`."""
 set_services!(value::EnergyReservoirStorage, val) = value.services = val
 """Set [`EnergyReservoirStorage`](@ref) `ext`."""

--- a/src/models/generated/EnergyReservoirStorage.jl
+++ b/src/models/generated/EnergyReservoirStorage.jl
@@ -179,6 +179,8 @@ get_storage_technology_type(value::EnergyReservoirStorage) = value.storage_techn
 get_storage_capacity(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:storage_capacity), Val(:mw), units))
 """Get [`EnergyReservoirStorage`](@ref) `storage_capacity` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_storage_capacity`](@ref)."""
 get_storage_capacity_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:storage_capacity), Val(:mw), units)
+get_storage_capacity(value::EnergyReservoirStorage) = _units_arg_required(get_storage_capacity, value, :storage_capacity, Val(:mw))
+get_storage_capacity_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_storage_capacity_unitful, value, :storage_capacity, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_storage_capacity), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_storage_capacity_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 """Get [`EnergyReservoirStorage`](@ref) `storage_level_limits`."""
@@ -189,24 +191,32 @@ get_initial_storage_capacity_level(value::EnergyReservoirStorage) = value.initia
 get_rating(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`EnergyReservoirStorage`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::EnergyReservoirStorage) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.DU
 """Get [`EnergyReservoirStorage`](@ref) `active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_unitful`](@ref)."""
 get_active_power(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`EnergyReservoirStorage`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::EnergyReservoirStorage) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 """Get [`EnergyReservoirStorage`](@ref) `input_active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_input_active_power_limits_unitful`](@ref)."""
 get_input_active_power_limits(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:input_active_power_limits), Val(:mw), units))
 """Get [`EnergyReservoirStorage`](@ref) `input_active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_input_active_power_limits`](@ref)."""
 get_input_active_power_limits_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:input_active_power_limits), Val(:mw), units)
+get_input_active_power_limits(value::EnergyReservoirStorage) = _units_arg_required(get_input_active_power_limits, value, :input_active_power_limits, Val(:mw))
+get_input_active_power_limits_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_input_active_power_limits_unitful, value, :input_active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_input_active_power_limits), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_input_active_power_limits_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 """Get [`EnergyReservoirStorage`](@ref) `output_active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_output_active_power_limits_unitful`](@ref)."""
 get_output_active_power_limits(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:output_active_power_limits), Val(:mw), units))
 """Get [`EnergyReservoirStorage`](@ref) `output_active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_output_active_power_limits`](@ref)."""
 get_output_active_power_limits_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:output_active_power_limits), Val(:mw), units)
+get_output_active_power_limits(value::EnergyReservoirStorage) = _units_arg_required(get_output_active_power_limits, value, :output_active_power_limits, Val(:mw))
+get_output_active_power_limits_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_output_active_power_limits_unitful, value, :output_active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_output_active_power_limits), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_output_active_power_limits_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 """Get [`EnergyReservoirStorage`](@ref) `efficiency`."""
@@ -215,12 +225,16 @@ get_efficiency(value::EnergyReservoirStorage) = value.efficiency
 get_reactive_power(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`EnergyReservoirStorage`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::EnergyReservoirStorage) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 """Get [`EnergyReservoirStorage`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`EnergyReservoirStorage`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::EnergyReservoirStorage) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 
@@ -237,6 +251,8 @@ get_cycle_limits(value::EnergyReservoirStorage) = value.cycle_limits
 get_ramp_limits(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:ramp_limits), Val(:mw), units))
 """Get [`EnergyReservoirStorage`](@ref) `ramp_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_ramp_limits`](@ref)."""
 get_ramp_limits_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:ramp_limits), Val(:mw), units)
+get_ramp_limits(value::EnergyReservoirStorage) = _units_arg_required(get_ramp_limits, value, :ramp_limits, Val(:mw))
+get_ramp_limits_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_ramp_limits_unitful, value, :ramp_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 """Get [`EnergyReservoirStorage`](@ref) `self_discharge`."""
@@ -245,6 +261,8 @@ get_self_discharge(value::EnergyReservoirStorage) = value.self_discharge
 get_standing_loss(value::EnergyReservoirStorage, units) = InfrastructureSystems._strip_units(get_value(value, Val(:standing_loss), Val(:mw), units))
 """Get [`EnergyReservoirStorage`](@ref) `standing_loss` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_standing_loss`](@ref)."""
 get_standing_loss_unitful(value::EnergyReservoirStorage, units) = get_value(value, Val(:standing_loss), Val(:mw), units)
+get_standing_loss(value::EnergyReservoirStorage) = _units_arg_required(get_standing_loss, value, :standing_loss, Val(:mw))
+get_standing_loss_unitful(value::EnergyReservoirStorage) = _units_arg_required(get_standing_loss_unitful, value, :standing_loss, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_standing_loss), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_standing_loss_unitful), ::Type{EnergyReservoirStorage}) = InfrastructureSystems.SU
 """Get [`EnergyReservoirStorage`](@ref) `services`."""
@@ -266,24 +284,38 @@ set_prime_mover_type!(value::EnergyReservoirStorage, val) = value.prime_mover_ty
 set_storage_technology_type!(value::EnergyReservoirStorage, val) = value.storage_technology_type = val
 """Set [`EnergyReservoirStorage`](@ref) `storage_capacity`."""
 set_storage_capacity!(value::EnergyReservoirStorage, val) = value.storage_capacity = set_value(value, Val(:storage_capacity), val, Val(:mw))
+set_storage_capacity!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_storage_capacity!, value, :storage_capacity, Val(:mw), val)
+set_storage_capacity!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_storage_capacity!, value, :storage_capacity, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `storage_level_limits`."""
 set_storage_level_limits!(value::EnergyReservoirStorage, val) = value.storage_level_limits = val
 """Set [`EnergyReservoirStorage`](@ref) `initial_storage_capacity_level`."""
 set_initial_storage_capacity_level!(value::EnergyReservoirStorage, val) = value.initial_storage_capacity_level = val
 """Set [`EnergyReservoirStorage`](@ref) `rating`."""
 set_rating!(value::EnergyReservoirStorage, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`EnergyReservoirStorage`](@ref) `active_power`."""
 set_active_power!(value::EnergyReservoirStorage, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `input_active_power_limits`."""
 set_input_active_power_limits!(value::EnergyReservoirStorage, val) = value.input_active_power_limits = set_value(value, Val(:input_active_power_limits), val, Val(:mw))
+set_input_active_power_limits!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
+set_input_active_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `output_active_power_limits`."""
 set_output_active_power_limits!(value::EnergyReservoirStorage, val) = value.output_active_power_limits = set_value(value, Val(:output_active_power_limits), val, Val(:mw))
+set_output_active_power_limits!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
+set_output_active_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `efficiency`."""
 set_efficiency!(value::EnergyReservoirStorage, val) = value.efficiency = val
 """Set [`EnergyReservoirStorage`](@ref) `reactive_power`."""
 set_reactive_power!(value::EnergyReservoirStorage, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`EnergyReservoirStorage`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::EnergyReservoirStorage, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`EnergyReservoirStorage`](@ref) `operation_cost`."""
 set_operation_cost!(value::EnergyReservoirStorage, val) = value.operation_cost = val
 """Set [`EnergyReservoirStorage`](@ref) `conversion_factor`."""
@@ -294,10 +326,14 @@ set_storage_target!(value::EnergyReservoirStorage, val) = value.storage_target =
 set_cycle_limits!(value::EnergyReservoirStorage, val) = value.cycle_limits = val
 """Set [`EnergyReservoirStorage`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::EnergyReservoirStorage, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
+set_ramp_limits!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `self_discharge`."""
 set_self_discharge!(value::EnergyReservoirStorage, val) = value.self_discharge = val
 """Set [`EnergyReservoirStorage`](@ref) `standing_loss`."""
 set_standing_loss!(value::EnergyReservoirStorage, val) = value.standing_loss = set_value(value, Val(:standing_loss), val, Val(:mw))
+set_standing_loss!(value::EnergyReservoirStorage, val::Real) = _units_tag_required(set_standing_loss!, value, :standing_loss, Val(:mw), val)
+set_standing_loss!(value::EnergyReservoirStorage, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_standing_loss!, value, :standing_loss, Val(:mw), val)
 """Set [`EnergyReservoirStorage`](@ref) `services`."""
 set_services!(value::EnergyReservoirStorage, val) = value.services = val
 """Set [`EnergyReservoirStorage`](@ref) `ext`."""

--- a/src/models/generated/ExponentialLoad.jl
+++ b/src/models/generated/ExponentialLoad.jl
@@ -166,24 +166,20 @@ set_available!(value::ExponentialLoad, val) = value.available = val
 set_bus!(value::ExponentialLoad, val) = value.bus = val
 """Set [`ExponentialLoad`](@ref) `active_power`."""
 set_active_power!(value::ExponentialLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::ExponentialLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::ExponentialLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::ExponentialLoad, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`ExponentialLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::ExponentialLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::ExponentialLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::ExponentialLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::ExponentialLoad, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`ExponentialLoad`](@ref) `α`."""
 set_α!(value::ExponentialLoad, val) = value.α = val
 """Set [`ExponentialLoad`](@ref) `β`."""
 set_β!(value::ExponentialLoad, val) = value.β = val
 """Set [`ExponentialLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::ExponentialLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
-set_max_active_power!(value::ExponentialLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
-set_max_active_power!(value::ExponentialLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::ExponentialLoad, val::_UntaggedNumber) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`ExponentialLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::ExponentialLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
-set_max_reactive_power!(value::ExponentialLoad, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
-set_max_reactive_power!(value::ExponentialLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::ExponentialLoad, val::_UntaggedNumber) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`ExponentialLoad`](@ref) `conformity`."""
 set_conformity!(value::ExponentialLoad, val) = value.conformity = val
 """Set [`ExponentialLoad`](@ref) `services`."""

--- a/src/models/generated/ExponentialLoad.jl
+++ b/src/models/generated/ExponentialLoad.jl
@@ -115,12 +115,16 @@ get_bus(value::ExponentialLoad) = value.bus
 get_active_power(value::ExponentialLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`ExponentialLoad`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::ExponentialLoad, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::ExponentialLoad) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::ExponentialLoad) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{ExponentialLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{ExponentialLoad}) = InfrastructureSystems.SU
 """Get [`ExponentialLoad`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::ExponentialLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`ExponentialLoad`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::ExponentialLoad, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::ExponentialLoad) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::ExponentialLoad) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{ExponentialLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{ExponentialLoad}) = InfrastructureSystems.SU
 """Get [`ExponentialLoad`](@ref) `α`."""
@@ -133,12 +137,16 @@ _get_base_power(value::ExponentialLoad) = value.base_power
 get_max_active_power(value::ExponentialLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_active_power), Val(:mw), units))
 """Get [`ExponentialLoad`](@ref) `max_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_active_power`](@ref)."""
 get_max_active_power_unitful(value::ExponentialLoad, units) = get_value(value, Val(:max_active_power), Val(:mw), units)
+get_max_active_power(value::ExponentialLoad) = _units_arg_required(get_max_active_power, value, :max_active_power, Val(:mw))
+get_max_active_power_unitful(value::ExponentialLoad) = _units_arg_required(get_max_active_power_unitful, value, :max_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power), ::Type{ExponentialLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power_unitful), ::Type{ExponentialLoad}) = InfrastructureSystems.SU
 """Get [`ExponentialLoad`](@ref) `max_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_reactive_power_unitful`](@ref)."""
 get_max_reactive_power(value::ExponentialLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_reactive_power), Val(:mvar), units))
 """Get [`ExponentialLoad`](@ref) `max_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_reactive_power`](@ref)."""
 get_max_reactive_power_unitful(value::ExponentialLoad, units) = get_value(value, Val(:max_reactive_power), Val(:mvar), units)
+get_max_reactive_power(value::ExponentialLoad) = _units_arg_required(get_max_reactive_power, value, :max_reactive_power, Val(:mvar))
+get_max_reactive_power_unitful(value::ExponentialLoad) = _units_arg_required(get_max_reactive_power_unitful, value, :max_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power), ::Type{ExponentialLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power_unitful), ::Type{ExponentialLoad}) = InfrastructureSystems.SU
 """Get [`ExponentialLoad`](@ref) `conformity`."""
@@ -158,16 +166,24 @@ set_available!(value::ExponentialLoad, val) = value.available = val
 set_bus!(value::ExponentialLoad, val) = value.bus = val
 """Set [`ExponentialLoad`](@ref) `active_power`."""
 set_active_power!(value::ExponentialLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::ExponentialLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::ExponentialLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`ExponentialLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::ExponentialLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::ExponentialLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::ExponentialLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`ExponentialLoad`](@ref) `α`."""
 set_α!(value::ExponentialLoad, val) = value.α = val
 """Set [`ExponentialLoad`](@ref) `β`."""
 set_β!(value::ExponentialLoad, val) = value.β = val
 """Set [`ExponentialLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::ExponentialLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
+set_max_active_power!(value::ExponentialLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::ExponentialLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`ExponentialLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::ExponentialLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
+set_max_reactive_power!(value::ExponentialLoad, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::ExponentialLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`ExponentialLoad`](@ref) `conformity`."""
 set_conformity!(value::ExponentialLoad, val) = value.conformity = val
 """Set [`ExponentialLoad`](@ref) `services`."""

--- a/src/models/generated/FACTSControlDevice.jl
+++ b/src/models/generated/FACTSControlDevice.jl
@@ -158,12 +158,10 @@ set_control_mode!(value::FACTSControlDevice, val) = value.control_mode = val
 set_voltage_setpoint!(value::FACTSControlDevice, val) = value.voltage_setpoint = val
 """Set [`FACTSControlDevice`](@ref) `max_shunt_current`."""
 set_max_shunt_current!(value::FACTSControlDevice, val) = value.max_shunt_current = set_value(value, Val(:max_shunt_current), val, Val(:mva))
-set_max_shunt_current!(value::FACTSControlDevice, val::Real) = _units_tag_required(set_max_shunt_current!, value, :max_shunt_current, Val(:mva), val)
-set_max_shunt_current!(value::FACTSControlDevice, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_shunt_current!, value, :max_shunt_current, Val(:mva), val)
+set_max_shunt_current!(value::FACTSControlDevice, val::_UntaggedNumber) = _units_tag_required(set_max_shunt_current!, value, :max_shunt_current, Val(:mva), val)
 """Set [`FACTSControlDevice`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::FACTSControlDevice, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
-set_max_reactive_power!(value::FACTSControlDevice, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
-set_max_reactive_power!(value::FACTSControlDevice, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::FACTSControlDevice, val::_UntaggedNumber) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`FACTSControlDevice`](@ref) `shunt_control_type`."""
 set_shunt_control_type!(value::FACTSControlDevice, val) = value.shunt_control_type = val
 """Set [`FACTSControlDevice`](@ref) `regulated_bus_number`."""

--- a/src/models/generated/FACTSControlDevice.jl
+++ b/src/models/generated/FACTSControlDevice.jl
@@ -119,12 +119,16 @@ get_voltage_setpoint(value::FACTSControlDevice) = value.voltage_setpoint
 get_max_shunt_current(value::FACTSControlDevice, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_shunt_current), Val(:mva), units))
 """Get [`FACTSControlDevice`](@ref) `max_shunt_current` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_shunt_current`](@ref)."""
 get_max_shunt_current_unitful(value::FACTSControlDevice, units) = get_value(value, Val(:max_shunt_current), Val(:mva), units)
+get_max_shunt_current(value::FACTSControlDevice) = _units_arg_required(get_max_shunt_current, value, :max_shunt_current, Val(:mva))
+get_max_shunt_current_unitful(value::FACTSControlDevice) = _units_arg_required(get_max_shunt_current_unitful, value, :max_shunt_current, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_max_shunt_current), ::Type{FACTSControlDevice}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_shunt_current_unitful), ::Type{FACTSControlDevice}) = InfrastructureSystems.SU
 """Get [`FACTSControlDevice`](@ref) `max_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_reactive_power_unitful`](@ref)."""
 get_max_reactive_power(value::FACTSControlDevice, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_reactive_power), Val(:mvar), units))
 """Get [`FACTSControlDevice`](@ref) `max_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_reactive_power`](@ref)."""
 get_max_reactive_power_unitful(value::FACTSControlDevice, units) = get_value(value, Val(:max_reactive_power), Val(:mvar), units)
+get_max_reactive_power(value::FACTSControlDevice) = _units_arg_required(get_max_reactive_power, value, :max_reactive_power, Val(:mvar))
+get_max_reactive_power_unitful(value::FACTSControlDevice) = _units_arg_required(get_max_reactive_power_unitful, value, :max_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power), ::Type{FACTSControlDevice}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power_unitful), ::Type{FACTSControlDevice}) = InfrastructureSystems.SU
 """Get [`FACTSControlDevice`](@ref) `shunt_control_type`."""
@@ -154,8 +158,12 @@ set_control_mode!(value::FACTSControlDevice, val) = value.control_mode = val
 set_voltage_setpoint!(value::FACTSControlDevice, val) = value.voltage_setpoint = val
 """Set [`FACTSControlDevice`](@ref) `max_shunt_current`."""
 set_max_shunt_current!(value::FACTSControlDevice, val) = value.max_shunt_current = set_value(value, Val(:max_shunt_current), val, Val(:mva))
+set_max_shunt_current!(value::FACTSControlDevice, val::Real) = _units_tag_required(set_max_shunt_current!, value, :max_shunt_current, Val(:mva), val)
+set_max_shunt_current!(value::FACTSControlDevice, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_shunt_current!, value, :max_shunt_current, Val(:mva), val)
 """Set [`FACTSControlDevice`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::FACTSControlDevice, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
+set_max_reactive_power!(value::FACTSControlDevice, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::FACTSControlDevice, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`FACTSControlDevice`](@ref) `shunt_control_type`."""
 set_shunt_control_type!(value::FACTSControlDevice, val) = value.shunt_control_type = val
 """Set [`FACTSControlDevice`](@ref) `regulated_bus_number`."""

--- a/src/models/generated/GenericArcImpedance.jl
+++ b/src/models/generated/GenericArcImpedance.jl
@@ -91,18 +91,24 @@ get_available(value::GenericArcImpedance) = value.available
 get_active_power_flow(value::GenericArcImpedance, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`GenericArcImpedance`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::GenericArcImpedance, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::GenericArcImpedance) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::GenericArcImpedance) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 """Get [`GenericArcImpedance`](@ref) `reactive_power_flow` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_flow_unitful`](@ref)."""
 get_reactive_power_flow(value::GenericArcImpedance, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_flow), Val(:mvar), units))
 """Get [`GenericArcImpedance`](@ref) `reactive_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_flow`](@ref)."""
 get_reactive_power_flow_unitful(value::GenericArcImpedance, units) = get_value(value, Val(:reactive_power_flow), Val(:mvar), units)
+get_reactive_power_flow(value::GenericArcImpedance) = _units_arg_required(get_reactive_power_flow, value, :reactive_power_flow, Val(:mvar))
+get_reactive_power_flow_unitful(value::GenericArcImpedance) = _units_arg_required(get_reactive_power_flow_unitful, value, :reactive_power_flow, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow_unitful), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 """Get [`GenericArcImpedance`](@ref) `max_flow` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_flow_unitful`](@ref)."""
 get_max_flow(value::GenericArcImpedance, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_flow), Val(:mw), units))
 """Get [`GenericArcImpedance`](@ref) `max_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_flow`](@ref)."""
 get_max_flow_unitful(value::GenericArcImpedance, units) = get_value(value, Val(:max_flow), Val(:mw), units)
+get_max_flow(value::GenericArcImpedance) = _units_arg_required(get_max_flow, value, :max_flow, Val(:mw))
+get_max_flow_unitful(value::GenericArcImpedance) = _units_arg_required(get_max_flow_unitful, value, :max_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_flow), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_flow_unitful), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 """Get [`GenericArcImpedance`](@ref) `arc`."""
@@ -111,12 +117,16 @@ get_arc(value::GenericArcImpedance) = value.arc
 get_r(value::GenericArcImpedance, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r), Val(:ohm), units))
 """Get [`GenericArcImpedance`](@ref) `r` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r`](@ref)."""
 get_r_unitful(value::GenericArcImpedance, units) = get_value(value, Val(:r), Val(:ohm), units)
+get_r(value::GenericArcImpedance) = _units_arg_required(get_r, value, :r, Val(:ohm))
+get_r_unitful(value::GenericArcImpedance) = _units_arg_required(get_r_unitful, value, :r, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_r), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_r_unitful), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 """Get [`GenericArcImpedance`](@ref) `x` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_x_unitful`](@ref)."""
 get_x(value::GenericArcImpedance, units) = InfrastructureSystems._strip_units(get_value(value, Val(:x), Val(:ohm), units))
 """Get [`GenericArcImpedance`](@ref) `x` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_x`](@ref)."""
 get_x_unitful(value::GenericArcImpedance, units) = get_value(value, Val(:x), Val(:ohm), units)
+get_x(value::GenericArcImpedance) = _units_arg_required(get_x, value, :x, Val(:ohm))
+get_x_unitful(value::GenericArcImpedance) = _units_arg_required(get_x_unitful, value, :x, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_x), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_x_unitful), ::Type{GenericArcImpedance}) = InfrastructureSystems.SU
 
@@ -130,15 +140,25 @@ get_internal(value::GenericArcImpedance) = value.internal
 set_available!(value::GenericArcImpedance, val) = value.available = val
 """Set [`GenericArcImpedance`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::GenericArcImpedance, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`GenericArcImpedance`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::GenericArcImpedance, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
+set_reactive_power_flow!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`GenericArcImpedance`](@ref) `max_flow`."""
 set_max_flow!(value::GenericArcImpedance, val) = value.max_flow = set_value(value, Val(:max_flow), val, Val(:mw))
+set_max_flow!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_max_flow!, value, :max_flow, Val(:mw), val)
+set_max_flow!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_flow!, value, :max_flow, Val(:mw), val)
 """Set [`GenericArcImpedance`](@ref) `arc`."""
 set_arc!(value::GenericArcImpedance, val) = value.arc = val
 """Set [`GenericArcImpedance`](@ref) `r`."""
 set_r!(value::GenericArcImpedance, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
+set_r!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`GenericArcImpedance`](@ref) `x`."""
 set_x!(value::GenericArcImpedance, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
+set_x!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`GenericArcImpedance`](@ref) `ext`."""
 set_ext!(value::GenericArcImpedance, val) = value.ext = val

--- a/src/models/generated/GenericArcImpedance.jl
+++ b/src/models/generated/GenericArcImpedance.jl
@@ -140,25 +140,20 @@ get_internal(value::GenericArcImpedance) = value.internal
 set_available!(value::GenericArcImpedance, val) = value.available = val
 """Set [`GenericArcImpedance`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::GenericArcImpedance, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::GenericArcImpedance, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`GenericArcImpedance`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::GenericArcImpedance, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
-set_reactive_power_flow!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
-set_reactive_power_flow!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::GenericArcImpedance, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`GenericArcImpedance`](@ref) `max_flow`."""
 set_max_flow!(value::GenericArcImpedance, val) = value.max_flow = set_value(value, Val(:max_flow), val, Val(:mw))
-set_max_flow!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_max_flow!, value, :max_flow, Val(:mw), val)
-set_max_flow!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_flow!, value, :max_flow, Val(:mw), val)
+set_max_flow!(value::GenericArcImpedance, val::_UntaggedNumber) = _units_tag_required(set_max_flow!, value, :max_flow, Val(:mw), val)
 """Set [`GenericArcImpedance`](@ref) `arc`."""
 set_arc!(value::GenericArcImpedance, val) = value.arc = val
 """Set [`GenericArcImpedance`](@ref) `r`."""
 set_r!(value::GenericArcImpedance, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
-set_r!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
-set_r!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::GenericArcImpedance, val::_UntaggedNumber) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`GenericArcImpedance`](@ref) `x`."""
 set_x!(value::GenericArcImpedance, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
-set_x!(value::GenericArcImpedance, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
-set_x!(value::GenericArcImpedance, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::GenericArcImpedance, val::_UntaggedNumber) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`GenericArcImpedance`](@ref) `ext`."""
 set_ext!(value::GenericArcImpedance, val) = value.ext = val

--- a/src/models/generated/HybridSystem.jl
+++ b/src/models/generated/HybridSystem.jl
@@ -152,12 +152,16 @@ get_bus(value::HybridSystem) = value.bus
 get_active_power(value::HybridSystem, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`HybridSystem`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::HybridSystem, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::HybridSystem) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::HybridSystem) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{HybridSystem}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{HybridSystem}) = InfrastructureSystems.SU
 """Get [`HybridSystem`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::HybridSystem, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`HybridSystem`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::HybridSystem, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::HybridSystem) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::HybridSystem) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{HybridSystem}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{HybridSystem}) = InfrastructureSystems.SU
 
@@ -178,24 +182,32 @@ get_interconnection_impedance(value::HybridSystem) = value.interconnection_imped
 get_interconnection_rating(value::HybridSystem, units) = InfrastructureSystems._strip_units(get_value(value, Val(:interconnection_rating), Val(:mva), units))
 """Get [`HybridSystem`](@ref) `interconnection_rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_interconnection_rating`](@ref)."""
 get_interconnection_rating_unitful(value::HybridSystem, units) = get_value(value, Val(:interconnection_rating), Val(:mva), units)
+get_interconnection_rating(value::HybridSystem) = _units_arg_required(get_interconnection_rating, value, :interconnection_rating, Val(:mva))
+get_interconnection_rating_unitful(value::HybridSystem) = _units_arg_required(get_interconnection_rating_unitful, value, :interconnection_rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_interconnection_rating), ::Type{HybridSystem}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_interconnection_rating_unitful), ::Type{HybridSystem}) = InfrastructureSystems.SU
 """Get [`HybridSystem`](@ref) `input_active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_input_active_power_limits_unitful`](@ref)."""
 get_input_active_power_limits(value::HybridSystem, units) = InfrastructureSystems._strip_units(get_value(value, Val(:input_active_power_limits), Val(:mw), units))
 """Get [`HybridSystem`](@ref) `input_active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_input_active_power_limits`](@ref)."""
 get_input_active_power_limits_unitful(value::HybridSystem, units) = get_value(value, Val(:input_active_power_limits), Val(:mw), units)
+get_input_active_power_limits(value::HybridSystem) = _units_arg_required(get_input_active_power_limits, value, :input_active_power_limits, Val(:mw))
+get_input_active_power_limits_unitful(value::HybridSystem) = _units_arg_required(get_input_active_power_limits_unitful, value, :input_active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_input_active_power_limits), ::Type{HybridSystem}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_input_active_power_limits_unitful), ::Type{HybridSystem}) = InfrastructureSystems.SU
 """Get [`HybridSystem`](@ref) `output_active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_output_active_power_limits_unitful`](@ref)."""
 get_output_active_power_limits(value::HybridSystem, units) = InfrastructureSystems._strip_units(get_value(value, Val(:output_active_power_limits), Val(:mw), units))
 """Get [`HybridSystem`](@ref) `output_active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_output_active_power_limits`](@ref)."""
 get_output_active_power_limits_unitful(value::HybridSystem, units) = get_value(value, Val(:output_active_power_limits), Val(:mw), units)
+get_output_active_power_limits(value::HybridSystem) = _units_arg_required(get_output_active_power_limits, value, :output_active_power_limits, Val(:mw))
+get_output_active_power_limits_unitful(value::HybridSystem) = _units_arg_required(get_output_active_power_limits_unitful, value, :output_active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_output_active_power_limits), ::Type{HybridSystem}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_output_active_power_limits_unitful), ::Type{HybridSystem}) = InfrastructureSystems.SU
 """Get [`HybridSystem`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::HybridSystem, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`HybridSystem`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::HybridSystem, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::HybridSystem) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::HybridSystem) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{HybridSystem}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{HybridSystem}) = InfrastructureSystems.SU
 """Get [`HybridSystem`](@ref) `interconnection_efficiency`."""
@@ -217,20 +229,32 @@ set_status!(value::HybridSystem, val) = value.status = val
 set_bus!(value::HybridSystem, val) = value.bus = val
 """Set [`HybridSystem`](@ref) `active_power`."""
 set_active_power!(value::HybridSystem, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::HybridSystem, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`HybridSystem`](@ref) `reactive_power`."""
 set_reactive_power!(value::HybridSystem, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::HybridSystem, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`HybridSystem`](@ref) `operation_cost`."""
 set_operation_cost!(value::HybridSystem, val) = value.operation_cost = val
 """Set [`HybridSystem`](@ref) `interconnection_impedance`."""
 set_interconnection_impedance!(value::HybridSystem, val) = value.interconnection_impedance = val
 """Set [`HybridSystem`](@ref) `interconnection_rating`."""
 set_interconnection_rating!(value::HybridSystem, val) = value.interconnection_rating = set_value(value, Val(:interconnection_rating), val, Val(:mva))
+set_interconnection_rating!(value::HybridSystem, val::Real) = _units_tag_required(set_interconnection_rating!, value, :interconnection_rating, Val(:mva), val)
+set_interconnection_rating!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_interconnection_rating!, value, :interconnection_rating, Val(:mva), val)
 """Set [`HybridSystem`](@ref) `input_active_power_limits`."""
 set_input_active_power_limits!(value::HybridSystem, val) = value.input_active_power_limits = set_value(value, Val(:input_active_power_limits), val, Val(:mw))
+set_input_active_power_limits!(value::HybridSystem, val::Real) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
+set_input_active_power_limits!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
 """Set [`HybridSystem`](@ref) `output_active_power_limits`."""
 set_output_active_power_limits!(value::HybridSystem, val) = value.output_active_power_limits = set_value(value, Val(:output_active_power_limits), val, Val(:mw))
+set_output_active_power_limits!(value::HybridSystem, val::Real) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
+set_output_active_power_limits!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
 """Set [`HybridSystem`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::HybridSystem, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::HybridSystem, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`HybridSystem`](@ref) `interconnection_efficiency`."""
 set_interconnection_efficiency!(value::HybridSystem, val) = value.interconnection_efficiency = val
 """Set [`HybridSystem`](@ref) `services`."""

--- a/src/models/generated/HybridSystem.jl
+++ b/src/models/generated/HybridSystem.jl
@@ -229,32 +229,29 @@ set_status!(value::HybridSystem, val) = value.status = val
 set_bus!(value::HybridSystem, val) = value.bus = val
 """Set [`HybridSystem`](@ref) `active_power`."""
 set_active_power!(value::HybridSystem, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::HybridSystem, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::HybridSystem, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`HybridSystem`](@ref) `reactive_power`."""
 set_reactive_power!(value::HybridSystem, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::HybridSystem, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::HybridSystem, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`HybridSystem`](@ref) `operation_cost`."""
 set_operation_cost!(value::HybridSystem, val) = value.operation_cost = val
 """Set [`HybridSystem`](@ref) `interconnection_impedance`."""
 set_interconnection_impedance!(value::HybridSystem, val) = value.interconnection_impedance = val
 """Set [`HybridSystem`](@ref) `interconnection_rating`."""
 set_interconnection_rating!(value::HybridSystem, val) = value.interconnection_rating = set_value(value, Val(:interconnection_rating), val, Val(:mva))
-set_interconnection_rating!(value::HybridSystem, val::Real) = _units_tag_required(set_interconnection_rating!, value, :interconnection_rating, Val(:mva), val)
-set_interconnection_rating!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_interconnection_rating!, value, :interconnection_rating, Val(:mva), val)
+set_interconnection_rating!(value::HybridSystem, val::_UntaggedNumber) = _units_tag_required(set_interconnection_rating!, value, :interconnection_rating, Val(:mva), val)
 """Set [`HybridSystem`](@ref) `input_active_power_limits`."""
 set_input_active_power_limits!(value::HybridSystem, val) = value.input_active_power_limits = set_value(value, Val(:input_active_power_limits), val, Val(:mw))
-set_input_active_power_limits!(value::HybridSystem, val::Real) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
-set_input_active_power_limits!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
+set_input_active_power_limits!(value::HybridSystem, val::_UntaggedNumber) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
+set_input_active_power_limits!(value::HybridSystem, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_input_active_power_limits!, value, :input_active_power_limits, Val(:mw), val)
 """Set [`HybridSystem`](@ref) `output_active_power_limits`."""
 set_output_active_power_limits!(value::HybridSystem, val) = value.output_active_power_limits = set_value(value, Val(:output_active_power_limits), val, Val(:mw))
-set_output_active_power_limits!(value::HybridSystem, val::Real) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
-set_output_active_power_limits!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
+set_output_active_power_limits!(value::HybridSystem, val::_UntaggedNumber) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
+set_output_active_power_limits!(value::HybridSystem, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_output_active_power_limits!, value, :output_active_power_limits, Val(:mw), val)
 """Set [`HybridSystem`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::HybridSystem, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::HybridSystem, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::HybridSystem, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HybridSystem, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HybridSystem, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`HybridSystem`](@ref) `interconnection_efficiency`."""
 set_interconnection_efficiency!(value::HybridSystem, val) = value.interconnection_efficiency = val
 """Set [`HybridSystem`](@ref) `services`."""

--- a/src/models/generated/HydroDispatch.jl
+++ b/src/models/generated/HydroDispatch.jl
@@ -135,18 +135,24 @@ get_bus(value::HydroDispatch) = value.bus
 get_active_power(value::HydroDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`HydroDispatch`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::HydroDispatch, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::HydroDispatch) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::HydroDispatch) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 """Get [`HydroDispatch`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::HydroDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`HydroDispatch`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::HydroDispatch, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::HydroDispatch) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::HydroDispatch) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 """Get [`HydroDispatch`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::HydroDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`HydroDispatch`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::HydroDispatch, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::HydroDispatch) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::HydroDispatch) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroDispatch}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroDispatch}) = InfrastructureSystems.DU
 """Get [`HydroDispatch`](@ref) `prime_mover_type`."""
@@ -155,18 +161,24 @@ get_prime_mover_type(value::HydroDispatch) = value.prime_mover_type
 get_active_power_limits(value::HydroDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mw), units))
 """Get [`HydroDispatch`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""
 get_active_power_limits_unitful(value::HydroDispatch, units) = get_value(value, Val(:active_power_limits), Val(:mw), units)
+get_active_power_limits(value::HydroDispatch) = _units_arg_required(get_active_power_limits, value, :active_power_limits, Val(:mw))
+get_active_power_limits_unitful(value::HydroDispatch) = _units_arg_required(get_active_power_limits_unitful, value, :active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_unitful), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 """Get [`HydroDispatch`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::HydroDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`HydroDispatch`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::HydroDispatch, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::HydroDispatch) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::HydroDispatch) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 """Get [`HydroDispatch`](@ref) `ramp_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_ramp_limits_unitful`](@ref)."""
 get_ramp_limits(value::HydroDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:ramp_limits), Val(:mw), units))
 """Get [`HydroDispatch`](@ref) `ramp_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_ramp_limits`](@ref)."""
 get_ramp_limits_unitful(value::HydroDispatch, units) = get_value(value, Val(:ramp_limits), Val(:mw), units)
+get_ramp_limits(value::HydroDispatch) = _units_arg_required(get_ramp_limits, value, :ramp_limits, Val(:mw))
+get_ramp_limits_unitful(value::HydroDispatch) = _units_arg_required(get_ramp_limits_unitful, value, :ramp_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits_unitful), ::Type{HydroDispatch}) = InfrastructureSystems.SU
 """Get [`HydroDispatch`](@ref) `time_limits`."""
@@ -194,18 +206,30 @@ set_available!(value::HydroDispatch, val) = value.available = val
 set_bus!(value::HydroDispatch, val) = value.bus = val
 """Set [`HydroDispatch`](@ref) `active_power`."""
 set_active_power!(value::HydroDispatch, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::HydroDispatch, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`HydroDispatch`](@ref) `reactive_power`."""
 set_reactive_power!(value::HydroDispatch, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::HydroDispatch, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`HydroDispatch`](@ref) `rating`."""
 set_rating!(value::HydroDispatch, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::HydroDispatch, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`HydroDispatch`](@ref) `prime_mover_type`."""
 set_prime_mover_type!(value::HydroDispatch, val) = value.prime_mover_type = val
 """Set [`HydroDispatch`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::HydroDispatch, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
+set_active_power_limits!(value::HydroDispatch, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`HydroDispatch`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::HydroDispatch, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::HydroDispatch, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`HydroDispatch`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::HydroDispatch, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
+set_ramp_limits!(value::HydroDispatch, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`HydroDispatch`](@ref) `time_limits`."""
 set_time_limits!(value::HydroDispatch, val) = value.time_limits = val
 """Set [`HydroDispatch`](@ref) `status`."""

--- a/src/models/generated/HydroDispatch.jl
+++ b/src/models/generated/HydroDispatch.jl
@@ -206,30 +206,27 @@ set_available!(value::HydroDispatch, val) = value.available = val
 set_bus!(value::HydroDispatch, val) = value.bus = val
 """Set [`HydroDispatch`](@ref) `active_power`."""
 set_active_power!(value::HydroDispatch, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::HydroDispatch, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::HydroDispatch, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`HydroDispatch`](@ref) `reactive_power`."""
 set_reactive_power!(value::HydroDispatch, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::HydroDispatch, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::HydroDispatch, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`HydroDispatch`](@ref) `rating`."""
 set_rating!(value::HydroDispatch, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::HydroDispatch, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::HydroDispatch, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`HydroDispatch`](@ref) `prime_mover_type`."""
 set_prime_mover_type!(value::HydroDispatch, val) = value.prime_mover_type = val
 """Set [`HydroDispatch`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::HydroDispatch, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
-set_active_power_limits!(value::HydroDispatch, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
-set_active_power_limits!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroDispatch, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroDispatch, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`HydroDispatch`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::HydroDispatch, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::HydroDispatch, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroDispatch, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroDispatch, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`HydroDispatch`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::HydroDispatch, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
-set_ramp_limits!(value::HydroDispatch, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
-set_ramp_limits!(value::HydroDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroDispatch, val::_UntaggedNumber) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroDispatch, val::NamedTuple{(:up, :down), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`HydroDispatch`](@ref) `time_limits`."""
 set_time_limits!(value::HydroDispatch, val) = value.time_limits = val
 """Set [`HydroDispatch`](@ref) `status`."""

--- a/src/models/generated/HydroPumpTurbine.jl
+++ b/src/models/generated/HydroPumpTurbine.jl
@@ -286,36 +286,33 @@ set_available!(value::HydroPumpTurbine, val) = value.available = val
 set_bus!(value::HydroPumpTurbine, val) = value.bus = val
 """Set [`HydroPumpTurbine`](@ref) `active_power`."""
 set_active_power!(value::HydroPumpTurbine, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::HydroPumpTurbine, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `reactive_power`."""
 set_reactive_power!(value::HydroPumpTurbine, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::HydroPumpTurbine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`HydroPumpTurbine`](@ref) `rating`."""
 set_rating!(value::HydroPumpTurbine, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::HydroPumpTurbine, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`HydroPumpTurbine`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::HydroPumpTurbine, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
-set_active_power_limits!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
-set_active_power_limits!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroPumpTurbine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroPumpTurbine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::HydroPumpTurbine, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroPumpTurbine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroPumpTurbine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`HydroPumpTurbine`](@ref) `active_power_limits_pump`."""
 set_active_power_limits_pump!(value::HydroPumpTurbine, val) = value.active_power_limits_pump = set_value(value, Val(:active_power_limits_pump), val, Val(:mw))
-set_active_power_limits_pump!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_active_power_limits_pump!, value, :active_power_limits_pump, Val(:mw), val)
-set_active_power_limits_pump!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_pump!, value, :active_power_limits_pump, Val(:mw), val)
+set_active_power_limits_pump!(value::HydroPumpTurbine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_pump!, value, :active_power_limits_pump, Val(:mw), val)
+set_active_power_limits_pump!(value::HydroPumpTurbine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_pump!, value, :active_power_limits_pump, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `outflow_limits`."""
 set_outflow_limits!(value::HydroPumpTurbine, val) = value.outflow_limits = val
 """Set [`HydroPumpTurbine`](@ref) `powerhouse_elevation`."""
 set_powerhouse_elevation!(value::HydroPumpTurbine, val) = value.powerhouse_elevation = val
 """Set [`HydroPumpTurbine`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::HydroPumpTurbine, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
-set_ramp_limits!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
-set_ramp_limits!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroPumpTurbine, val::_UntaggedNumber) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroPumpTurbine, val::NamedTuple{(:up, :down), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `time_limits`."""
 set_time_limits!(value::HydroPumpTurbine, val) = value.time_limits = val
 """Set [`HydroPumpTurbine`](@ref) `status`."""
@@ -326,8 +323,7 @@ set_time_at_status!(value::HydroPumpTurbine, val) = value.time_at_status = val
 set_operation_cost!(value::HydroPumpTurbine, val) = value.operation_cost = val
 """Set [`HydroPumpTurbine`](@ref) `active_power_pump`."""
 set_active_power_pump!(value::HydroPumpTurbine, val) = value.active_power_pump = set_value(value, Val(:active_power_pump), val, Val(:mw))
-set_active_power_pump!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_active_power_pump!, value, :active_power_pump, Val(:mw), val)
-set_active_power_pump!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_pump!, value, :active_power_pump, Val(:mw), val)
+set_active_power_pump!(value::HydroPumpTurbine, val::_UntaggedNumber) = _units_tag_required(set_active_power_pump!, value, :active_power_pump, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `efficiency`."""
 set_efficiency!(value::HydroPumpTurbine, val) = value.efficiency = val
 """Set [`HydroPumpTurbine`](@ref) `transition_time`."""

--- a/src/models/generated/HydroPumpTurbine.jl
+++ b/src/models/generated/HydroPumpTurbine.jl
@@ -183,36 +183,48 @@ get_bus(value::HydroPumpTurbine) = value.bus
 get_active_power(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`HydroPumpTurbine`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::HydroPumpTurbine) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::HydroPumpTurbine) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 """Get [`HydroPumpTurbine`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`HydroPumpTurbine`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::HydroPumpTurbine) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::HydroPumpTurbine) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 """Get [`HydroPumpTurbine`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`HydroPumpTurbine`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::HydroPumpTurbine) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::HydroPumpTurbine) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroPumpTurbine}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.DU
 """Get [`HydroPumpTurbine`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mw), units))
 """Get [`HydroPumpTurbine`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""
 get_active_power_limits_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:active_power_limits), Val(:mw), units)
+get_active_power_limits(value::HydroPumpTurbine) = _units_arg_required(get_active_power_limits, value, :active_power_limits, Val(:mw))
+get_active_power_limits_unitful(value::HydroPumpTurbine) = _units_arg_required(get_active_power_limits_unitful, value, :active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 """Get [`HydroPumpTurbine`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`HydroPumpTurbine`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::HydroPumpTurbine) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::HydroPumpTurbine) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 """Get [`HydroPumpTurbine`](@ref) `active_power_limits_pump` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_pump_unitful`](@ref)."""
 get_active_power_limits_pump(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_pump), Val(:mw), units))
 """Get [`HydroPumpTurbine`](@ref) `active_power_limits_pump` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_pump`](@ref)."""
 get_active_power_limits_pump_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:active_power_limits_pump), Val(:mw), units)
+get_active_power_limits_pump(value::HydroPumpTurbine) = _units_arg_required(get_active_power_limits_pump, value, :active_power_limits_pump, Val(:mw))
+get_active_power_limits_pump_unitful(value::HydroPumpTurbine) = _units_arg_required(get_active_power_limits_pump_unitful, value, :active_power_limits_pump, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_pump), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_pump_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 """Get [`HydroPumpTurbine`](@ref) `outflow_limits`."""
@@ -223,6 +235,8 @@ get_powerhouse_elevation(value::HydroPumpTurbine) = value.powerhouse_elevation
 get_ramp_limits(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:ramp_limits), Val(:mw), units))
 """Get [`HydroPumpTurbine`](@ref) `ramp_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_ramp_limits`](@ref)."""
 get_ramp_limits_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:ramp_limits), Val(:mw), units)
+get_ramp_limits(value::HydroPumpTurbine) = _units_arg_required(get_ramp_limits, value, :ramp_limits, Val(:mw))
+get_ramp_limits_unitful(value::HydroPumpTurbine) = _units_arg_required(get_ramp_limits_unitful, value, :ramp_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 """Get [`HydroPumpTurbine`](@ref) `time_limits`."""
@@ -239,6 +253,8 @@ get_operation_cost(value::HydroPumpTurbine) = value.operation_cost
 get_active_power_pump(value::HydroPumpTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_pump), Val(:mw), units))
 """Get [`HydroPumpTurbine`](@ref) `active_power_pump` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_pump`](@ref)."""
 get_active_power_pump_unitful(value::HydroPumpTurbine, units) = get_value(value, Val(:active_power_pump), Val(:mw), units)
+get_active_power_pump(value::HydroPumpTurbine) = _units_arg_required(get_active_power_pump, value, :active_power_pump, Val(:mw))
+get_active_power_pump_unitful(value::HydroPumpTurbine) = _units_arg_required(get_active_power_pump_unitful, value, :active_power_pump, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_pump), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_pump_unitful), ::Type{HydroPumpTurbine}) = InfrastructureSystems.SU
 """Get [`HydroPumpTurbine`](@ref) `efficiency`."""
@@ -270,22 +286,36 @@ set_available!(value::HydroPumpTurbine, val) = value.available = val
 set_bus!(value::HydroPumpTurbine, val) = value.bus = val
 """Set [`HydroPumpTurbine`](@ref) `active_power`."""
 set_active_power!(value::HydroPumpTurbine, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `reactive_power`."""
 set_reactive_power!(value::HydroPumpTurbine, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`HydroPumpTurbine`](@ref) `rating`."""
 set_rating!(value::HydroPumpTurbine, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`HydroPumpTurbine`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::HydroPumpTurbine, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
+set_active_power_limits!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::HydroPumpTurbine, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`HydroPumpTurbine`](@ref) `active_power_limits_pump`."""
 set_active_power_limits_pump!(value::HydroPumpTurbine, val) = value.active_power_limits_pump = set_value(value, Val(:active_power_limits_pump), val, Val(:mw))
+set_active_power_limits_pump!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_active_power_limits_pump!, value, :active_power_limits_pump, Val(:mw), val)
+set_active_power_limits_pump!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_pump!, value, :active_power_limits_pump, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `outflow_limits`."""
 set_outflow_limits!(value::HydroPumpTurbine, val) = value.outflow_limits = val
 """Set [`HydroPumpTurbine`](@ref) `powerhouse_elevation`."""
 set_powerhouse_elevation!(value::HydroPumpTurbine, val) = value.powerhouse_elevation = val
 """Set [`HydroPumpTurbine`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::HydroPumpTurbine, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
+set_ramp_limits!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `time_limits`."""
 set_time_limits!(value::HydroPumpTurbine, val) = value.time_limits = val
 """Set [`HydroPumpTurbine`](@ref) `status`."""
@@ -296,6 +326,8 @@ set_time_at_status!(value::HydroPumpTurbine, val) = value.time_at_status = val
 set_operation_cost!(value::HydroPumpTurbine, val) = value.operation_cost = val
 """Set [`HydroPumpTurbine`](@ref) `active_power_pump`."""
 set_active_power_pump!(value::HydroPumpTurbine, val) = value.active_power_pump = set_value(value, Val(:active_power_pump), val, Val(:mw))
+set_active_power_pump!(value::HydroPumpTurbine, val::Real) = _units_tag_required(set_active_power_pump!, value, :active_power_pump, Val(:mw), val)
+set_active_power_pump!(value::HydroPumpTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_pump!, value, :active_power_pump, Val(:mw), val)
 """Set [`HydroPumpTurbine`](@ref) `efficiency`."""
 set_efficiency!(value::HydroPumpTurbine, val) = value.efficiency = val
 """Set [`HydroPumpTurbine`](@ref) `transition_time`."""

--- a/src/models/generated/HydroTurbine.jl
+++ b/src/models/generated/HydroTurbine.jl
@@ -153,30 +153,40 @@ get_bus(value::HydroTurbine) = value.bus
 get_active_power(value::HydroTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`HydroTurbine`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::HydroTurbine, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::HydroTurbine) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::HydroTurbine) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 """Get [`HydroTurbine`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::HydroTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`HydroTurbine`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::HydroTurbine, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::HydroTurbine) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::HydroTurbine) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 """Get [`HydroTurbine`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::HydroTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`HydroTurbine`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::HydroTurbine, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::HydroTurbine) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::HydroTurbine) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{HydroTurbine}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{HydroTurbine}) = InfrastructureSystems.DU
 """Get [`HydroTurbine`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::HydroTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mw), units))
 """Get [`HydroTurbine`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""
 get_active_power_limits_unitful(value::HydroTurbine, units) = get_value(value, Val(:active_power_limits), Val(:mw), units)
+get_active_power_limits(value::HydroTurbine) = _units_arg_required(get_active_power_limits, value, :active_power_limits, Val(:mw))
+get_active_power_limits_unitful(value::HydroTurbine) = _units_arg_required(get_active_power_limits_unitful, value, :active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_unitful), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 """Get [`HydroTurbine`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::HydroTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`HydroTurbine`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::HydroTurbine, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::HydroTurbine) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::HydroTurbine) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 
@@ -189,6 +199,8 @@ get_powerhouse_elevation(value::HydroTurbine) = value.powerhouse_elevation
 get_ramp_limits(value::HydroTurbine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:ramp_limits), Val(:mw), units))
 """Get [`HydroTurbine`](@ref) `ramp_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_ramp_limits`](@ref)."""
 get_ramp_limits_unitful(value::HydroTurbine, units) = get_value(value, Val(:ramp_limits), Val(:mw), units)
+get_ramp_limits(value::HydroTurbine) = _units_arg_required(get_ramp_limits, value, :ramp_limits, Val(:mw))
+get_ramp_limits_unitful(value::HydroTurbine) = _units_arg_required(get_ramp_limits_unitful, value, :ramp_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits_unitful), ::Type{HydroTurbine}) = InfrastructureSystems.SU
 """Get [`HydroTurbine`](@ref) `time_limits`."""
@@ -220,20 +232,32 @@ set_available!(value::HydroTurbine, val) = value.available = val
 set_bus!(value::HydroTurbine, val) = value.bus = val
 """Set [`HydroTurbine`](@ref) `active_power`."""
 set_active_power!(value::HydroTurbine, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::HydroTurbine, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`HydroTurbine`](@ref) `reactive_power`."""
 set_reactive_power!(value::HydroTurbine, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::HydroTurbine, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`HydroTurbine`](@ref) `rating`."""
 set_rating!(value::HydroTurbine, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::HydroTurbine, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`HydroTurbine`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::HydroTurbine, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
+set_active_power_limits!(value::HydroTurbine, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`HydroTurbine`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::HydroTurbine, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::HydroTurbine, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`HydroTurbine`](@ref) `operation_cost`."""
 set_operation_cost!(value::HydroTurbine, val) = value.operation_cost = val
 """Set [`HydroTurbine`](@ref) `powerhouse_elevation`."""
 set_powerhouse_elevation!(value::HydroTurbine, val) = value.powerhouse_elevation = val
 """Set [`HydroTurbine`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::HydroTurbine, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
+set_ramp_limits!(value::HydroTurbine, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`HydroTurbine`](@ref) `time_limits`."""
 set_time_limits!(value::HydroTurbine, val) = value.time_limits = val
 """Set [`HydroTurbine`](@ref) `outflow_limits`."""

--- a/src/models/generated/HydroTurbine.jl
+++ b/src/models/generated/HydroTurbine.jl
@@ -232,32 +232,29 @@ set_available!(value::HydroTurbine, val) = value.available = val
 set_bus!(value::HydroTurbine, val) = value.bus = val
 """Set [`HydroTurbine`](@ref) `active_power`."""
 set_active_power!(value::HydroTurbine, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::HydroTurbine, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::HydroTurbine, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`HydroTurbine`](@ref) `reactive_power`."""
 set_reactive_power!(value::HydroTurbine, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::HydroTurbine, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::HydroTurbine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`HydroTurbine`](@ref) `rating`."""
 set_rating!(value::HydroTurbine, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::HydroTurbine, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::HydroTurbine, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`HydroTurbine`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::HydroTurbine, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
-set_active_power_limits!(value::HydroTurbine, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
-set_active_power_limits!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroTurbine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::HydroTurbine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`HydroTurbine`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::HydroTurbine, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::HydroTurbine, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroTurbine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::HydroTurbine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`HydroTurbine`](@ref) `operation_cost`."""
 set_operation_cost!(value::HydroTurbine, val) = value.operation_cost = val
 """Set [`HydroTurbine`](@ref) `powerhouse_elevation`."""
 set_powerhouse_elevation!(value::HydroTurbine, val) = value.powerhouse_elevation = val
 """Set [`HydroTurbine`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::HydroTurbine, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
-set_ramp_limits!(value::HydroTurbine, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
-set_ramp_limits!(value::HydroTurbine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroTurbine, val::_UntaggedNumber) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::HydroTurbine, val::NamedTuple{(:up, :down), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`HydroTurbine`](@ref) `time_limits`."""
 set_time_limits!(value::HydroTurbine, val) = value.time_limits = val
 """Set [`HydroTurbine`](@ref) `outflow_limits`."""

--- a/src/models/generated/InterconnectingConverter.jl
+++ b/src/models/generated/InterconnectingConverter.jl
@@ -248,28 +248,24 @@ set_bus!(value::InterconnectingConverter, val) = value.bus = val
 set_dc_bus!(value::InterconnectingConverter, val) = value.dc_bus = val
 """Set [`InterconnectingConverter`](@ref) `active_power`."""
 set_active_power!(value::InterconnectingConverter, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::InterconnectingConverter, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`InterconnectingConverter`](@ref) `rating`."""
 set_rating!(value::InterconnectingConverter, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::InterconnectingConverter, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`InterconnectingConverter`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::InterconnectingConverter, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
-set_active_power_limits!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
-set_active_power_limits!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::InterconnectingConverter, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::InterconnectingConverter, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`InterconnectingConverter`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::InterconnectingConverter, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::InterconnectingConverter, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::InterconnectingConverter, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`InterconnectingConverter`](@ref) `dc_current`."""
 set_dc_current!(value::InterconnectingConverter, val) = value.dc_current = set_value(value, Val(:dc_current), val, Val(:mva))
-set_dc_current!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_dc_current!, value, :dc_current, Val(:mva), val)
-set_dc_current!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_dc_current!, value, :dc_current, Val(:mva), val)
+set_dc_current!(value::InterconnectingConverter, val::_UntaggedNumber) = _units_tag_required(set_dc_current!, value, :dc_current, Val(:mva), val)
 """Set [`InterconnectingConverter`](@ref) `max_dc_current`."""
 set_max_dc_current!(value::InterconnectingConverter, val) = value.max_dc_current = set_value(value, Val(:max_dc_current), val, Val(:mva))
-set_max_dc_current!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_max_dc_current!, value, :max_dc_current, Val(:mva), val)
-set_max_dc_current!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_dc_current!, value, :max_dc_current, Val(:mva), val)
+set_max_dc_current!(value::InterconnectingConverter, val::_UntaggedNumber) = _units_tag_required(set_max_dc_current!, value, :max_dc_current, Val(:mva), val)
 """Set [`InterconnectingConverter`](@ref) `loss_function`."""
 set_loss_function!(value::InterconnectingConverter, val) = value.loss_function = val
 """Set [`InterconnectingConverter`](@ref) `dc_control`."""

--- a/src/models/generated/InterconnectingConverter.jl
+++ b/src/models/generated/InterconnectingConverter.jl
@@ -165,18 +165,24 @@ get_dc_bus(value::InterconnectingConverter) = value.dc_bus
 get_active_power(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`InterconnectingConverter`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::InterconnectingConverter) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::InterconnectingConverter) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 """Get [`InterconnectingConverter`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`InterconnectingConverter`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::InterconnectingConverter) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::InterconnectingConverter) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{InterconnectingConverter}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.DU
 """Get [`InterconnectingConverter`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mw), units))
 """Get [`InterconnectingConverter`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""
 get_active_power_limits_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:active_power_limits), Val(:mw), units)
+get_active_power_limits(value::InterconnectingConverter) = _units_arg_required(get_active_power_limits, value, :active_power_limits, Val(:mw))
+get_active_power_limits_unitful(value::InterconnectingConverter) = _units_arg_required(get_active_power_limits_unitful, value, :active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 
@@ -185,18 +191,24 @@ _get_base_power(value::InterconnectingConverter) = value.base_power
 get_reactive_power_limits(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`InterconnectingConverter`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::InterconnectingConverter) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::InterconnectingConverter) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 """Get [`InterconnectingConverter`](@ref) `dc_current` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_dc_current_unitful`](@ref)."""
 get_dc_current(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:dc_current), Val(:mva), units))
 """Get [`InterconnectingConverter`](@ref) `dc_current` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_dc_current`](@ref)."""
 get_dc_current_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:dc_current), Val(:mva), units)
+get_dc_current(value::InterconnectingConverter) = _units_arg_required(get_dc_current, value, :dc_current, Val(:mva))
+get_dc_current_unitful(value::InterconnectingConverter) = _units_arg_required(get_dc_current_unitful, value, :dc_current, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_dc_current), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_dc_current_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 """Get [`InterconnectingConverter`](@ref) `max_dc_current` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_dc_current_unitful`](@ref)."""
 get_max_dc_current(value::InterconnectingConverter, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_dc_current), Val(:mva), units))
 """Get [`InterconnectingConverter`](@ref) `max_dc_current` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_dc_current`](@ref)."""
 get_max_dc_current_unitful(value::InterconnectingConverter, units) = get_value(value, Val(:max_dc_current), Val(:mva), units)
+get_max_dc_current(value::InterconnectingConverter) = _units_arg_required(get_max_dc_current, value, :max_dc_current, Val(:mva))
+get_max_dc_current_unitful(value::InterconnectingConverter) = _units_arg_required(get_max_dc_current_unitful, value, :max_dc_current, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_max_dc_current), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_dc_current_unitful), ::Type{InterconnectingConverter}) = InfrastructureSystems.SU
 """Get [`InterconnectingConverter`](@ref) `loss_function`."""
@@ -236,16 +248,28 @@ set_bus!(value::InterconnectingConverter, val) = value.bus = val
 set_dc_bus!(value::InterconnectingConverter, val) = value.dc_bus = val
 """Set [`InterconnectingConverter`](@ref) `active_power`."""
 set_active_power!(value::InterconnectingConverter, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`InterconnectingConverter`](@ref) `rating`."""
 set_rating!(value::InterconnectingConverter, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`InterconnectingConverter`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::InterconnectingConverter, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
+set_active_power_limits!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`InterconnectingConverter`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::InterconnectingConverter, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`InterconnectingConverter`](@ref) `dc_current`."""
 set_dc_current!(value::InterconnectingConverter, val) = value.dc_current = set_value(value, Val(:dc_current), val, Val(:mva))
+set_dc_current!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_dc_current!, value, :dc_current, Val(:mva), val)
+set_dc_current!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_dc_current!, value, :dc_current, Val(:mva), val)
 """Set [`InterconnectingConverter`](@ref) `max_dc_current`."""
 set_max_dc_current!(value::InterconnectingConverter, val) = value.max_dc_current = set_value(value, Val(:max_dc_current), val, Val(:mva))
+set_max_dc_current!(value::InterconnectingConverter, val::Real) = _units_tag_required(set_max_dc_current!, value, :max_dc_current, Val(:mva), val)
+set_max_dc_current!(value::InterconnectingConverter, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_dc_current!, value, :max_dc_current, Val(:mva), val)
 """Set [`InterconnectingConverter`](@ref) `loss_function`."""
 set_loss_function!(value::InterconnectingConverter, val) = value.loss_function = val
 """Set [`InterconnectingConverter`](@ref) `dc_control`."""

--- a/src/models/generated/InterruptiblePowerLoad.jl
+++ b/src/models/generated/InterruptiblePowerLoad.jl
@@ -110,24 +110,32 @@ get_bus(value::InterruptiblePowerLoad) = value.bus
 get_active_power(value::InterruptiblePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`InterruptiblePowerLoad`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::InterruptiblePowerLoad, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::InterruptiblePowerLoad) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::InterruptiblePowerLoad) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{InterruptiblePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{InterruptiblePowerLoad}) = InfrastructureSystems.SU
 """Get [`InterruptiblePowerLoad`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::InterruptiblePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`InterruptiblePowerLoad`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::InterruptiblePowerLoad, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::InterruptiblePowerLoad) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::InterruptiblePowerLoad) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{InterruptiblePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{InterruptiblePowerLoad}) = InfrastructureSystems.SU
 """Get [`InterruptiblePowerLoad`](@ref) `max_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_active_power_unitful`](@ref)."""
 get_max_active_power(value::InterruptiblePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_active_power), Val(:mw), units))
 """Get [`InterruptiblePowerLoad`](@ref) `max_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_active_power`](@ref)."""
 get_max_active_power_unitful(value::InterruptiblePowerLoad, units) = get_value(value, Val(:max_active_power), Val(:mw), units)
+get_max_active_power(value::InterruptiblePowerLoad) = _units_arg_required(get_max_active_power, value, :max_active_power, Val(:mw))
+get_max_active_power_unitful(value::InterruptiblePowerLoad) = _units_arg_required(get_max_active_power_unitful, value, :max_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power), ::Type{InterruptiblePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power_unitful), ::Type{InterruptiblePowerLoad}) = InfrastructureSystems.SU
 """Get [`InterruptiblePowerLoad`](@ref) `max_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_reactive_power_unitful`](@ref)."""
 get_max_reactive_power(value::InterruptiblePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_reactive_power), Val(:mvar), units))
 """Get [`InterruptiblePowerLoad`](@ref) `max_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_reactive_power`](@ref)."""
 get_max_reactive_power_unitful(value::InterruptiblePowerLoad, units) = get_value(value, Val(:max_reactive_power), Val(:mvar), units)
+get_max_reactive_power(value::InterruptiblePowerLoad) = _units_arg_required(get_max_reactive_power, value, :max_reactive_power, Val(:mvar))
+get_max_reactive_power_unitful(value::InterruptiblePowerLoad) = _units_arg_required(get_max_reactive_power_unitful, value, :max_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power), ::Type{InterruptiblePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power_unitful), ::Type{InterruptiblePowerLoad}) = InfrastructureSystems.SU
 
@@ -151,12 +159,20 @@ set_available!(value::InterruptiblePowerLoad, val) = value.available = val
 set_bus!(value::InterruptiblePowerLoad, val) = value.bus = val
 """Set [`InterruptiblePowerLoad`](@ref) `active_power`."""
 set_active_power!(value::InterruptiblePowerLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::InterruptiblePowerLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::InterruptiblePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`InterruptiblePowerLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::InterruptiblePowerLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::InterruptiblePowerLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::InterruptiblePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`InterruptiblePowerLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::InterruptiblePowerLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
+set_max_active_power!(value::InterruptiblePowerLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::InterruptiblePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`InterruptiblePowerLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::InterruptiblePowerLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
+set_max_reactive_power!(value::InterruptiblePowerLoad, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::InterruptiblePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`InterruptiblePowerLoad`](@ref) `operation_cost`."""
 set_operation_cost!(value::InterruptiblePowerLoad, val) = value.operation_cost = val
 """Set [`InterruptiblePowerLoad`](@ref) `conformity`."""

--- a/src/models/generated/InterruptiblePowerLoad.jl
+++ b/src/models/generated/InterruptiblePowerLoad.jl
@@ -159,20 +159,16 @@ set_available!(value::InterruptiblePowerLoad, val) = value.available = val
 set_bus!(value::InterruptiblePowerLoad, val) = value.bus = val
 """Set [`InterruptiblePowerLoad`](@ref) `active_power`."""
 set_active_power!(value::InterruptiblePowerLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::InterruptiblePowerLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::InterruptiblePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::InterruptiblePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`InterruptiblePowerLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::InterruptiblePowerLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::InterruptiblePowerLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::InterruptiblePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::InterruptiblePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`InterruptiblePowerLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::InterruptiblePowerLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
-set_max_active_power!(value::InterruptiblePowerLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
-set_max_active_power!(value::InterruptiblePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::InterruptiblePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`InterruptiblePowerLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::InterruptiblePowerLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
-set_max_reactive_power!(value::InterruptiblePowerLoad, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
-set_max_reactive_power!(value::InterruptiblePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::InterruptiblePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`InterruptiblePowerLoad`](@ref) `operation_cost`."""
 set_operation_cost!(value::InterruptiblePowerLoad, val) = value.operation_cost = val
 """Set [`InterruptiblePowerLoad`](@ref) `conformity`."""

--- a/src/models/generated/InterruptibleStandardLoad.jl
+++ b/src/models/generated/InterruptibleStandardLoad.jl
@@ -158,72 +158,96 @@ get_conformity(value::InterruptibleStandardLoad) = value.conformity
 get_constant_active_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:constant_active_power), Val(:mw), units))
 """Get [`InterruptibleStandardLoad`](@ref) `constant_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_constant_active_power`](@ref)."""
 get_constant_active_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:constant_active_power), Val(:mw), units)
+get_constant_active_power(value::InterruptibleStandardLoad) = _units_arg_required(get_constant_active_power, value, :constant_active_power, Val(:mw))
+get_constant_active_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_constant_active_power_unitful, value, :constant_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_constant_active_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_constant_active_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `constant_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_constant_reactive_power_unitful`](@ref)."""
 get_constant_reactive_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:constant_reactive_power), Val(:mvar), units))
 """Get [`InterruptibleStandardLoad`](@ref) `constant_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_constant_reactive_power`](@ref)."""
 get_constant_reactive_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:constant_reactive_power), Val(:mvar), units)
+get_constant_reactive_power(value::InterruptibleStandardLoad) = _units_arg_required(get_constant_reactive_power, value, :constant_reactive_power, Val(:mvar))
+get_constant_reactive_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_constant_reactive_power_unitful, value, :constant_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_constant_reactive_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_constant_reactive_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `impedance_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_impedance_active_power_unitful`](@ref)."""
 get_impedance_active_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:impedance_active_power), Val(:mw), units))
 """Get [`InterruptibleStandardLoad`](@ref) `impedance_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_impedance_active_power`](@ref)."""
 get_impedance_active_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:impedance_active_power), Val(:mw), units)
+get_impedance_active_power(value::InterruptibleStandardLoad) = _units_arg_required(get_impedance_active_power, value, :impedance_active_power, Val(:mw))
+get_impedance_active_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_impedance_active_power_unitful, value, :impedance_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_impedance_active_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_impedance_active_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `impedance_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_impedance_reactive_power_unitful`](@ref)."""
 get_impedance_reactive_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:impedance_reactive_power), Val(:mvar), units))
 """Get [`InterruptibleStandardLoad`](@ref) `impedance_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_impedance_reactive_power`](@ref)."""
 get_impedance_reactive_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:impedance_reactive_power), Val(:mvar), units)
+get_impedance_reactive_power(value::InterruptibleStandardLoad) = _units_arg_required(get_impedance_reactive_power, value, :impedance_reactive_power, Val(:mvar))
+get_impedance_reactive_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_impedance_reactive_power_unitful, value, :impedance_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_impedance_reactive_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_impedance_reactive_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `current_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_current_active_power_unitful`](@ref)."""
 get_current_active_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:current_active_power), Val(:mw), units))
 """Get [`InterruptibleStandardLoad`](@ref) `current_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_current_active_power`](@ref)."""
 get_current_active_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:current_active_power), Val(:mw), units)
+get_current_active_power(value::InterruptibleStandardLoad) = _units_arg_required(get_current_active_power, value, :current_active_power, Val(:mw))
+get_current_active_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_current_active_power_unitful, value, :current_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_current_active_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_current_active_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `current_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_current_reactive_power_unitful`](@ref)."""
 get_current_reactive_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:current_reactive_power), Val(:mvar), units))
 """Get [`InterruptibleStandardLoad`](@ref) `current_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_current_reactive_power`](@ref)."""
 get_current_reactive_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:current_reactive_power), Val(:mvar), units)
+get_current_reactive_power(value::InterruptibleStandardLoad) = _units_arg_required(get_current_reactive_power, value, :current_reactive_power, Val(:mvar))
+get_current_reactive_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_current_reactive_power_unitful, value, :current_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_current_reactive_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_current_reactive_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `max_constant_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_constant_active_power_unitful`](@ref)."""
 get_max_constant_active_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_constant_active_power), Val(:mw), units))
 """Get [`InterruptibleStandardLoad`](@ref) `max_constant_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_constant_active_power`](@ref)."""
 get_max_constant_active_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:max_constant_active_power), Val(:mw), units)
+get_max_constant_active_power(value::InterruptibleStandardLoad) = _units_arg_required(get_max_constant_active_power, value, :max_constant_active_power, Val(:mw))
+get_max_constant_active_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_max_constant_active_power_unitful, value, :max_constant_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_constant_active_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_constant_active_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `max_constant_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_constant_reactive_power_unitful`](@ref)."""
 get_max_constant_reactive_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_constant_reactive_power), Val(:mvar), units))
 """Get [`InterruptibleStandardLoad`](@ref) `max_constant_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_constant_reactive_power`](@ref)."""
 get_max_constant_reactive_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:max_constant_reactive_power), Val(:mvar), units)
+get_max_constant_reactive_power(value::InterruptibleStandardLoad) = _units_arg_required(get_max_constant_reactive_power, value, :max_constant_reactive_power, Val(:mvar))
+get_max_constant_reactive_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_max_constant_reactive_power_unitful, value, :max_constant_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_constant_reactive_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_constant_reactive_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `max_impedance_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_impedance_active_power_unitful`](@ref)."""
 get_max_impedance_active_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_impedance_active_power), Val(:mw), units))
 """Get [`InterruptibleStandardLoad`](@ref) `max_impedance_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_impedance_active_power`](@ref)."""
 get_max_impedance_active_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:max_impedance_active_power), Val(:mw), units)
+get_max_impedance_active_power(value::InterruptibleStandardLoad) = _units_arg_required(get_max_impedance_active_power, value, :max_impedance_active_power, Val(:mw))
+get_max_impedance_active_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_max_impedance_active_power_unitful, value, :max_impedance_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_impedance_active_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_impedance_active_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `max_impedance_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_impedance_reactive_power_unitful`](@ref)."""
 get_max_impedance_reactive_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_impedance_reactive_power), Val(:mvar), units))
 """Get [`InterruptibleStandardLoad`](@ref) `max_impedance_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_impedance_reactive_power`](@ref)."""
 get_max_impedance_reactive_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:max_impedance_reactive_power), Val(:mvar), units)
+get_max_impedance_reactive_power(value::InterruptibleStandardLoad) = _units_arg_required(get_max_impedance_reactive_power, value, :max_impedance_reactive_power, Val(:mvar))
+get_max_impedance_reactive_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_max_impedance_reactive_power_unitful, value, :max_impedance_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_impedance_reactive_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_impedance_reactive_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `max_current_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_current_active_power_unitful`](@ref)."""
 get_max_current_active_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_current_active_power), Val(:mw), units))
 """Get [`InterruptibleStandardLoad`](@ref) `max_current_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_current_active_power`](@ref)."""
 get_max_current_active_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:max_current_active_power), Val(:mw), units)
+get_max_current_active_power(value::InterruptibleStandardLoad) = _units_arg_required(get_max_current_active_power, value, :max_current_active_power, Val(:mw))
+get_max_current_active_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_max_current_active_power_unitful, value, :max_current_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_current_active_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_current_active_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `max_current_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_current_reactive_power_unitful`](@ref)."""
 get_max_current_reactive_power(value::InterruptibleStandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_current_reactive_power), Val(:mvar), units))
 """Get [`InterruptibleStandardLoad`](@ref) `max_current_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_current_reactive_power`](@ref)."""
 get_max_current_reactive_power_unitful(value::InterruptibleStandardLoad, units) = get_value(value, Val(:max_current_reactive_power), Val(:mvar), units)
+get_max_current_reactive_power(value::InterruptibleStandardLoad) = _units_arg_required(get_max_current_reactive_power, value, :max_current_reactive_power, Val(:mvar))
+get_max_current_reactive_power_unitful(value::InterruptibleStandardLoad) = _units_arg_required(get_max_current_reactive_power_unitful, value, :max_current_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_current_reactive_power), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_current_reactive_power_unitful), ::Type{InterruptibleStandardLoad}) = InfrastructureSystems.SU
 """Get [`InterruptibleStandardLoad`](@ref) `services`."""
@@ -245,28 +269,52 @@ set_operation_cost!(value::InterruptibleStandardLoad, val) = value.operation_cos
 set_conformity!(value::InterruptibleStandardLoad, val) = value.conformity = val
 """Set [`InterruptibleStandardLoad`](@ref) `constant_active_power`."""
 set_constant_active_power!(value::InterruptibleStandardLoad, val) = value.constant_active_power = set_value(value, Val(:constant_active_power), val, Val(:mw))
+set_constant_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
+set_constant_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `constant_reactive_power`."""
 set_constant_reactive_power!(value::InterruptibleStandardLoad, val) = value.constant_reactive_power = set_value(value, Val(:constant_reactive_power), val, Val(:mvar))
+set_constant_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
+set_constant_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `impedance_active_power`."""
 set_impedance_active_power!(value::InterruptibleStandardLoad, val) = value.impedance_active_power = set_value(value, Val(:impedance_active_power), val, Val(:mw))
+set_impedance_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
+set_impedance_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `impedance_reactive_power`."""
 set_impedance_reactive_power!(value::InterruptibleStandardLoad, val) = value.impedance_reactive_power = set_value(value, Val(:impedance_reactive_power), val, Val(:mvar))
+set_impedance_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
+set_impedance_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `current_active_power`."""
 set_current_active_power!(value::InterruptibleStandardLoad, val) = value.current_active_power = set_value(value, Val(:current_active_power), val, Val(:mw))
+set_current_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
+set_current_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `current_reactive_power`."""
 set_current_reactive_power!(value::InterruptibleStandardLoad, val) = value.current_reactive_power = set_value(value, Val(:current_reactive_power), val, Val(:mvar))
+set_current_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
+set_current_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_constant_active_power`."""
 set_max_constant_active_power!(value::InterruptibleStandardLoad, val) = value.max_constant_active_power = set_value(value, Val(:max_constant_active_power), val, Val(:mw))
+set_max_constant_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
+set_max_constant_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_constant_reactive_power`."""
 set_max_constant_reactive_power!(value::InterruptibleStandardLoad, val) = value.max_constant_reactive_power = set_value(value, Val(:max_constant_reactive_power), val, Val(:mvar))
+set_max_constant_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
+set_max_constant_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_impedance_active_power`."""
 set_max_impedance_active_power!(value::InterruptibleStandardLoad, val) = value.max_impedance_active_power = set_value(value, Val(:max_impedance_active_power), val, Val(:mw))
+set_max_impedance_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
+set_max_impedance_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_impedance_reactive_power`."""
 set_max_impedance_reactive_power!(value::InterruptibleStandardLoad, val) = value.max_impedance_reactive_power = set_value(value, Val(:max_impedance_reactive_power), val, Val(:mvar))
+set_max_impedance_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
+set_max_impedance_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_current_active_power`."""
 set_max_current_active_power!(value::InterruptibleStandardLoad, val) = value.max_current_active_power = set_value(value, Val(:max_current_active_power), val, Val(:mw))
+set_max_current_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
+set_max_current_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_current_reactive_power`."""
 set_max_current_reactive_power!(value::InterruptibleStandardLoad, val) = value.max_current_reactive_power = set_value(value, Val(:max_current_reactive_power), val, Val(:mvar))
+set_max_current_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
+set_max_current_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `services`."""
 set_services!(value::InterruptibleStandardLoad, val) = value.services = val
 """Set [`InterruptibleStandardLoad`](@ref) `ext`."""

--- a/src/models/generated/InterruptibleStandardLoad.jl
+++ b/src/models/generated/InterruptibleStandardLoad.jl
@@ -269,52 +269,40 @@ set_operation_cost!(value::InterruptibleStandardLoad, val) = value.operation_cos
 set_conformity!(value::InterruptibleStandardLoad, val) = value.conformity = val
 """Set [`InterruptibleStandardLoad`](@ref) `constant_active_power`."""
 set_constant_active_power!(value::InterruptibleStandardLoad, val) = value.constant_active_power = set_value(value, Val(:constant_active_power), val, Val(:mw))
-set_constant_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
-set_constant_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
+set_constant_active_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `constant_reactive_power`."""
 set_constant_reactive_power!(value::InterruptibleStandardLoad, val) = value.constant_reactive_power = set_value(value, Val(:constant_reactive_power), val, Val(:mvar))
-set_constant_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
-set_constant_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
+set_constant_reactive_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `impedance_active_power`."""
 set_impedance_active_power!(value::InterruptibleStandardLoad, val) = value.impedance_active_power = set_value(value, Val(:impedance_active_power), val, Val(:mw))
-set_impedance_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
-set_impedance_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
+set_impedance_active_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `impedance_reactive_power`."""
 set_impedance_reactive_power!(value::InterruptibleStandardLoad, val) = value.impedance_reactive_power = set_value(value, Val(:impedance_reactive_power), val, Val(:mvar))
-set_impedance_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
-set_impedance_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
+set_impedance_reactive_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `current_active_power`."""
 set_current_active_power!(value::InterruptibleStandardLoad, val) = value.current_active_power = set_value(value, Val(:current_active_power), val, Val(:mw))
-set_current_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
-set_current_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
+set_current_active_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `current_reactive_power`."""
 set_current_reactive_power!(value::InterruptibleStandardLoad, val) = value.current_reactive_power = set_value(value, Val(:current_reactive_power), val, Val(:mvar))
-set_current_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
-set_current_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
+set_current_reactive_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_constant_active_power`."""
 set_max_constant_active_power!(value::InterruptibleStandardLoad, val) = value.max_constant_active_power = set_value(value, Val(:max_constant_active_power), val, Val(:mw))
-set_max_constant_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
-set_max_constant_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
+set_max_constant_active_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_constant_reactive_power`."""
 set_max_constant_reactive_power!(value::InterruptibleStandardLoad, val) = value.max_constant_reactive_power = set_value(value, Val(:max_constant_reactive_power), val, Val(:mvar))
-set_max_constant_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
-set_max_constant_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
+set_max_constant_reactive_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_impedance_active_power`."""
 set_max_impedance_active_power!(value::InterruptibleStandardLoad, val) = value.max_impedance_active_power = set_value(value, Val(:max_impedance_active_power), val, Val(:mw))
-set_max_impedance_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
-set_max_impedance_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
+set_max_impedance_active_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_impedance_reactive_power`."""
 set_max_impedance_reactive_power!(value::InterruptibleStandardLoad, val) = value.max_impedance_reactive_power = set_value(value, Val(:max_impedance_reactive_power), val, Val(:mvar))
-set_max_impedance_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
-set_max_impedance_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
+set_max_impedance_reactive_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_current_active_power`."""
 set_max_current_active_power!(value::InterruptibleStandardLoad, val) = value.max_current_active_power = set_value(value, Val(:max_current_active_power), val, Val(:mw))
-set_max_current_active_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
-set_max_current_active_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
+set_max_current_active_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
 """Set [`InterruptibleStandardLoad`](@ref) `max_current_reactive_power`."""
 set_max_current_reactive_power!(value::InterruptibleStandardLoad, val) = value.max_current_reactive_power = set_value(value, Val(:max_current_reactive_power), val, Val(:mvar))
-set_max_current_reactive_power!(value::InterruptibleStandardLoad, val::Real) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
-set_max_current_reactive_power!(value::InterruptibleStandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
+set_max_current_reactive_power!(value::InterruptibleStandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
 """Set [`InterruptibleStandardLoad`](@ref) `services`."""
 set_services!(value::InterruptibleStandardLoad, val) = value.services = val
 """Set [`InterruptibleStandardLoad`](@ref) `ext`."""

--- a/src/models/generated/Line.jl
+++ b/src/models/generated/Line.jl
@@ -206,44 +206,37 @@ get_internal(value::Line) = value.internal
 set_available!(value::Line, val) = value.available = val
 """Set [`Line`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::Line, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::Line, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`Line`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::Line, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
-set_reactive_power_flow!(value::Line, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
-set_reactive_power_flow!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`Line`](@ref) `arc`."""
 set_arc!(value::Line, val) = value.arc = val
 """Set [`Line`](@ref) `r`."""
 set_r!(value::Line, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
-set_r!(value::Line, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
-set_r!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`Line`](@ref) `x`."""
 set_x!(value::Line, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
-set_x!(value::Line, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
-set_x!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`Line`](@ref) `b`."""
 set_b!(value::Line, val) = value.b = set_value(value, Val(:b), val, Val(:siemens))
-set_b!(value::Line, val::Real) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
-set_b!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
+set_b!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
+set_b!(value::Line, val::NamedTuple{(:from, :to), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
 """Set [`Line`](@ref) `rating`."""
 set_rating!(value::Line, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::Line, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`Line`](@ref) `angle_limits`."""
 set_angle_limits!(value::Line, val) = value.angle_limits = val
 """Set [`Line`](@ref) `rating_b`."""
 set_rating_b!(value::Line, val) = value.rating_b = set_value(value, Val(:rating_b), val, Val(:mva))
-set_rating_b!(value::Line, val::Real) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
-set_rating_b!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
+set_rating_b!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
 """Set [`Line`](@ref) `rating_c`."""
 set_rating_c!(value::Line, val) = value.rating_c = set_value(value, Val(:rating_c), val, Val(:mva))
-set_rating_c!(value::Line, val::Real) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
-set_rating_c!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
+set_rating_c!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
 """Set [`Line`](@ref) `g`."""
 set_g!(value::Line, val) = value.g = set_value(value, Val(:g), val, Val(:siemens))
-set_g!(value::Line, val::Real) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
-set_g!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
+set_g!(value::Line, val::_UntaggedNumber) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
+set_g!(value::Line, val::NamedTuple{(:from, :to), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
 """Set [`Line`](@ref) `services`."""
 set_services!(value::Line, val) = value.services = val
 """Set [`Line`](@ref) `ext`."""

--- a/src/models/generated/Line.jl
+++ b/src/models/generated/Line.jl
@@ -121,12 +121,16 @@ get_available(value::Line) = value.available
 get_active_power_flow(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`Line`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::Line, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::Line) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::Line) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{Line}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{Line}) = InfrastructureSystems.SU
 """Get [`Line`](@ref) `reactive_power_flow` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_flow_unitful`](@ref)."""
 get_reactive_power_flow(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_flow), Val(:mvar), units))
 """Get [`Line`](@ref) `reactive_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_flow`](@ref)."""
 get_reactive_power_flow_unitful(value::Line, units) = get_value(value, Val(:reactive_power_flow), Val(:mvar), units)
+get_reactive_power_flow(value::Line) = _units_arg_required(get_reactive_power_flow, value, :reactive_power_flow, Val(:mvar))
+get_reactive_power_flow_unitful(value::Line) = _units_arg_required(get_reactive_power_flow_unitful, value, :reactive_power_flow, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow), ::Type{Line}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow_unitful), ::Type{Line}) = InfrastructureSystems.SU
 """Get [`Line`](@ref) `arc`."""
@@ -135,24 +139,32 @@ get_arc(value::Line) = value.arc
 get_r(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r), Val(:ohm), units))
 """Get [`Line`](@ref) `r` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r`](@ref)."""
 get_r_unitful(value::Line, units) = get_value(value, Val(:r), Val(:ohm), units)
+get_r(value::Line) = _units_arg_required(get_r, value, :r, Val(:ohm))
+get_r_unitful(value::Line) = _units_arg_required(get_r_unitful, value, :r, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_r), ::Type{Line}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_r_unitful), ::Type{Line}) = InfrastructureSystems.SU
 """Get [`Line`](@ref) `x` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_x_unitful`](@ref)."""
 get_x(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:x), Val(:ohm), units))
 """Get [`Line`](@ref) `x` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_x`](@ref)."""
 get_x_unitful(value::Line, units) = get_value(value, Val(:x), Val(:ohm), units)
+get_x(value::Line) = _units_arg_required(get_x, value, :x, Val(:ohm))
+get_x_unitful(value::Line) = _units_arg_required(get_x_unitful, value, :x, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_x), ::Type{Line}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_x_unitful), ::Type{Line}) = InfrastructureSystems.SU
 """Get [`Line`](@ref) `b` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_b_unitful`](@ref)."""
 get_b(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:b), Val(:siemens), units))
 """Get [`Line`](@ref) `b` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_b`](@ref)."""
 get_b_unitful(value::Line, units) = get_value(value, Val(:b), Val(:siemens), units)
+get_b(value::Line) = _units_arg_required(get_b, value, :b, Val(:siemens))
+get_b_unitful(value::Line) = _units_arg_required(get_b_unitful, value, :b, Val(:siemens))
 InfrastructureSystems.display_units_arg(::typeof(get_b), ::Type{Line}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_b_unitful), ::Type{Line}) = InfrastructureSystems.SU
 """Get [`Line`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`Line`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::Line, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::Line) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::Line) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{Line}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{Line}) = InfrastructureSystems.DU
 """Get [`Line`](@ref) `angle_limits`."""
@@ -161,18 +173,24 @@ get_angle_limits(value::Line) = value.angle_limits
 get_rating_b(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_b), Val(:mva), units))
 """Get [`Line`](@ref) `rating_b` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_b`](@ref)."""
 get_rating_b_unitful(value::Line, units) = get_value(value, Val(:rating_b), Val(:mva), units)
+get_rating_b(value::Line) = _units_arg_required(get_rating_b, value, :rating_b, Val(:mva))
+get_rating_b_unitful(value::Line) = _units_arg_required(get_rating_b_unitful, value, :rating_b, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating_b), ::Type{Line}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_b_unitful), ::Type{Line}) = InfrastructureSystems.SU
 """Get [`Line`](@ref) `rating_c` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_c_unitful`](@ref)."""
 get_rating_c(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_c), Val(:mva), units))
 """Get [`Line`](@ref) `rating_c` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_c`](@ref)."""
 get_rating_c_unitful(value::Line, units) = get_value(value, Val(:rating_c), Val(:mva), units)
+get_rating_c(value::Line) = _units_arg_required(get_rating_c, value, :rating_c, Val(:mva))
+get_rating_c_unitful(value::Line) = _units_arg_required(get_rating_c_unitful, value, :rating_c, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating_c), ::Type{Line}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_c_unitful), ::Type{Line}) = InfrastructureSystems.SU
 """Get [`Line`](@ref) `g` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_g_unitful`](@ref)."""
 get_g(value::Line, units) = InfrastructureSystems._strip_units(get_value(value, Val(:g), Val(:siemens), units))
 """Get [`Line`](@ref) `g` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_g`](@ref)."""
 get_g_unitful(value::Line, units) = get_value(value, Val(:g), Val(:siemens), units)
+get_g(value::Line) = _units_arg_required(get_g, value, :g, Val(:siemens))
+get_g_unitful(value::Line) = _units_arg_required(get_g_unitful, value, :g, Val(:siemens))
 InfrastructureSystems.display_units_arg(::typeof(get_g), ::Type{Line}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_g_unitful), ::Type{Line}) = InfrastructureSystems.SU
 """Get [`Line`](@ref) `services`."""
@@ -188,26 +206,44 @@ get_internal(value::Line) = value.internal
 set_available!(value::Line, val) = value.available = val
 """Set [`Line`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::Line, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::Line, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`Line`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::Line, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
+set_reactive_power_flow!(value::Line, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`Line`](@ref) `arc`."""
 set_arc!(value::Line, val) = value.arc = val
 """Set [`Line`](@ref) `r`."""
 set_r!(value::Line, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
+set_r!(value::Line, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`Line`](@ref) `x`."""
 set_x!(value::Line, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
+set_x!(value::Line, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`Line`](@ref) `b`."""
 set_b!(value::Line, val) = value.b = set_value(value, Val(:b), val, Val(:siemens))
+set_b!(value::Line, val::Real) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
+set_b!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
 """Set [`Line`](@ref) `rating`."""
 set_rating!(value::Line, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::Line, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`Line`](@ref) `angle_limits`."""
 set_angle_limits!(value::Line, val) = value.angle_limits = val
 """Set [`Line`](@ref) `rating_b`."""
 set_rating_b!(value::Line, val) = value.rating_b = set_value(value, Val(:rating_b), val, Val(:mva))
+set_rating_b!(value::Line, val::Real) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
+set_rating_b!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
 """Set [`Line`](@ref) `rating_c`."""
 set_rating_c!(value::Line, val) = value.rating_c = set_value(value, Val(:rating_c), val, Val(:mva))
+set_rating_c!(value::Line, val::Real) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
+set_rating_c!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
 """Set [`Line`](@ref) `g`."""
 set_g!(value::Line, val) = value.g = set_value(value, Val(:g), val, Val(:siemens))
+set_g!(value::Line, val::Real) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
+set_g!(value::Line, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
 """Set [`Line`](@ref) `services`."""
 set_services!(value::Line, val) = value.services = val
 """Set [`Line`](@ref) `ext`."""

--- a/src/models/generated/LoadZone.jl
+++ b/src/models/generated/LoadZone.jl
@@ -66,12 +66,16 @@ get_name(value::LoadZone) = value.name
 get_peak_active_power(value::LoadZone, units) = InfrastructureSystems._strip_units(get_value(value, Val(:peak_active_power), Val(:mw), units))
 """Get [`LoadZone`](@ref) `peak_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_peak_active_power`](@ref)."""
 get_peak_active_power_unitful(value::LoadZone, units) = get_value(value, Val(:peak_active_power), Val(:mw), units)
+get_peak_active_power(value::LoadZone) = _units_arg_required(get_peak_active_power, value, :peak_active_power, Val(:mw))
+get_peak_active_power_unitful(value::LoadZone) = _units_arg_required(get_peak_active_power_unitful, value, :peak_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_peak_active_power), ::Type{LoadZone}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_peak_active_power_unitful), ::Type{LoadZone}) = InfrastructureSystems.SU
 """Get [`LoadZone`](@ref) `peak_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_peak_reactive_power_unitful`](@ref)."""
 get_peak_reactive_power(value::LoadZone, units) = InfrastructureSystems._strip_units(get_value(value, Val(:peak_reactive_power), Val(:mvar), units))
 """Get [`LoadZone`](@ref) `peak_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_peak_reactive_power`](@ref)."""
 get_peak_reactive_power_unitful(value::LoadZone, units) = get_value(value, Val(:peak_reactive_power), Val(:mvar), units)
+get_peak_reactive_power(value::LoadZone) = _units_arg_required(get_peak_reactive_power, value, :peak_reactive_power, Val(:mvar))
+get_peak_reactive_power_unitful(value::LoadZone) = _units_arg_required(get_peak_reactive_power_unitful, value, :peak_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_peak_reactive_power), ::Type{LoadZone}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_peak_reactive_power_unitful), ::Type{LoadZone}) = InfrastructureSystems.SU
 
@@ -83,7 +87,11 @@ get_internal(value::LoadZone) = value.internal
 
 """Set [`LoadZone`](@ref) `peak_active_power`."""
 set_peak_active_power!(value::LoadZone, val) = value.peak_active_power = set_value(value, Val(:peak_active_power), val, Val(:mw))
+set_peak_active_power!(value::LoadZone, val::Real) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
+set_peak_active_power!(value::LoadZone, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
 """Set [`LoadZone`](@ref) `peak_reactive_power`."""
 set_peak_reactive_power!(value::LoadZone, val) = value.peak_reactive_power = set_value(value, Val(:peak_reactive_power), val, Val(:mvar))
+set_peak_reactive_power!(value::LoadZone, val::Real) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
+set_peak_reactive_power!(value::LoadZone, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
 """Set [`LoadZone`](@ref) `ext`."""
 set_ext!(value::LoadZone, val) = value.ext = val

--- a/src/models/generated/LoadZone.jl
+++ b/src/models/generated/LoadZone.jl
@@ -87,11 +87,9 @@ get_internal(value::LoadZone) = value.internal
 
 """Set [`LoadZone`](@ref) `peak_active_power`."""
 set_peak_active_power!(value::LoadZone, val) = value.peak_active_power = set_value(value, Val(:peak_active_power), val, Val(:mw))
-set_peak_active_power!(value::LoadZone, val::Real) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
-set_peak_active_power!(value::LoadZone, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
+set_peak_active_power!(value::LoadZone, val::_UntaggedNumber) = _units_tag_required(set_peak_active_power!, value, :peak_active_power, Val(:mw), val)
 """Set [`LoadZone`](@ref) `peak_reactive_power`."""
 set_peak_reactive_power!(value::LoadZone, val) = value.peak_reactive_power = set_value(value, Val(:peak_reactive_power), val, Val(:mvar))
-set_peak_reactive_power!(value::LoadZone, val::Real) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
-set_peak_reactive_power!(value::LoadZone, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
+set_peak_reactive_power!(value::LoadZone, val::_UntaggedNumber) = _units_tag_required(set_peak_reactive_power!, value, :peak_reactive_power, Val(:mvar), val)
 """Set [`LoadZone`](@ref) `ext`."""
 set_ext!(value::LoadZone, val) = value.ext = val

--- a/src/models/generated/MonitoredLine.jl
+++ b/src/models/generated/MonitoredLine.jl
@@ -221,48 +221,41 @@ get_internal(value::MonitoredLine) = value.internal
 set_available!(value::MonitoredLine, val) = value.available = val
 """Set [`MonitoredLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::MonitoredLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::MonitoredLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`MonitoredLine`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::MonitoredLine, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
-set_reactive_power_flow!(value::MonitoredLine, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
-set_reactive_power_flow!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`MonitoredLine`](@ref) `arc`."""
 set_arc!(value::MonitoredLine, val) = value.arc = val
 """Set [`MonitoredLine`](@ref) `r`."""
 set_r!(value::MonitoredLine, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
-set_r!(value::MonitoredLine, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
-set_r!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`MonitoredLine`](@ref) `x`."""
 set_x!(value::MonitoredLine, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
-set_x!(value::MonitoredLine, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
-set_x!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`MonitoredLine`](@ref) `b`."""
 set_b!(value::MonitoredLine, val) = value.b = set_value(value, Val(:b), val, Val(:siemens))
-set_b!(value::MonitoredLine, val::Real) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
-set_b!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
+set_b!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
+set_b!(value::MonitoredLine, val::NamedTuple{(:from, :to), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
 """Set [`MonitoredLine`](@ref) `flow_limits`."""
 set_flow_limits!(value::MonitoredLine, val) = value.flow_limits = set_value(value, Val(:flow_limits), val, Val(:mw))
-set_flow_limits!(value::MonitoredLine, val::Real) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
-set_flow_limits!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
+set_flow_limits!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
+set_flow_limits!(value::MonitoredLine, val::NamedTuple{(:from_to, :to_from), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
 """Set [`MonitoredLine`](@ref) `rating`."""
 set_rating!(value::MonitoredLine, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::MonitoredLine, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`MonitoredLine`](@ref) `angle_limits`."""
 set_angle_limits!(value::MonitoredLine, val) = value.angle_limits = val
 """Set [`MonitoredLine`](@ref) `rating_b`."""
 set_rating_b!(value::MonitoredLine, val) = value.rating_b = set_value(value, Val(:rating_b), val, Val(:mva))
-set_rating_b!(value::MonitoredLine, val::Real) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
-set_rating_b!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
+set_rating_b!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
 """Set [`MonitoredLine`](@ref) `rating_c`."""
 set_rating_c!(value::MonitoredLine, val) = value.rating_c = set_value(value, Val(:rating_c), val, Val(:mva))
-set_rating_c!(value::MonitoredLine, val::Real) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
-set_rating_c!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
+set_rating_c!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
 """Set [`MonitoredLine`](@ref) `g`."""
 set_g!(value::MonitoredLine, val) = value.g = set_value(value, Val(:g), val, Val(:siemens))
-set_g!(value::MonitoredLine, val::Real) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
-set_g!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
+set_g!(value::MonitoredLine, val::_UntaggedNumber) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
+set_g!(value::MonitoredLine, val::NamedTuple{(:from, :to), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
 """Set [`MonitoredLine`](@ref) `services`."""
 set_services!(value::MonitoredLine, val) = value.services = val
 """Set [`MonitoredLine`](@ref) `ext`."""

--- a/src/models/generated/MonitoredLine.jl
+++ b/src/models/generated/MonitoredLine.jl
@@ -128,12 +128,16 @@ get_available(value::MonitoredLine) = value.available
 get_active_power_flow(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`MonitoredLine`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::MonitoredLine, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::MonitoredLine) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::MonitoredLine) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `reactive_power_flow` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_flow_unitful`](@ref)."""
 get_reactive_power_flow(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_flow), Val(:mvar), units))
 """Get [`MonitoredLine`](@ref) `reactive_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_flow`](@ref)."""
 get_reactive_power_flow_unitful(value::MonitoredLine, units) = get_value(value, Val(:reactive_power_flow), Val(:mvar), units)
+get_reactive_power_flow(value::MonitoredLine) = _units_arg_required(get_reactive_power_flow, value, :reactive_power_flow, Val(:mvar))
+get_reactive_power_flow_unitful(value::MonitoredLine) = _units_arg_required(get_reactive_power_flow_unitful, value, :reactive_power_flow, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `arc`."""
@@ -142,30 +146,40 @@ get_arc(value::MonitoredLine) = value.arc
 get_r(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r), Val(:ohm), units))
 """Get [`MonitoredLine`](@ref) `r` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r`](@ref)."""
 get_r_unitful(value::MonitoredLine, units) = get_value(value, Val(:r), Val(:ohm), units)
+get_r(value::MonitoredLine) = _units_arg_required(get_r, value, :r, Val(:ohm))
+get_r_unitful(value::MonitoredLine) = _units_arg_required(get_r_unitful, value, :r, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_r), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_r_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `x` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_x_unitful`](@ref)."""
 get_x(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:x), Val(:ohm), units))
 """Get [`MonitoredLine`](@ref) `x` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_x`](@ref)."""
 get_x_unitful(value::MonitoredLine, units) = get_value(value, Val(:x), Val(:ohm), units)
+get_x(value::MonitoredLine) = _units_arg_required(get_x, value, :x, Val(:ohm))
+get_x_unitful(value::MonitoredLine) = _units_arg_required(get_x_unitful, value, :x, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_x), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_x_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `b` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_b_unitful`](@ref)."""
 get_b(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:b), Val(:siemens), units))
 """Get [`MonitoredLine`](@ref) `b` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_b`](@ref)."""
 get_b_unitful(value::MonitoredLine, units) = get_value(value, Val(:b), Val(:siemens), units)
+get_b(value::MonitoredLine) = _units_arg_required(get_b, value, :b, Val(:siemens))
+get_b_unitful(value::MonitoredLine) = _units_arg_required(get_b_unitful, value, :b, Val(:siemens))
 InfrastructureSystems.display_units_arg(::typeof(get_b), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_b_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `flow_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_flow_limits_unitful`](@ref)."""
 get_flow_limits(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:flow_limits), Val(:mw), units))
 """Get [`MonitoredLine`](@ref) `flow_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_flow_limits`](@ref)."""
 get_flow_limits_unitful(value::MonitoredLine, units) = get_value(value, Val(:flow_limits), Val(:mw), units)
+get_flow_limits(value::MonitoredLine) = _units_arg_required(get_flow_limits, value, :flow_limits, Val(:mw))
+get_flow_limits_unitful(value::MonitoredLine) = _units_arg_required(get_flow_limits_unitful, value, :flow_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_flow_limits), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_flow_limits_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`MonitoredLine`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::MonitoredLine, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::MonitoredLine) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::MonitoredLine) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{MonitoredLine}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.DU
 """Get [`MonitoredLine`](@ref) `angle_limits`."""
@@ -174,18 +188,24 @@ get_angle_limits(value::MonitoredLine) = value.angle_limits
 get_rating_b(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_b), Val(:mva), units))
 """Get [`MonitoredLine`](@ref) `rating_b` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_b`](@ref)."""
 get_rating_b_unitful(value::MonitoredLine, units) = get_value(value, Val(:rating_b), Val(:mva), units)
+get_rating_b(value::MonitoredLine) = _units_arg_required(get_rating_b, value, :rating_b, Val(:mva))
+get_rating_b_unitful(value::MonitoredLine) = _units_arg_required(get_rating_b_unitful, value, :rating_b, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating_b), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_b_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `rating_c` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_c_unitful`](@ref)."""
 get_rating_c(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_c), Val(:mva), units))
 """Get [`MonitoredLine`](@ref) `rating_c` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_c`](@ref)."""
 get_rating_c_unitful(value::MonitoredLine, units) = get_value(value, Val(:rating_c), Val(:mva), units)
+get_rating_c(value::MonitoredLine) = _units_arg_required(get_rating_c, value, :rating_c, Val(:mva))
+get_rating_c_unitful(value::MonitoredLine) = _units_arg_required(get_rating_c_unitful, value, :rating_c, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating_c), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_c_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `g` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_g_unitful`](@ref)."""
 get_g(value::MonitoredLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:g), Val(:siemens), units))
 """Get [`MonitoredLine`](@ref) `g` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_g`](@ref)."""
 get_g_unitful(value::MonitoredLine, units) = get_value(value, Val(:g), Val(:siemens), units)
+get_g(value::MonitoredLine) = _units_arg_required(get_g, value, :g, Val(:siemens))
+get_g_unitful(value::MonitoredLine) = _units_arg_required(get_g_unitful, value, :g, Val(:siemens))
 InfrastructureSystems.display_units_arg(::typeof(get_g), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_g_unitful), ::Type{MonitoredLine}) = InfrastructureSystems.SU
 """Get [`MonitoredLine`](@ref) `services`."""
@@ -201,28 +221,48 @@ get_internal(value::MonitoredLine) = value.internal
 set_available!(value::MonitoredLine, val) = value.available = val
 """Set [`MonitoredLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::MonitoredLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::MonitoredLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`MonitoredLine`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::MonitoredLine, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
+set_reactive_power_flow!(value::MonitoredLine, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`MonitoredLine`](@ref) `arc`."""
 set_arc!(value::MonitoredLine, val) = value.arc = val
 """Set [`MonitoredLine`](@ref) `r`."""
 set_r!(value::MonitoredLine, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
+set_r!(value::MonitoredLine, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`MonitoredLine`](@ref) `x`."""
 set_x!(value::MonitoredLine, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
+set_x!(value::MonitoredLine, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`MonitoredLine`](@ref) `b`."""
 set_b!(value::MonitoredLine, val) = value.b = set_value(value, Val(:b), val, Val(:siemens))
+set_b!(value::MonitoredLine, val::Real) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
+set_b!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_b!, value, :b, Val(:siemens), val)
 """Set [`MonitoredLine`](@ref) `flow_limits`."""
 set_flow_limits!(value::MonitoredLine, val) = value.flow_limits = set_value(value, Val(:flow_limits), val, Val(:mw))
+set_flow_limits!(value::MonitoredLine, val::Real) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
+set_flow_limits!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_flow_limits!, value, :flow_limits, Val(:mw), val)
 """Set [`MonitoredLine`](@ref) `rating`."""
 set_rating!(value::MonitoredLine, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::MonitoredLine, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`MonitoredLine`](@ref) `angle_limits`."""
 set_angle_limits!(value::MonitoredLine, val) = value.angle_limits = val
 """Set [`MonitoredLine`](@ref) `rating_b`."""
 set_rating_b!(value::MonitoredLine, val) = value.rating_b = set_value(value, Val(:rating_b), val, Val(:mva))
+set_rating_b!(value::MonitoredLine, val::Real) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
+set_rating_b!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
 """Set [`MonitoredLine`](@ref) `rating_c`."""
 set_rating_c!(value::MonitoredLine, val) = value.rating_c = set_value(value, Val(:rating_c), val, Val(:mva))
+set_rating_c!(value::MonitoredLine, val::Real) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
+set_rating_c!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
 """Set [`MonitoredLine`](@ref) `g`."""
 set_g!(value::MonitoredLine, val) = value.g = set_value(value, Val(:g), val, Val(:siemens))
+set_g!(value::MonitoredLine, val::Real) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
+set_g!(value::MonitoredLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_g!, value, :g, Val(:siemens), val)
 """Set [`MonitoredLine`](@ref) `services`."""
 set_services!(value::MonitoredLine, val) = value.services = val
 """Set [`MonitoredLine`](@ref) `ext`."""

--- a/src/models/generated/MotorLoad.jl
+++ b/src/models/generated/MotorLoad.jl
@@ -165,24 +165,20 @@ set_available!(value::MotorLoad, val) = value.available = val
 set_bus!(value::MotorLoad, val) = value.bus = val
 """Set [`MotorLoad`](@ref) `active_power`."""
 set_active_power!(value::MotorLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::MotorLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::MotorLoad, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`MotorLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::MotorLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::MotorLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::MotorLoad, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`MotorLoad`](@ref) `rating`."""
 set_rating!(value::MotorLoad, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::MotorLoad, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::MotorLoad, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`MotorLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::MotorLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
-set_max_active_power!(value::MotorLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
-set_max_active_power!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::MotorLoad, val::_UntaggedNumber) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`MotorLoad`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::MotorLoad, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::MotorLoad, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::MotorLoad, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::MotorLoad, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`MotorLoad`](@ref) `motor_technology`."""
 set_motor_technology!(value::MotorLoad, val) = value.motor_technology = val
 """Set [`MotorLoad`](@ref) `services`."""

--- a/src/models/generated/MotorLoad.jl
+++ b/src/models/generated/MotorLoad.jl
@@ -110,12 +110,16 @@ get_bus(value::MotorLoad) = value.bus
 get_active_power(value::MotorLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`MotorLoad`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::MotorLoad, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::MotorLoad) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::MotorLoad) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{MotorLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{MotorLoad}) = InfrastructureSystems.SU
 """Get [`MotorLoad`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::MotorLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`MotorLoad`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::MotorLoad, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::MotorLoad) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::MotorLoad) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{MotorLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{MotorLoad}) = InfrastructureSystems.SU
 
@@ -124,18 +128,24 @@ _get_base_power(value::MotorLoad) = value.base_power
 get_rating(value::MotorLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`MotorLoad`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::MotorLoad, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::MotorLoad) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::MotorLoad) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{MotorLoad}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{MotorLoad}) = InfrastructureSystems.DU
 """Get [`MotorLoad`](@ref) `max_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_active_power_unitful`](@ref)."""
 get_max_active_power(value::MotorLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_active_power), Val(:mw), units))
 """Get [`MotorLoad`](@ref) `max_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_active_power`](@ref)."""
 get_max_active_power_unitful(value::MotorLoad, units) = get_value(value, Val(:max_active_power), Val(:mw), units)
+get_max_active_power(value::MotorLoad) = _units_arg_required(get_max_active_power, value, :max_active_power, Val(:mw))
+get_max_active_power_unitful(value::MotorLoad) = _units_arg_required(get_max_active_power_unitful, value, :max_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power), ::Type{MotorLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power_unitful), ::Type{MotorLoad}) = InfrastructureSystems.SU
 """Get [`MotorLoad`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::MotorLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`MotorLoad`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::MotorLoad, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::MotorLoad) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::MotorLoad) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{MotorLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{MotorLoad}) = InfrastructureSystems.SU
 """Get [`MotorLoad`](@ref) `motor_technology`."""
@@ -155,14 +165,24 @@ set_available!(value::MotorLoad, val) = value.available = val
 set_bus!(value::MotorLoad, val) = value.bus = val
 """Set [`MotorLoad`](@ref) `active_power`."""
 set_active_power!(value::MotorLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::MotorLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`MotorLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::MotorLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::MotorLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`MotorLoad`](@ref) `rating`."""
 set_rating!(value::MotorLoad, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::MotorLoad, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`MotorLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::MotorLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
+set_max_active_power!(value::MotorLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`MotorLoad`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::MotorLoad, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::MotorLoad, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::MotorLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`MotorLoad`](@ref) `motor_technology`."""
 set_motor_technology!(value::MotorLoad, val) = value.motor_technology = val
 """Set [`MotorLoad`](@ref) `services`."""

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -105,12 +105,16 @@ get_bus(value::PowerLoad) = value.bus
 get_active_power(value::PowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`PowerLoad`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::PowerLoad, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::PowerLoad) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::PowerLoad) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{PowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{PowerLoad}) = InfrastructureSystems.SU
 """Get [`PowerLoad`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::PowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`PowerLoad`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::PowerLoad, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::PowerLoad) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::PowerLoad) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{PowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{PowerLoad}) = InfrastructureSystems.SU
 
@@ -119,12 +123,16 @@ _get_base_power(value::PowerLoad) = value.base_power
 get_max_active_power(value::PowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_active_power), Val(:mw), units))
 """Get [`PowerLoad`](@ref) `max_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_active_power`](@ref)."""
 get_max_active_power_unitful(value::PowerLoad, units) = get_value(value, Val(:max_active_power), Val(:mw), units)
+get_max_active_power(value::PowerLoad) = _units_arg_required(get_max_active_power, value, :max_active_power, Val(:mw))
+get_max_active_power_unitful(value::PowerLoad) = _units_arg_required(get_max_active_power_unitful, value, :max_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power), ::Type{PowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power_unitful), ::Type{PowerLoad}) = InfrastructureSystems.SU
 """Get [`PowerLoad`](@ref) `max_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_reactive_power_unitful`](@ref)."""
 get_max_reactive_power(value::PowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_reactive_power), Val(:mvar), units))
 """Get [`PowerLoad`](@ref) `max_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_reactive_power`](@ref)."""
 get_max_reactive_power_unitful(value::PowerLoad, units) = get_value(value, Val(:max_reactive_power), Val(:mvar), units)
+get_max_reactive_power(value::PowerLoad) = _units_arg_required(get_max_reactive_power, value, :max_reactive_power, Val(:mvar))
+get_max_reactive_power_unitful(value::PowerLoad) = _units_arg_required(get_max_reactive_power_unitful, value, :max_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power), ::Type{PowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power_unitful), ::Type{PowerLoad}) = InfrastructureSystems.SU
 """Get [`PowerLoad`](@ref) `conformity`."""
@@ -144,12 +152,20 @@ set_available!(value::PowerLoad, val) = value.available = val
 set_bus!(value::PowerLoad, val) = value.bus = val
 """Set [`PowerLoad`](@ref) `active_power`."""
 set_active_power!(value::PowerLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::PowerLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::PowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`PowerLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::PowerLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::PowerLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::PowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`PowerLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::PowerLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
+set_max_active_power!(value::PowerLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::PowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`PowerLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::PowerLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
+set_max_reactive_power!(value::PowerLoad, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::PowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`PowerLoad`](@ref) `conformity`."""
 set_conformity!(value::PowerLoad, val) = value.conformity = val
 """Set [`PowerLoad`](@ref) `services`."""

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -152,20 +152,16 @@ set_available!(value::PowerLoad, val) = value.available = val
 set_bus!(value::PowerLoad, val) = value.bus = val
 """Set [`PowerLoad`](@ref) `active_power`."""
 set_active_power!(value::PowerLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::PowerLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::PowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::PowerLoad, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`PowerLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::PowerLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::PowerLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::PowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::PowerLoad, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`PowerLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::PowerLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
-set_max_active_power!(value::PowerLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
-set_max_active_power!(value::PowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::PowerLoad, val::_UntaggedNumber) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`PowerLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::PowerLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
-set_max_reactive_power!(value::PowerLoad, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
-set_max_reactive_power!(value::PowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::PowerLoad, val::_UntaggedNumber) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`PowerLoad`](@ref) `conformity`."""
 set_conformity!(value::PowerLoad, val) = value.conformity = val
 """Set [`PowerLoad`](@ref) `services`."""

--- a/src/models/generated/RenewableDispatch.jl
+++ b/src/models/generated/RenewableDispatch.jl
@@ -117,18 +117,24 @@ get_bus(value::RenewableDispatch) = value.bus
 get_active_power(value::RenewableDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`RenewableDispatch`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::RenewableDispatch, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::RenewableDispatch) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::RenewableDispatch) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{RenewableDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{RenewableDispatch}) = InfrastructureSystems.SU
 """Get [`RenewableDispatch`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::RenewableDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`RenewableDispatch`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::RenewableDispatch, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::RenewableDispatch) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::RenewableDispatch) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{RenewableDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{RenewableDispatch}) = InfrastructureSystems.SU
 """Get [`RenewableDispatch`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::RenewableDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`RenewableDispatch`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::RenewableDispatch, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::RenewableDispatch) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::RenewableDispatch) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{RenewableDispatch}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{RenewableDispatch}) = InfrastructureSystems.DU
 """Get [`RenewableDispatch`](@ref) `prime_mover_type`."""
@@ -137,6 +143,8 @@ get_prime_mover_type(value::RenewableDispatch) = value.prime_mover_type
 get_reactive_power_limits(value::RenewableDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`RenewableDispatch`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::RenewableDispatch, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::RenewableDispatch) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::RenewableDispatch) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{RenewableDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{RenewableDispatch}) = InfrastructureSystems.SU
 """Get [`RenewableDispatch`](@ref) `power_factor`."""
@@ -160,14 +168,22 @@ set_available!(value::RenewableDispatch, val) = value.available = val
 set_bus!(value::RenewableDispatch, val) = value.bus = val
 """Set [`RenewableDispatch`](@ref) `active_power`."""
 set_active_power!(value::RenewableDispatch, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::RenewableDispatch, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::RenewableDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`RenewableDispatch`](@ref) `reactive_power`."""
 set_reactive_power!(value::RenewableDispatch, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::RenewableDispatch, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::RenewableDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`RenewableDispatch`](@ref) `rating`."""
 set_rating!(value::RenewableDispatch, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::RenewableDispatch, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::RenewableDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`RenewableDispatch`](@ref) `prime_mover_type`."""
 set_prime_mover_type!(value::RenewableDispatch, val) = value.prime_mover_type = val
 """Set [`RenewableDispatch`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::RenewableDispatch, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::RenewableDispatch, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::RenewableDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`RenewableDispatch`](@ref) `power_factor`."""
 set_power_factor!(value::RenewableDispatch, val) = value.power_factor = val
 """Set [`RenewableDispatch`](@ref) `operation_cost`."""

--- a/src/models/generated/RenewableDispatch.jl
+++ b/src/models/generated/RenewableDispatch.jl
@@ -168,22 +168,19 @@ set_available!(value::RenewableDispatch, val) = value.available = val
 set_bus!(value::RenewableDispatch, val) = value.bus = val
 """Set [`RenewableDispatch`](@ref) `active_power`."""
 set_active_power!(value::RenewableDispatch, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::RenewableDispatch, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::RenewableDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::RenewableDispatch, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`RenewableDispatch`](@ref) `reactive_power`."""
 set_reactive_power!(value::RenewableDispatch, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::RenewableDispatch, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::RenewableDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::RenewableDispatch, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`RenewableDispatch`](@ref) `rating`."""
 set_rating!(value::RenewableDispatch, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::RenewableDispatch, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::RenewableDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::RenewableDispatch, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`RenewableDispatch`](@ref) `prime_mover_type`."""
 set_prime_mover_type!(value::RenewableDispatch, val) = value.prime_mover_type = val
 """Set [`RenewableDispatch`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::RenewableDispatch, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::RenewableDispatch, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::RenewableDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::RenewableDispatch, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::RenewableDispatch, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`RenewableDispatch`](@ref) `power_factor`."""
 set_power_factor!(value::RenewableDispatch, val) = value.power_factor = val
 """Set [`RenewableDispatch`](@ref) `operation_cost`."""

--- a/src/models/generated/RenewableNonDispatch.jl
+++ b/src/models/generated/RenewableNonDispatch.jl
@@ -107,18 +107,24 @@ get_bus(value::RenewableNonDispatch) = value.bus
 get_active_power(value::RenewableNonDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`RenewableNonDispatch`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::RenewableNonDispatch, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::RenewableNonDispatch) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::RenewableNonDispatch) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{RenewableNonDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{RenewableNonDispatch}) = InfrastructureSystems.SU
 """Get [`RenewableNonDispatch`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::RenewableNonDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`RenewableNonDispatch`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::RenewableNonDispatch, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::RenewableNonDispatch) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::RenewableNonDispatch) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{RenewableNonDispatch}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{RenewableNonDispatch}) = InfrastructureSystems.SU
 """Get [`RenewableNonDispatch`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::RenewableNonDispatch, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`RenewableNonDispatch`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::RenewableNonDispatch, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::RenewableNonDispatch) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::RenewableNonDispatch) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{RenewableNonDispatch}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{RenewableNonDispatch}) = InfrastructureSystems.DU
 """Get [`RenewableNonDispatch`](@ref) `prime_mover_type`."""
@@ -142,10 +148,16 @@ set_available!(value::RenewableNonDispatch, val) = value.available = val
 set_bus!(value::RenewableNonDispatch, val) = value.bus = val
 """Set [`RenewableNonDispatch`](@ref) `active_power`."""
 set_active_power!(value::RenewableNonDispatch, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::RenewableNonDispatch, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::RenewableNonDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`RenewableNonDispatch`](@ref) `reactive_power`."""
 set_reactive_power!(value::RenewableNonDispatch, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::RenewableNonDispatch, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::RenewableNonDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`RenewableNonDispatch`](@ref) `rating`."""
 set_rating!(value::RenewableNonDispatch, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::RenewableNonDispatch, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::RenewableNonDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`RenewableNonDispatch`](@ref) `prime_mover_type`."""
 set_prime_mover_type!(value::RenewableNonDispatch, val) = value.prime_mover_type = val
 """Set [`RenewableNonDispatch`](@ref) `power_factor`."""

--- a/src/models/generated/RenewableNonDispatch.jl
+++ b/src/models/generated/RenewableNonDispatch.jl
@@ -148,16 +148,13 @@ set_available!(value::RenewableNonDispatch, val) = value.available = val
 set_bus!(value::RenewableNonDispatch, val) = value.bus = val
 """Set [`RenewableNonDispatch`](@ref) `active_power`."""
 set_active_power!(value::RenewableNonDispatch, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::RenewableNonDispatch, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::RenewableNonDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::RenewableNonDispatch, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`RenewableNonDispatch`](@ref) `reactive_power`."""
 set_reactive_power!(value::RenewableNonDispatch, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::RenewableNonDispatch, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::RenewableNonDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::RenewableNonDispatch, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`RenewableNonDispatch`](@ref) `rating`."""
 set_rating!(value::RenewableNonDispatch, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::RenewableNonDispatch, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::RenewableNonDispatch, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::RenewableNonDispatch, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`RenewableNonDispatch`](@ref) `prime_mover_type`."""
 set_prime_mover_type!(value::RenewableNonDispatch, val) = value.prime_mover_type = val
 """Set [`RenewableNonDispatch`](@ref) `power_factor`."""

--- a/src/models/generated/ShiftablePowerLoad.jl
+++ b/src/models/generated/ShiftablePowerLoad.jl
@@ -172,24 +172,20 @@ set_available!(value::ShiftablePowerLoad, val) = value.available = val
 set_bus!(value::ShiftablePowerLoad, val) = value.bus = val
 """Set [`ShiftablePowerLoad`](@ref) `active_power`."""
 set_active_power!(value::ShiftablePowerLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::ShiftablePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`ShiftablePowerLoad`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::ShiftablePowerLoad, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
-set_active_power_limits!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
-set_active_power_limits!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ShiftablePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ShiftablePowerLoad, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`ShiftablePowerLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::ShiftablePowerLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::ShiftablePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`ShiftablePowerLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::ShiftablePowerLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
-set_max_active_power!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
-set_max_active_power!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::ShiftablePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`ShiftablePowerLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::ShiftablePowerLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
-set_max_reactive_power!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
-set_max_reactive_power!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::ShiftablePowerLoad, val::_UntaggedNumber) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`ShiftablePowerLoad`](@ref) `load_balance_time_horizon`."""
 set_load_balance_time_horizon!(value::ShiftablePowerLoad, val) = value.load_balance_time_horizon = val
 """Set [`ShiftablePowerLoad`](@ref) `operation_cost`."""

--- a/src/models/generated/ShiftablePowerLoad.jl
+++ b/src/models/generated/ShiftablePowerLoad.jl
@@ -115,30 +115,40 @@ get_bus(value::ShiftablePowerLoad) = value.bus
 get_active_power(value::ShiftablePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`ShiftablePowerLoad`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::ShiftablePowerLoad, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::ShiftablePowerLoad) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::ShiftablePowerLoad) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 """Get [`ShiftablePowerLoad`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::ShiftablePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mw), units))
 """Get [`ShiftablePowerLoad`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""
 get_active_power_limits_unitful(value::ShiftablePowerLoad, units) = get_value(value, Val(:active_power_limits), Val(:mw), units)
+get_active_power_limits(value::ShiftablePowerLoad) = _units_arg_required(get_active_power_limits, value, :active_power_limits, Val(:mw))
+get_active_power_limits_unitful(value::ShiftablePowerLoad) = _units_arg_required(get_active_power_limits_unitful, value, :active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_unitful), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 """Get [`ShiftablePowerLoad`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::ShiftablePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`ShiftablePowerLoad`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::ShiftablePowerLoad, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::ShiftablePowerLoad) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::ShiftablePowerLoad) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 """Get [`ShiftablePowerLoad`](@ref) `max_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_active_power_unitful`](@ref)."""
 get_max_active_power(value::ShiftablePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_active_power), Val(:mw), units))
 """Get [`ShiftablePowerLoad`](@ref) `max_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_active_power`](@ref)."""
 get_max_active_power_unitful(value::ShiftablePowerLoad, units) = get_value(value, Val(:max_active_power), Val(:mw), units)
+get_max_active_power(value::ShiftablePowerLoad) = _units_arg_required(get_max_active_power, value, :max_active_power, Val(:mw))
+get_max_active_power_unitful(value::ShiftablePowerLoad) = _units_arg_required(get_max_active_power_unitful, value, :max_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_active_power_unitful), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 """Get [`ShiftablePowerLoad`](@ref) `max_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_reactive_power_unitful`](@ref)."""
 get_max_reactive_power(value::ShiftablePowerLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_reactive_power), Val(:mvar), units))
 """Get [`ShiftablePowerLoad`](@ref) `max_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_reactive_power`](@ref)."""
 get_max_reactive_power_unitful(value::ShiftablePowerLoad, units) = get_value(value, Val(:max_reactive_power), Val(:mvar), units)
+get_max_reactive_power(value::ShiftablePowerLoad) = _units_arg_required(get_max_reactive_power, value, :max_reactive_power, Val(:mvar))
+get_max_reactive_power_unitful(value::ShiftablePowerLoad) = _units_arg_required(get_max_reactive_power_unitful, value, :max_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_reactive_power_unitful), ::Type{ShiftablePowerLoad}) = InfrastructureSystems.SU
 
@@ -162,14 +172,24 @@ set_available!(value::ShiftablePowerLoad, val) = value.available = val
 set_bus!(value::ShiftablePowerLoad, val) = value.bus = val
 """Set [`ShiftablePowerLoad`](@ref) `active_power`."""
 set_active_power!(value::ShiftablePowerLoad, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`ShiftablePowerLoad`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::ShiftablePowerLoad, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
+set_active_power_limits!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`ShiftablePowerLoad`](@ref) `reactive_power`."""
 set_reactive_power!(value::ShiftablePowerLoad, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`ShiftablePowerLoad`](@ref) `max_active_power`."""
 set_max_active_power!(value::ShiftablePowerLoad, val) = value.max_active_power = set_value(value, Val(:max_active_power), val, Val(:mw))
+set_max_active_power!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
+set_max_active_power!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_active_power!, value, :max_active_power, Val(:mw), val)
 """Set [`ShiftablePowerLoad`](@ref) `max_reactive_power`."""
 set_max_reactive_power!(value::ShiftablePowerLoad, val) = value.max_reactive_power = set_value(value, Val(:max_reactive_power), val, Val(:mvar))
+set_max_reactive_power!(value::ShiftablePowerLoad, val::Real) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
+set_max_reactive_power!(value::ShiftablePowerLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_reactive_power!, value, :max_reactive_power, Val(:mvar), val)
 """Set [`ShiftablePowerLoad`](@ref) `load_balance_time_horizon`."""
 set_load_balance_time_horizon!(value::ShiftablePowerLoad, val) = value.load_balance_time_horizon = val
 """Set [`ShiftablePowerLoad`](@ref) `operation_cost`."""

--- a/src/models/generated/Source.jl
+++ b/src/models/generated/Source.jl
@@ -130,24 +130,32 @@ get_bus(value::Source) = value.bus
 get_active_power(value::Source, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`Source`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::Source, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::Source) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::Source) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{Source}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{Source}) = InfrastructureSystems.SU
 """Get [`Source`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::Source, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`Source`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::Source, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::Source) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::Source) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{Source}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{Source}) = InfrastructureSystems.SU
 """Get [`Source`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::Source, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mw), units))
 """Get [`Source`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""
 get_active_power_limits_unitful(value::Source, units) = get_value(value, Val(:active_power_limits), Val(:mw), units)
+get_active_power_limits(value::Source) = _units_arg_required(get_active_power_limits, value, :active_power_limits, Val(:mw))
+get_active_power_limits_unitful(value::Source) = _units_arg_required(get_active_power_limits_unitful, value, :active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits), ::Type{Source}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_unitful), ::Type{Source}) = InfrastructureSystems.SU
 """Get [`Source`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::Source, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`Source`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::Source, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::Source) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::Source) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{Source}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{Source}) = InfrastructureSystems.SU
 """Get [`Source`](@ref) `R_th`."""
@@ -179,12 +187,20 @@ set_available!(value::Source, val) = value.available = val
 set_bus!(value::Source, val) = value.bus = val
 """Set [`Source`](@ref) `active_power`."""
 set_active_power!(value::Source, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::Source, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::Source, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`Source`](@ref) `reactive_power`."""
 set_reactive_power!(value::Source, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::Source, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::Source, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`Source`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::Source, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
+set_active_power_limits!(value::Source, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::Source, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`Source`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::Source, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::Source, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::Source, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`Source`](@ref) `R_th`."""
 set_R_th!(value::Source, val) = value.R_th = val
 """Set [`Source`](@ref) `X_th`."""

--- a/src/models/generated/Source.jl
+++ b/src/models/generated/Source.jl
@@ -187,20 +187,18 @@ set_available!(value::Source, val) = value.available = val
 set_bus!(value::Source, val) = value.bus = val
 """Set [`Source`](@ref) `active_power`."""
 set_active_power!(value::Source, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::Source, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::Source, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::Source, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`Source`](@ref) `reactive_power`."""
 set_reactive_power!(value::Source, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::Source, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::Source, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::Source, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`Source`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::Source, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
-set_active_power_limits!(value::Source, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
-set_active_power_limits!(value::Source, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::Source, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::Source, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`Source`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::Source, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::Source, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::Source, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::Source, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::Source, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`Source`](@ref) `R_th`."""
 set_R_th!(value::Source, val) = value.R_th = val
 """Set [`Source`](@ref) `X_th`."""

--- a/src/models/generated/StandardLoad.jl
+++ b/src/models/generated/StandardLoad.jl
@@ -149,72 +149,96 @@ _get_base_power(value::StandardLoad) = value.base_power
 get_constant_active_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:constant_active_power), Val(:mw), units))
 """Get [`StandardLoad`](@ref) `constant_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_constant_active_power`](@ref)."""
 get_constant_active_power_unitful(value::StandardLoad, units) = get_value(value, Val(:constant_active_power), Val(:mw), units)
+get_constant_active_power(value::StandardLoad) = _units_arg_required(get_constant_active_power, value, :constant_active_power, Val(:mw))
+get_constant_active_power_unitful(value::StandardLoad) = _units_arg_required(get_constant_active_power_unitful, value, :constant_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_constant_active_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_constant_active_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `constant_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_constant_reactive_power_unitful`](@ref)."""
 get_constant_reactive_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:constant_reactive_power), Val(:mvar), units))
 """Get [`StandardLoad`](@ref) `constant_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_constant_reactive_power`](@ref)."""
 get_constant_reactive_power_unitful(value::StandardLoad, units) = get_value(value, Val(:constant_reactive_power), Val(:mvar), units)
+get_constant_reactive_power(value::StandardLoad) = _units_arg_required(get_constant_reactive_power, value, :constant_reactive_power, Val(:mvar))
+get_constant_reactive_power_unitful(value::StandardLoad) = _units_arg_required(get_constant_reactive_power_unitful, value, :constant_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_constant_reactive_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_constant_reactive_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `impedance_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_impedance_active_power_unitful`](@ref)."""
 get_impedance_active_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:impedance_active_power), Val(:mw), units))
 """Get [`StandardLoad`](@ref) `impedance_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_impedance_active_power`](@ref)."""
 get_impedance_active_power_unitful(value::StandardLoad, units) = get_value(value, Val(:impedance_active_power), Val(:mw), units)
+get_impedance_active_power(value::StandardLoad) = _units_arg_required(get_impedance_active_power, value, :impedance_active_power, Val(:mw))
+get_impedance_active_power_unitful(value::StandardLoad) = _units_arg_required(get_impedance_active_power_unitful, value, :impedance_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_impedance_active_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_impedance_active_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `impedance_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_impedance_reactive_power_unitful`](@ref)."""
 get_impedance_reactive_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:impedance_reactive_power), Val(:mvar), units))
 """Get [`StandardLoad`](@ref) `impedance_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_impedance_reactive_power`](@ref)."""
 get_impedance_reactive_power_unitful(value::StandardLoad, units) = get_value(value, Val(:impedance_reactive_power), Val(:mvar), units)
+get_impedance_reactive_power(value::StandardLoad) = _units_arg_required(get_impedance_reactive_power, value, :impedance_reactive_power, Val(:mvar))
+get_impedance_reactive_power_unitful(value::StandardLoad) = _units_arg_required(get_impedance_reactive_power_unitful, value, :impedance_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_impedance_reactive_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_impedance_reactive_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `current_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_current_active_power_unitful`](@ref)."""
 get_current_active_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:current_active_power), Val(:mw), units))
 """Get [`StandardLoad`](@ref) `current_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_current_active_power`](@ref)."""
 get_current_active_power_unitful(value::StandardLoad, units) = get_value(value, Val(:current_active_power), Val(:mw), units)
+get_current_active_power(value::StandardLoad) = _units_arg_required(get_current_active_power, value, :current_active_power, Val(:mw))
+get_current_active_power_unitful(value::StandardLoad) = _units_arg_required(get_current_active_power_unitful, value, :current_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_current_active_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_current_active_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `current_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_current_reactive_power_unitful`](@ref)."""
 get_current_reactive_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:current_reactive_power), Val(:mvar), units))
 """Get [`StandardLoad`](@ref) `current_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_current_reactive_power`](@ref)."""
 get_current_reactive_power_unitful(value::StandardLoad, units) = get_value(value, Val(:current_reactive_power), Val(:mvar), units)
+get_current_reactive_power(value::StandardLoad) = _units_arg_required(get_current_reactive_power, value, :current_reactive_power, Val(:mvar))
+get_current_reactive_power_unitful(value::StandardLoad) = _units_arg_required(get_current_reactive_power_unitful, value, :current_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_current_reactive_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_current_reactive_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `max_constant_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_constant_active_power_unitful`](@ref)."""
 get_max_constant_active_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_constant_active_power), Val(:mw), units))
 """Get [`StandardLoad`](@ref) `max_constant_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_constant_active_power`](@ref)."""
 get_max_constant_active_power_unitful(value::StandardLoad, units) = get_value(value, Val(:max_constant_active_power), Val(:mw), units)
+get_max_constant_active_power(value::StandardLoad) = _units_arg_required(get_max_constant_active_power, value, :max_constant_active_power, Val(:mw))
+get_max_constant_active_power_unitful(value::StandardLoad) = _units_arg_required(get_max_constant_active_power_unitful, value, :max_constant_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_constant_active_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_constant_active_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `max_constant_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_constant_reactive_power_unitful`](@ref)."""
 get_max_constant_reactive_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_constant_reactive_power), Val(:mvar), units))
 """Get [`StandardLoad`](@ref) `max_constant_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_constant_reactive_power`](@ref)."""
 get_max_constant_reactive_power_unitful(value::StandardLoad, units) = get_value(value, Val(:max_constant_reactive_power), Val(:mvar), units)
+get_max_constant_reactive_power(value::StandardLoad) = _units_arg_required(get_max_constant_reactive_power, value, :max_constant_reactive_power, Val(:mvar))
+get_max_constant_reactive_power_unitful(value::StandardLoad) = _units_arg_required(get_max_constant_reactive_power_unitful, value, :max_constant_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_constant_reactive_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_constant_reactive_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `max_impedance_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_impedance_active_power_unitful`](@ref)."""
 get_max_impedance_active_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_impedance_active_power), Val(:mw), units))
 """Get [`StandardLoad`](@ref) `max_impedance_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_impedance_active_power`](@ref)."""
 get_max_impedance_active_power_unitful(value::StandardLoad, units) = get_value(value, Val(:max_impedance_active_power), Val(:mw), units)
+get_max_impedance_active_power(value::StandardLoad) = _units_arg_required(get_max_impedance_active_power, value, :max_impedance_active_power, Val(:mw))
+get_max_impedance_active_power_unitful(value::StandardLoad) = _units_arg_required(get_max_impedance_active_power_unitful, value, :max_impedance_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_impedance_active_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_impedance_active_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `max_impedance_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_impedance_reactive_power_unitful`](@ref)."""
 get_max_impedance_reactive_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_impedance_reactive_power), Val(:mvar), units))
 """Get [`StandardLoad`](@ref) `max_impedance_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_impedance_reactive_power`](@ref)."""
 get_max_impedance_reactive_power_unitful(value::StandardLoad, units) = get_value(value, Val(:max_impedance_reactive_power), Val(:mvar), units)
+get_max_impedance_reactive_power(value::StandardLoad) = _units_arg_required(get_max_impedance_reactive_power, value, :max_impedance_reactive_power, Val(:mvar))
+get_max_impedance_reactive_power_unitful(value::StandardLoad) = _units_arg_required(get_max_impedance_reactive_power_unitful, value, :max_impedance_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_impedance_reactive_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_impedance_reactive_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `max_current_active_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_current_active_power_unitful`](@ref)."""
 get_max_current_active_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_current_active_power), Val(:mw), units))
 """Get [`StandardLoad`](@ref) `max_current_active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_current_active_power`](@ref)."""
 get_max_current_active_power_unitful(value::StandardLoad, units) = get_value(value, Val(:max_current_active_power), Val(:mw), units)
+get_max_current_active_power(value::StandardLoad) = _units_arg_required(get_max_current_active_power, value, :max_current_active_power, Val(:mw))
+get_max_current_active_power_unitful(value::StandardLoad) = _units_arg_required(get_max_current_active_power_unitful, value, :max_current_active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_max_current_active_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_current_active_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `max_current_reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_max_current_reactive_power_unitful`](@ref)."""
 get_max_current_reactive_power(value::StandardLoad, units) = InfrastructureSystems._strip_units(get_value(value, Val(:max_current_reactive_power), Val(:mvar), units))
 """Get [`StandardLoad`](@ref) `max_current_reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_max_current_reactive_power`](@ref)."""
 get_max_current_reactive_power_unitful(value::StandardLoad, units) = get_value(value, Val(:max_current_reactive_power), Val(:mvar), units)
+get_max_current_reactive_power(value::StandardLoad) = _units_arg_required(get_max_current_reactive_power, value, :max_current_reactive_power, Val(:mvar))
+get_max_current_reactive_power_unitful(value::StandardLoad) = _units_arg_required(get_max_current_reactive_power_unitful, value, :max_current_reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_max_current_reactive_power), ::Type{StandardLoad}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_max_current_reactive_power_unitful), ::Type{StandardLoad}) = InfrastructureSystems.SU
 """Get [`StandardLoad`](@ref) `conformity`."""
@@ -234,28 +258,52 @@ set_available!(value::StandardLoad, val) = value.available = val
 set_bus!(value::StandardLoad, val) = value.bus = val
 """Set [`StandardLoad`](@ref) `constant_active_power`."""
 set_constant_active_power!(value::StandardLoad, val) = value.constant_active_power = set_value(value, Val(:constant_active_power), val, Val(:mw))
+set_constant_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
+set_constant_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `constant_reactive_power`."""
 set_constant_reactive_power!(value::StandardLoad, val) = value.constant_reactive_power = set_value(value, Val(:constant_reactive_power), val, Val(:mvar))
+set_constant_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
+set_constant_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `impedance_active_power`."""
 set_impedance_active_power!(value::StandardLoad, val) = value.impedance_active_power = set_value(value, Val(:impedance_active_power), val, Val(:mw))
+set_impedance_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
+set_impedance_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `impedance_reactive_power`."""
 set_impedance_reactive_power!(value::StandardLoad, val) = value.impedance_reactive_power = set_value(value, Val(:impedance_reactive_power), val, Val(:mvar))
+set_impedance_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
+set_impedance_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `current_active_power`."""
 set_current_active_power!(value::StandardLoad, val) = value.current_active_power = set_value(value, Val(:current_active_power), val, Val(:mw))
+set_current_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
+set_current_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `current_reactive_power`."""
 set_current_reactive_power!(value::StandardLoad, val) = value.current_reactive_power = set_value(value, Val(:current_reactive_power), val, Val(:mvar))
+set_current_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
+set_current_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `max_constant_active_power`."""
 set_max_constant_active_power!(value::StandardLoad, val) = value.max_constant_active_power = set_value(value, Val(:max_constant_active_power), val, Val(:mw))
+set_max_constant_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
+set_max_constant_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `max_constant_reactive_power`."""
 set_max_constant_reactive_power!(value::StandardLoad, val) = value.max_constant_reactive_power = set_value(value, Val(:max_constant_reactive_power), val, Val(:mvar))
+set_max_constant_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
+set_max_constant_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `max_impedance_active_power`."""
 set_max_impedance_active_power!(value::StandardLoad, val) = value.max_impedance_active_power = set_value(value, Val(:max_impedance_active_power), val, Val(:mw))
+set_max_impedance_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
+set_max_impedance_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `max_impedance_reactive_power`."""
 set_max_impedance_reactive_power!(value::StandardLoad, val) = value.max_impedance_reactive_power = set_value(value, Val(:max_impedance_reactive_power), val, Val(:mvar))
+set_max_impedance_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
+set_max_impedance_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `max_current_active_power`."""
 set_max_current_active_power!(value::StandardLoad, val) = value.max_current_active_power = set_value(value, Val(:max_current_active_power), val, Val(:mw))
+set_max_current_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
+set_max_current_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `max_current_reactive_power`."""
 set_max_current_reactive_power!(value::StandardLoad, val) = value.max_current_reactive_power = set_value(value, Val(:max_current_reactive_power), val, Val(:mvar))
+set_max_current_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
+set_max_current_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `conformity`."""
 set_conformity!(value::StandardLoad, val) = value.conformity = val
 """Set [`StandardLoad`](@ref) `services`."""

--- a/src/models/generated/StandardLoad.jl
+++ b/src/models/generated/StandardLoad.jl
@@ -258,52 +258,40 @@ set_available!(value::StandardLoad, val) = value.available = val
 set_bus!(value::StandardLoad, val) = value.bus = val
 """Set [`StandardLoad`](@ref) `constant_active_power`."""
 set_constant_active_power!(value::StandardLoad, val) = value.constant_active_power = set_value(value, Val(:constant_active_power), val, Val(:mw))
-set_constant_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
-set_constant_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
+set_constant_active_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_constant_active_power!, value, :constant_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `constant_reactive_power`."""
 set_constant_reactive_power!(value::StandardLoad, val) = value.constant_reactive_power = set_value(value, Val(:constant_reactive_power), val, Val(:mvar))
-set_constant_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
-set_constant_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
+set_constant_reactive_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_constant_reactive_power!, value, :constant_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `impedance_active_power`."""
 set_impedance_active_power!(value::StandardLoad, val) = value.impedance_active_power = set_value(value, Val(:impedance_active_power), val, Val(:mw))
-set_impedance_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
-set_impedance_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
+set_impedance_active_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_impedance_active_power!, value, :impedance_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `impedance_reactive_power`."""
 set_impedance_reactive_power!(value::StandardLoad, val) = value.impedance_reactive_power = set_value(value, Val(:impedance_reactive_power), val, Val(:mvar))
-set_impedance_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
-set_impedance_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
+set_impedance_reactive_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_impedance_reactive_power!, value, :impedance_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `current_active_power`."""
 set_current_active_power!(value::StandardLoad, val) = value.current_active_power = set_value(value, Val(:current_active_power), val, Val(:mw))
-set_current_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
-set_current_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
+set_current_active_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_current_active_power!, value, :current_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `current_reactive_power`."""
 set_current_reactive_power!(value::StandardLoad, val) = value.current_reactive_power = set_value(value, Val(:current_reactive_power), val, Val(:mvar))
-set_current_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
-set_current_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
+set_current_reactive_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_current_reactive_power!, value, :current_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `max_constant_active_power`."""
 set_max_constant_active_power!(value::StandardLoad, val) = value.max_constant_active_power = set_value(value, Val(:max_constant_active_power), val, Val(:mw))
-set_max_constant_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
-set_max_constant_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
+set_max_constant_active_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_constant_active_power!, value, :max_constant_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `max_constant_reactive_power`."""
 set_max_constant_reactive_power!(value::StandardLoad, val) = value.max_constant_reactive_power = set_value(value, Val(:max_constant_reactive_power), val, Val(:mvar))
-set_max_constant_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
-set_max_constant_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
+set_max_constant_reactive_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_constant_reactive_power!, value, :max_constant_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `max_impedance_active_power`."""
 set_max_impedance_active_power!(value::StandardLoad, val) = value.max_impedance_active_power = set_value(value, Val(:max_impedance_active_power), val, Val(:mw))
-set_max_impedance_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
-set_max_impedance_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
+set_max_impedance_active_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_impedance_active_power!, value, :max_impedance_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `max_impedance_reactive_power`."""
 set_max_impedance_reactive_power!(value::StandardLoad, val) = value.max_impedance_reactive_power = set_value(value, Val(:max_impedance_reactive_power), val, Val(:mvar))
-set_max_impedance_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
-set_max_impedance_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
+set_max_impedance_reactive_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_impedance_reactive_power!, value, :max_impedance_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `max_current_active_power`."""
 set_max_current_active_power!(value::StandardLoad, val) = value.max_current_active_power = set_value(value, Val(:max_current_active_power), val, Val(:mw))
-set_max_current_active_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
-set_max_current_active_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
+set_max_current_active_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_current_active_power!, value, :max_current_active_power, Val(:mw), val)
 """Set [`StandardLoad`](@ref) `max_current_reactive_power`."""
 set_max_current_reactive_power!(value::StandardLoad, val) = value.max_current_reactive_power = set_value(value, Val(:max_current_reactive_power), val, Val(:mvar))
-set_max_current_reactive_power!(value::StandardLoad, val::Real) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
-set_max_current_reactive_power!(value::StandardLoad, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
+set_max_current_reactive_power!(value::StandardLoad, val::_UntaggedNumber) = _units_tag_required(set_max_current_reactive_power!, value, :max_current_reactive_power, Val(:mvar), val)
 """Set [`StandardLoad`](@ref) `conformity`."""
 set_conformity!(value::StandardLoad, val) = value.conformity = val
 """Set [`StandardLoad`](@ref) `services`."""

--- a/src/models/generated/SynchronousCondenser.jl
+++ b/src/models/generated/SynchronousCondenser.jl
@@ -98,18 +98,24 @@ get_bus(value::SynchronousCondenser) = value.bus
 get_reactive_power(value::SynchronousCondenser, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`SynchronousCondenser`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::SynchronousCondenser, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::SynchronousCondenser) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::SynchronousCondenser) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{SynchronousCondenser}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{SynchronousCondenser}) = InfrastructureSystems.SU
 """Get [`SynchronousCondenser`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::SynchronousCondenser, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`SynchronousCondenser`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::SynchronousCondenser, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::SynchronousCondenser) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::SynchronousCondenser) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{SynchronousCondenser}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{SynchronousCondenser}) = InfrastructureSystems.DU
 """Get [`SynchronousCondenser`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::SynchronousCondenser, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`SynchronousCondenser`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::SynchronousCondenser, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::SynchronousCondenser) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::SynchronousCondenser) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{SynchronousCondenser}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{SynchronousCondenser}) = InfrastructureSystems.SU
 
@@ -118,6 +124,8 @@ _get_base_power(value::SynchronousCondenser) = value.base_power
 get_active_power_losses(value::SynchronousCondenser, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_losses), Val(:mw), units))
 """Get [`SynchronousCondenser`](@ref) `active_power_losses` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_losses`](@ref)."""
 get_active_power_losses_unitful(value::SynchronousCondenser, units) = get_value(value, Val(:active_power_losses), Val(:mw), units)
+get_active_power_losses(value::SynchronousCondenser) = _units_arg_required(get_active_power_losses, value, :active_power_losses, Val(:mw))
+get_active_power_losses_unitful(value::SynchronousCondenser) = _units_arg_required(get_active_power_losses_unitful, value, :active_power_losses, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_losses), ::Type{SynchronousCondenser}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_losses_unitful), ::Type{SynchronousCondenser}) = InfrastructureSystems.SU
 """Get [`SynchronousCondenser`](@ref) `services`."""
@@ -135,12 +143,20 @@ set_available!(value::SynchronousCondenser, val) = value.available = val
 set_bus!(value::SynchronousCondenser, val) = value.bus = val
 """Set [`SynchronousCondenser`](@ref) `reactive_power`."""
 set_reactive_power!(value::SynchronousCondenser, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::SynchronousCondenser, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::SynchronousCondenser, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`SynchronousCondenser`](@ref) `rating`."""
 set_rating!(value::SynchronousCondenser, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::SynchronousCondenser, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::SynchronousCondenser, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`SynchronousCondenser`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::SynchronousCondenser, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::SynchronousCondenser, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::SynchronousCondenser, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`SynchronousCondenser`](@ref) `active_power_losses`."""
 set_active_power_losses!(value::SynchronousCondenser, val) = value.active_power_losses = set_value(value, Val(:active_power_losses), val, Val(:mw))
+set_active_power_losses!(value::SynchronousCondenser, val::Real) = _units_tag_required(set_active_power_losses!, value, :active_power_losses, Val(:mw), val)
+set_active_power_losses!(value::SynchronousCondenser, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_losses!, value, :active_power_losses, Val(:mw), val)
 """Set [`SynchronousCondenser`](@ref) `services`."""
 set_services!(value::SynchronousCondenser, val) = value.services = val
 """Set [`SynchronousCondenser`](@ref) `ext`."""

--- a/src/models/generated/SynchronousCondenser.jl
+++ b/src/models/generated/SynchronousCondenser.jl
@@ -143,20 +143,17 @@ set_available!(value::SynchronousCondenser, val) = value.available = val
 set_bus!(value::SynchronousCondenser, val) = value.bus = val
 """Set [`SynchronousCondenser`](@ref) `reactive_power`."""
 set_reactive_power!(value::SynchronousCondenser, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::SynchronousCondenser, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::SynchronousCondenser, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::SynchronousCondenser, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`SynchronousCondenser`](@ref) `rating`."""
 set_rating!(value::SynchronousCondenser, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::SynchronousCondenser, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::SynchronousCondenser, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::SynchronousCondenser, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`SynchronousCondenser`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::SynchronousCondenser, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::SynchronousCondenser, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::SynchronousCondenser, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::SynchronousCondenser, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::SynchronousCondenser, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`SynchronousCondenser`](@ref) `active_power_losses`."""
 set_active_power_losses!(value::SynchronousCondenser, val) = value.active_power_losses = set_value(value, Val(:active_power_losses), val, Val(:mw))
-set_active_power_losses!(value::SynchronousCondenser, val::Real) = _units_tag_required(set_active_power_losses!, value, :active_power_losses, Val(:mw), val)
-set_active_power_losses!(value::SynchronousCondenser, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_losses!, value, :active_power_losses, Val(:mw), val)
+set_active_power_losses!(value::SynchronousCondenser, val::_UntaggedNumber) = _units_tag_required(set_active_power_losses!, value, :active_power_losses, Val(:mw), val)
 """Set [`SynchronousCondenser`](@ref) `services`."""
 set_services!(value::SynchronousCondenser, val) = value.services = val
 """Set [`SynchronousCondenser`](@ref) `ext`."""

--- a/src/models/generated/TModelHVDCLine.jl
+++ b/src/models/generated/TModelHVDCLine.jl
@@ -144,8 +144,7 @@ get_internal(value::TModelHVDCLine) = value.internal
 set_available!(value::TModelHVDCLine, val) = value.available = val
 """Set [`TModelHVDCLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TModelHVDCLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::TModelHVDCLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::TModelHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TModelHVDCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TModelHVDCLine`](@ref) `arc`."""
 set_arc!(value::TModelHVDCLine, val) = value.arc = val
 """Set [`TModelHVDCLine`](@ref) `r`."""
@@ -156,12 +155,12 @@ set_l!(value::TModelHVDCLine, val) = value.l = val
 set_c!(value::TModelHVDCLine, val) = value.c = val
 """Set [`TModelHVDCLine`](@ref) `active_power_limits_from`."""
 set_active_power_limits_from!(value::TModelHVDCLine, val) = value.active_power_limits_from = set_value(value, Val(:active_power_limits_from), val, Val(:mw))
-set_active_power_limits_from!(value::TModelHVDCLine, val::Real) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
-set_active_power_limits_from!(value::TModelHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TModelHVDCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TModelHVDCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
 """Set [`TModelHVDCLine`](@ref) `active_power_limits_to`."""
 set_active_power_limits_to!(value::TModelHVDCLine, val) = value.active_power_limits_to = set_value(value, Val(:active_power_limits_to), val, Val(:mw))
-set_active_power_limits_to!(value::TModelHVDCLine, val::Real) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
-set_active_power_limits_to!(value::TModelHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TModelHVDCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TModelHVDCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
 """Set [`TModelHVDCLine`](@ref) `base_current`."""
 set_base_current!(value::TModelHVDCLine, val) = value.base_current = val
 """Set [`TModelHVDCLine`](@ref) `services`."""

--- a/src/models/generated/TModelHVDCLine.jl
+++ b/src/models/generated/TModelHVDCLine.jl
@@ -103,6 +103,8 @@ get_available(value::TModelHVDCLine) = value.available
 get_active_power_flow(value::TModelHVDCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`TModelHVDCLine`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::TModelHVDCLine, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::TModelHVDCLine) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::TModelHVDCLine) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{TModelHVDCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{TModelHVDCLine}) = InfrastructureSystems.SU
 """Get [`TModelHVDCLine`](@ref) `arc`."""
@@ -117,12 +119,16 @@ get_c(value::TModelHVDCLine) = value.c
 get_active_power_limits_from(value::TModelHVDCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_from), Val(:mw), units))
 """Get [`TModelHVDCLine`](@ref) `active_power_limits_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_from`](@ref)."""
 get_active_power_limits_from_unitful(value::TModelHVDCLine, units) = get_value(value, Val(:active_power_limits_from), Val(:mw), units)
+get_active_power_limits_from(value::TModelHVDCLine) = _units_arg_required(get_active_power_limits_from, value, :active_power_limits_from, Val(:mw))
+get_active_power_limits_from_unitful(value::TModelHVDCLine) = _units_arg_required(get_active_power_limits_from_unitful, value, :active_power_limits_from, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_from), ::Type{TModelHVDCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_from_unitful), ::Type{TModelHVDCLine}) = InfrastructureSystems.SU
 """Get [`TModelHVDCLine`](@ref) `active_power_limits_to` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_to_unitful`](@ref)."""
 get_active_power_limits_to(value::TModelHVDCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_to), Val(:mw), units))
 """Get [`TModelHVDCLine`](@ref) `active_power_limits_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_to`](@ref)."""
 get_active_power_limits_to_unitful(value::TModelHVDCLine, units) = get_value(value, Val(:active_power_limits_to), Val(:mw), units)
+get_active_power_limits_to(value::TModelHVDCLine) = _units_arg_required(get_active_power_limits_to, value, :active_power_limits_to, Val(:mw))
+get_active_power_limits_to_unitful(value::TModelHVDCLine) = _units_arg_required(get_active_power_limits_to_unitful, value, :active_power_limits_to, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_to), ::Type{TModelHVDCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_to_unitful), ::Type{TModelHVDCLine}) = InfrastructureSystems.SU
 """Get [`TModelHVDCLine`](@ref) `base_current`."""
@@ -138,6 +144,8 @@ get_internal(value::TModelHVDCLine) = value.internal
 set_available!(value::TModelHVDCLine, val) = value.available = val
 """Set [`TModelHVDCLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TModelHVDCLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::TModelHVDCLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TModelHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TModelHVDCLine`](@ref) `arc`."""
 set_arc!(value::TModelHVDCLine, val) = value.arc = val
 """Set [`TModelHVDCLine`](@ref) `r`."""
@@ -148,8 +156,12 @@ set_l!(value::TModelHVDCLine, val) = value.l = val
 set_c!(value::TModelHVDCLine, val) = value.c = val
 """Set [`TModelHVDCLine`](@ref) `active_power_limits_from`."""
 set_active_power_limits_from!(value::TModelHVDCLine, val) = value.active_power_limits_from = set_value(value, Val(:active_power_limits_from), val, Val(:mw))
+set_active_power_limits_from!(value::TModelHVDCLine, val::Real) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TModelHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
 """Set [`TModelHVDCLine`](@ref) `active_power_limits_to`."""
 set_active_power_limits_to!(value::TModelHVDCLine, val) = value.active_power_limits_to = set_value(value, Val(:active_power_limits_to), val, Val(:mw))
+set_active_power_limits_to!(value::TModelHVDCLine, val::Real) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TModelHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
 """Set [`TModelHVDCLine`](@ref) `base_current`."""
 set_base_current!(value::TModelHVDCLine, val) = value.base_current = val
 """Set [`TModelHVDCLine`](@ref) `services`."""

--- a/src/models/generated/ThermalMultiStart.jl
+++ b/src/models/generated/ThermalMultiStart.jl
@@ -248,36 +248,33 @@ set_status!(value::ThermalMultiStart, val) = value.status = val
 set_bus!(value::ThermalMultiStart, val) = value.bus = val
 """Set [`ThermalMultiStart`](@ref) `active_power`."""
 set_active_power!(value::ThermalMultiStart, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::ThermalMultiStart, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`ThermalMultiStart`](@ref) `reactive_power`."""
 set_reactive_power!(value::ThermalMultiStart, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::ThermalMultiStart, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`ThermalMultiStart`](@ref) `rating`."""
 set_rating!(value::ThermalMultiStart, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::ThermalMultiStart, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`ThermalMultiStart`](@ref) `prime_mover_type`."""
 set_prime_mover_type!(value::ThermalMultiStart, val) = value.prime_mover_type = val
 """Set [`ThermalMultiStart`](@ref) `fuel`."""
 set_fuel!(value::ThermalMultiStart, val) = value.fuel = val
 """Set [`ThermalMultiStart`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::ThermalMultiStart, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
-set_active_power_limits!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
-set_active_power_limits!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ThermalMultiStart, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ThermalMultiStart, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`ThermalMultiStart`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::ThermalMultiStart, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::ThermalMultiStart, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::ThermalMultiStart, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`ThermalMultiStart`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::ThermalMultiStart, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
-set_ramp_limits!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
-set_ramp_limits!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::ThermalMultiStart, val::_UntaggedNumber) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::ThermalMultiStart, val::NamedTuple{(:up, :down), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`ThermalMultiStart`](@ref) `power_trajectory`."""
 set_power_trajectory!(value::ThermalMultiStart, val) = value.power_trajectory = set_value(value, Val(:power_trajectory), val, Val(:mw))
-set_power_trajectory!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_power_trajectory!, value, :power_trajectory, Val(:mw), val)
-set_power_trajectory!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_power_trajectory!, value, :power_trajectory, Val(:mw), val)
+set_power_trajectory!(value::ThermalMultiStart, val::_UntaggedNumber) = _units_tag_required(set_power_trajectory!, value, :power_trajectory, Val(:mw), val)
+set_power_trajectory!(value::ThermalMultiStart, val::NamedTuple{(:startup, :shutdown), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_power_trajectory!, value, :power_trajectory, Val(:mw), val)
 """Set [`ThermalMultiStart`](@ref) `time_limits`."""
 set_time_limits!(value::ThermalMultiStart, val) = value.time_limits = val
 """Set [`ThermalMultiStart`](@ref) `start_time_limits`."""

--- a/src/models/generated/ThermalMultiStart.jl
+++ b/src/models/generated/ThermalMultiStart.jl
@@ -161,18 +161,24 @@ get_bus(value::ThermalMultiStart) = value.bus
 get_active_power(value::ThermalMultiStart, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`ThermalMultiStart`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::ThermalMultiStart, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::ThermalMultiStart) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::ThermalMultiStart) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 """Get [`ThermalMultiStart`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::ThermalMultiStart, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`ThermalMultiStart`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::ThermalMultiStart, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::ThermalMultiStart) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::ThermalMultiStart) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 """Get [`ThermalMultiStart`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::ThermalMultiStart, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`ThermalMultiStart`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::ThermalMultiStart, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::ThermalMultiStart) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::ThermalMultiStart) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{ThermalMultiStart}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.DU
 """Get [`ThermalMultiStart`](@ref) `prime_mover_type`."""
@@ -183,24 +189,32 @@ get_fuel(value::ThermalMultiStart) = value.fuel
 get_active_power_limits(value::ThermalMultiStart, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mw), units))
 """Get [`ThermalMultiStart`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""
 get_active_power_limits_unitful(value::ThermalMultiStart, units) = get_value(value, Val(:active_power_limits), Val(:mw), units)
+get_active_power_limits(value::ThermalMultiStart) = _units_arg_required(get_active_power_limits, value, :active_power_limits, Val(:mw))
+get_active_power_limits_unitful(value::ThermalMultiStart) = _units_arg_required(get_active_power_limits_unitful, value, :active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 """Get [`ThermalMultiStart`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::ThermalMultiStart, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`ThermalMultiStart`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::ThermalMultiStart, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::ThermalMultiStart) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::ThermalMultiStart) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 """Get [`ThermalMultiStart`](@ref) `ramp_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_ramp_limits_unitful`](@ref)."""
 get_ramp_limits(value::ThermalMultiStart, units) = InfrastructureSystems._strip_units(get_value(value, Val(:ramp_limits), Val(:mw), units))
 """Get [`ThermalMultiStart`](@ref) `ramp_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_ramp_limits`](@ref)."""
 get_ramp_limits_unitful(value::ThermalMultiStart, units) = get_value(value, Val(:ramp_limits), Val(:mw), units)
+get_ramp_limits(value::ThermalMultiStart) = _units_arg_required(get_ramp_limits, value, :ramp_limits, Val(:mw))
+get_ramp_limits_unitful(value::ThermalMultiStart) = _units_arg_required(get_ramp_limits_unitful, value, :ramp_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 """Get [`ThermalMultiStart`](@ref) `power_trajectory` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_power_trajectory_unitful`](@ref)."""
 get_power_trajectory(value::ThermalMultiStart, units) = InfrastructureSystems._strip_units(get_value(value, Val(:power_trajectory), Val(:mw), units))
 """Get [`ThermalMultiStart`](@ref) `power_trajectory` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_power_trajectory`](@ref)."""
 get_power_trajectory_unitful(value::ThermalMultiStart, units) = get_value(value, Val(:power_trajectory), Val(:mw), units)
+get_power_trajectory(value::ThermalMultiStart) = _units_arg_required(get_power_trajectory, value, :power_trajectory, Val(:mw))
+get_power_trajectory_unitful(value::ThermalMultiStart) = _units_arg_required(get_power_trajectory_unitful, value, :power_trajectory, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_power_trajectory), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_power_trajectory_unitful), ::Type{ThermalMultiStart}) = InfrastructureSystems.SU
 """Get [`ThermalMultiStart`](@ref) `time_limits`."""
@@ -234,22 +248,36 @@ set_status!(value::ThermalMultiStart, val) = value.status = val
 set_bus!(value::ThermalMultiStart, val) = value.bus = val
 """Set [`ThermalMultiStart`](@ref) `active_power`."""
 set_active_power!(value::ThermalMultiStart, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`ThermalMultiStart`](@ref) `reactive_power`."""
 set_reactive_power!(value::ThermalMultiStart, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`ThermalMultiStart`](@ref) `rating`."""
 set_rating!(value::ThermalMultiStart, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`ThermalMultiStart`](@ref) `prime_mover_type`."""
 set_prime_mover_type!(value::ThermalMultiStart, val) = value.prime_mover_type = val
 """Set [`ThermalMultiStart`](@ref) `fuel`."""
 set_fuel!(value::ThermalMultiStart, val) = value.fuel = val
 """Set [`ThermalMultiStart`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::ThermalMultiStart, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
+set_active_power_limits!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`ThermalMultiStart`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::ThermalMultiStart, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`ThermalMultiStart`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::ThermalMultiStart, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
+set_ramp_limits!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`ThermalMultiStart`](@ref) `power_trajectory`."""
 set_power_trajectory!(value::ThermalMultiStart, val) = value.power_trajectory = set_value(value, Val(:power_trajectory), val, Val(:mw))
+set_power_trajectory!(value::ThermalMultiStart, val::Real) = _units_tag_required(set_power_trajectory!, value, :power_trajectory, Val(:mw), val)
+set_power_trajectory!(value::ThermalMultiStart, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_power_trajectory!, value, :power_trajectory, Val(:mw), val)
 """Set [`ThermalMultiStart`](@ref) `time_limits`."""
 set_time_limits!(value::ThermalMultiStart, val) = value.time_limits = val
 """Set [`ThermalMultiStart`](@ref) `start_time_limits`."""

--- a/src/models/generated/ThermalStandard.jl
+++ b/src/models/generated/ThermalStandard.jl
@@ -222,28 +222,25 @@ set_status!(value::ThermalStandard, val) = value.status = val
 set_bus!(value::ThermalStandard, val) = value.bus = val
 """Set [`ThermalStandard`](@ref) `active_power`."""
 set_active_power!(value::ThermalStandard, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
-set_active_power!(value::ThermalStandard, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
-set_active_power!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::ThermalStandard, val::_UntaggedNumber) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`ThermalStandard`](@ref) `reactive_power`."""
 set_reactive_power!(value::ThermalStandard, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
-set_reactive_power!(value::ThermalStandard, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
-set_reactive_power!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::ThermalStandard, val::_UntaggedNumber) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`ThermalStandard`](@ref) `rating`."""
 set_rating!(value::ThermalStandard, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::ThermalStandard, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::ThermalStandard, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`ThermalStandard`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::ThermalStandard, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
-set_active_power_limits!(value::ThermalStandard, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
-set_active_power_limits!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ThermalStandard, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ThermalStandard, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`ThermalStandard`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::ThermalStandard, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
-set_reactive_power_limits!(value::ThermalStandard, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
-set_reactive_power_limits!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::ThermalStandard, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::ThermalStandard, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`ThermalStandard`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::ThermalStandard, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
-set_ramp_limits!(value::ThermalStandard, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
-set_ramp_limits!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::ThermalStandard, val::_UntaggedNumber) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::ThermalStandard, val::NamedTuple{(:up, :down), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`ThermalStandard`](@ref) `operation_cost`."""
 set_operation_cost!(value::ThermalStandard, val) = value.operation_cost = val
 """Set [`ThermalStandard`](@ref) `time_limits`."""

--- a/src/models/generated/ThermalStandard.jl
+++ b/src/models/generated/ThermalStandard.jl
@@ -147,36 +147,48 @@ get_bus(value::ThermalStandard) = value.bus
 get_active_power(value::ThermalStandard, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power), Val(:mw), units))
 """Get [`ThermalStandard`](@ref) `active_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power`](@ref)."""
 get_active_power_unitful(value::ThermalStandard, units) = get_value(value, Val(:active_power), Val(:mw), units)
+get_active_power(value::ThermalStandard) = _units_arg_required(get_active_power, value, :active_power, Val(:mw))
+get_active_power_unitful(value::ThermalStandard) = _units_arg_required(get_active_power_unitful, value, :active_power, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_unitful), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 """Get [`ThermalStandard`](@ref) `reactive_power` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_unitful`](@ref)."""
 get_reactive_power(value::ThermalStandard, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power), Val(:mvar), units))
 """Get [`ThermalStandard`](@ref) `reactive_power` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power`](@ref)."""
 get_reactive_power_unitful(value::ThermalStandard, units) = get_value(value, Val(:reactive_power), Val(:mvar), units)
+get_reactive_power(value::ThermalStandard) = _units_arg_required(get_reactive_power, value, :reactive_power, Val(:mvar))
+get_reactive_power_unitful(value::ThermalStandard) = _units_arg_required(get_reactive_power_unitful, value, :reactive_power, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_unitful), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 """Get [`ThermalStandard`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::ThermalStandard, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`ThermalStandard`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::ThermalStandard, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::ThermalStandard) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::ThermalStandard) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{ThermalStandard}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{ThermalStandard}) = InfrastructureSystems.DU
 """Get [`ThermalStandard`](@ref) `active_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_unitful`](@ref)."""
 get_active_power_limits(value::ThermalStandard, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits), Val(:mw), units))
 """Get [`ThermalStandard`](@ref) `active_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits`](@ref)."""
 get_active_power_limits_unitful(value::ThermalStandard, units) = get_value(value, Val(:active_power_limits), Val(:mw), units)
+get_active_power_limits(value::ThermalStandard) = _units_arg_required(get_active_power_limits, value, :active_power_limits, Val(:mw))
+get_active_power_limits_unitful(value::ThermalStandard) = _units_arg_required(get_active_power_limits_unitful, value, :active_power_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_unitful), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 """Get [`ThermalStandard`](@ref) `reactive_power_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_unitful`](@ref)."""
 get_reactive_power_limits(value::ThermalStandard, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits), Val(:mvar), units))
 """Get [`ThermalStandard`](@ref) `reactive_power_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits`](@ref)."""
 get_reactive_power_limits_unitful(value::ThermalStandard, units) = get_value(value, Val(:reactive_power_limits), Val(:mvar), units)
+get_reactive_power_limits(value::ThermalStandard) = _units_arg_required(get_reactive_power_limits, value, :reactive_power_limits, Val(:mvar))
+get_reactive_power_limits_unitful(value::ThermalStandard) = _units_arg_required(get_reactive_power_limits_unitful, value, :reactive_power_limits, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_unitful), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 """Get [`ThermalStandard`](@ref) `ramp_limits` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_ramp_limits_unitful`](@ref)."""
 get_ramp_limits(value::ThermalStandard, units) = InfrastructureSystems._strip_units(get_value(value, Val(:ramp_limits), Val(:mw), units))
 """Get [`ThermalStandard`](@ref) `ramp_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_ramp_limits`](@ref)."""
 get_ramp_limits_unitful(value::ThermalStandard, units) = get_value(value, Val(:ramp_limits), Val(:mw), units)
+get_ramp_limits(value::ThermalStandard) = _units_arg_required(get_ramp_limits, value, :ramp_limits, Val(:mw))
+get_ramp_limits_unitful(value::ThermalStandard) = _units_arg_required(get_ramp_limits_unitful, value, :ramp_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_ramp_limits_unitful), ::Type{ThermalStandard}) = InfrastructureSystems.SU
 """Get [`ThermalStandard`](@ref) `operation_cost`."""
@@ -210,16 +222,28 @@ set_status!(value::ThermalStandard, val) = value.status = val
 set_bus!(value::ThermalStandard, val) = value.bus = val
 """Set [`ThermalStandard`](@ref) `active_power`."""
 set_active_power!(value::ThermalStandard, val) = value.active_power = set_value(value, Val(:active_power), val, Val(:mw))
+set_active_power!(value::ThermalStandard, val::Real) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
+set_active_power!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power!, value, :active_power, Val(:mw), val)
 """Set [`ThermalStandard`](@ref) `reactive_power`."""
 set_reactive_power!(value::ThermalStandard, val) = value.reactive_power = set_value(value, Val(:reactive_power), val, Val(:mvar))
+set_reactive_power!(value::ThermalStandard, val::Real) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
+set_reactive_power!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power!, value, :reactive_power, Val(:mvar), val)
 """Set [`ThermalStandard`](@ref) `rating`."""
 set_rating!(value::ThermalStandard, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::ThermalStandard, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`ThermalStandard`](@ref) `active_power_limits`."""
 set_active_power_limits!(value::ThermalStandard, val) = value.active_power_limits = set_value(value, Val(:active_power_limits), val, Val(:mw))
+set_active_power_limits!(value::ThermalStandard, val::Real) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
+set_active_power_limits!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits!, value, :active_power_limits, Val(:mw), val)
 """Set [`ThermalStandard`](@ref) `reactive_power_limits`."""
 set_reactive_power_limits!(value::ThermalStandard, val) = value.reactive_power_limits = set_value(value, Val(:reactive_power_limits), val, Val(:mvar))
+set_reactive_power_limits!(value::ThermalStandard, val::Real) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
+set_reactive_power_limits!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits!, value, :reactive_power_limits, Val(:mvar), val)
 """Set [`ThermalStandard`](@ref) `ramp_limits`."""
 set_ramp_limits!(value::ThermalStandard, val) = value.ramp_limits = set_value(value, Val(:ramp_limits), val, Val(:mw))
+set_ramp_limits!(value::ThermalStandard, val::Real) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
+set_ramp_limits!(value::ThermalStandard, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_ramp_limits!, value, :ramp_limits, Val(:mw), val)
 """Set [`ThermalStandard`](@ref) `operation_cost`."""
 set_operation_cost!(value::ThermalStandard, val) = value.operation_cost = val
 """Set [`ThermalStandard`](@ref) `time_limits`."""

--- a/src/models/generated/ThreeWindingTransformer.jl
+++ b/src/models/generated/ThreeWindingTransformer.jl
@@ -210,32 +210,25 @@ get_internal(value::ThreeWindingTransformer) = value.internal
 set_star_bus!(value::ThreeWindingTransformer, val) = value.star_bus = val
 """Set [`ThreeWindingTransformer`](@ref) `r_12`."""
 set_r_12!(value::ThreeWindingTransformer, val) = value.r_12 = set_value(value, Val(:r_12), val, Val(:ohm))
-set_r_12!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_r_12!, value, :r_12, Val(:ohm), val)
-set_r_12!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r_12!, value, :r_12, Val(:ohm), val)
+set_r_12!(value::ThreeWindingTransformer, val::_UntaggedNumber) = _units_tag_required(set_r_12!, value, :r_12, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `x_12`."""
 set_x_12!(value::ThreeWindingTransformer, val) = value.x_12 = set_value(value, Val(:x_12), val, Val(:ohm))
-set_x_12!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_x_12!, value, :x_12, Val(:ohm), val)
-set_x_12!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x_12!, value, :x_12, Val(:ohm), val)
+set_x_12!(value::ThreeWindingTransformer, val::_UntaggedNumber) = _units_tag_required(set_x_12!, value, :x_12, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `r_23`."""
 set_r_23!(value::ThreeWindingTransformer, val) = value.r_23 = set_value(value, Val(:r_23), val, Val(:ohm))
-set_r_23!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_r_23!, value, :r_23, Val(:ohm), val)
-set_r_23!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r_23!, value, :r_23, Val(:ohm), val)
+set_r_23!(value::ThreeWindingTransformer, val::_UntaggedNumber) = _units_tag_required(set_r_23!, value, :r_23, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `x_23`."""
 set_x_23!(value::ThreeWindingTransformer, val) = value.x_23 = set_value(value, Val(:x_23), val, Val(:ohm))
-set_x_23!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_x_23!, value, :x_23, Val(:ohm), val)
-set_x_23!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x_23!, value, :x_23, Val(:ohm), val)
+set_x_23!(value::ThreeWindingTransformer, val::_UntaggedNumber) = _units_tag_required(set_x_23!, value, :x_23, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `r_31`."""
 set_r_31!(value::ThreeWindingTransformer, val) = value.r_31 = set_value(value, Val(:r_31), val, Val(:ohm))
-set_r_31!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_r_31!, value, :r_31, Val(:ohm), val)
-set_r_31!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r_31!, value, :r_31, Val(:ohm), val)
+set_r_31!(value::ThreeWindingTransformer, val::_UntaggedNumber) = _units_tag_required(set_r_31!, value, :r_31, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `x_31`."""
 set_x_31!(value::ThreeWindingTransformer, val) = value.x_31 = set_value(value, Val(:x_31), val, Val(:ohm))
-set_x_31!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_x_31!, value, :x_31, Val(:ohm), val)
-set_x_31!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x_31!, value, :x_31, Val(:ohm), val)
+set_x_31!(value::ThreeWindingTransformer, val::_UntaggedNumber) = _units_tag_required(set_x_31!, value, :x_31, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `magnetizing_shunt`."""
 set_magnetizing_shunt!(value::ThreeWindingTransformer, val) = value.magnetizing_shunt = set_value(value, Val(:magnetizing_shunt), val, Val(:siemens))
-set_magnetizing_shunt!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
-set_magnetizing_shunt!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
+set_magnetizing_shunt!(value::ThreeWindingTransformer, val::_UntaggedNumber) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
 """Set [`ThreeWindingTransformer`](@ref) `shunt_location`."""
 set_shunt_location!(value::ThreeWindingTransformer, val) = value.shunt_location = val
 """Set [`ThreeWindingTransformer`](@ref) `services`."""

--- a/src/models/generated/ThreeWindingTransformer.jl
+++ b/src/models/generated/ThreeWindingTransformer.jl
@@ -139,36 +139,48 @@ get_star_bus(value::ThreeWindingTransformer) = value.star_bus
 get_r_12(value::ThreeWindingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r_12), Val(:ohm), units))
 """Get [`ThreeWindingTransformer`](@ref) `r_12` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r_12`](@ref)."""
 get_r_12_unitful(value::ThreeWindingTransformer, units) = get_value(value, Val(:r_12), Val(:ohm), units)
+get_r_12(value::ThreeWindingTransformer) = _units_arg_required(get_r_12, value, :r_12, Val(:ohm))
+get_r_12_unitful(value::ThreeWindingTransformer) = _units_arg_required(get_r_12_unitful, value, :r_12, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_r_12), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_r_12_unitful), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 """Get [`ThreeWindingTransformer`](@ref) `x_12` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_x_12_unitful`](@ref)."""
 get_x_12(value::ThreeWindingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:x_12), Val(:ohm), units))
 """Get [`ThreeWindingTransformer`](@ref) `x_12` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_x_12`](@ref)."""
 get_x_12_unitful(value::ThreeWindingTransformer, units) = get_value(value, Val(:x_12), Val(:ohm), units)
+get_x_12(value::ThreeWindingTransformer) = _units_arg_required(get_x_12, value, :x_12, Val(:ohm))
+get_x_12_unitful(value::ThreeWindingTransformer) = _units_arg_required(get_x_12_unitful, value, :x_12, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_x_12), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_x_12_unitful), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 """Get [`ThreeWindingTransformer`](@ref) `r_23` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_r_23_unitful`](@ref)."""
 get_r_23(value::ThreeWindingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r_23), Val(:ohm), units))
 """Get [`ThreeWindingTransformer`](@ref) `r_23` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r_23`](@ref)."""
 get_r_23_unitful(value::ThreeWindingTransformer, units) = get_value(value, Val(:r_23), Val(:ohm), units)
+get_r_23(value::ThreeWindingTransformer) = _units_arg_required(get_r_23, value, :r_23, Val(:ohm))
+get_r_23_unitful(value::ThreeWindingTransformer) = _units_arg_required(get_r_23_unitful, value, :r_23, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_r_23), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_r_23_unitful), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 """Get [`ThreeWindingTransformer`](@ref) `x_23` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_x_23_unitful`](@ref)."""
 get_x_23(value::ThreeWindingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:x_23), Val(:ohm), units))
 """Get [`ThreeWindingTransformer`](@ref) `x_23` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_x_23`](@ref)."""
 get_x_23_unitful(value::ThreeWindingTransformer, units) = get_value(value, Val(:x_23), Val(:ohm), units)
+get_x_23(value::ThreeWindingTransformer) = _units_arg_required(get_x_23, value, :x_23, Val(:ohm))
+get_x_23_unitful(value::ThreeWindingTransformer) = _units_arg_required(get_x_23_unitful, value, :x_23, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_x_23), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_x_23_unitful), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 """Get [`ThreeWindingTransformer`](@ref) `r_31` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_r_31_unitful`](@ref)."""
 get_r_31(value::ThreeWindingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r_31), Val(:ohm), units))
 """Get [`ThreeWindingTransformer`](@ref) `r_31` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r_31`](@ref)."""
 get_r_31_unitful(value::ThreeWindingTransformer, units) = get_value(value, Val(:r_31), Val(:ohm), units)
+get_r_31(value::ThreeWindingTransformer) = _units_arg_required(get_r_31, value, :r_31, Val(:ohm))
+get_r_31_unitful(value::ThreeWindingTransformer) = _units_arg_required(get_r_31_unitful, value, :r_31, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_r_31), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_r_31_unitful), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 """Get [`ThreeWindingTransformer`](@ref) `x_31` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_x_31_unitful`](@ref)."""
 get_x_31(value::ThreeWindingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:x_31), Val(:ohm), units))
 """Get [`ThreeWindingTransformer`](@ref) `x_31` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_x_31`](@ref)."""
 get_x_31_unitful(value::ThreeWindingTransformer, units) = get_value(value, Val(:x_31), Val(:ohm), units)
+get_x_31(value::ThreeWindingTransformer) = _units_arg_required(get_x_31, value, :x_31, Val(:ohm))
+get_x_31_unitful(value::ThreeWindingTransformer) = _units_arg_required(get_x_31_unitful, value, :x_31, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_x_31), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_x_31_unitful), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 
@@ -181,6 +193,8 @@ _get_base_power_31(value::ThreeWindingTransformer) = value.base_power_31
 get_magnetizing_shunt(value::ThreeWindingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:magnetizing_shunt), Val(:siemens), units))
 """Get [`ThreeWindingTransformer`](@ref) `magnetizing_shunt` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_magnetizing_shunt`](@ref)."""
 get_magnetizing_shunt_unitful(value::ThreeWindingTransformer, units) = get_value(value, Val(:magnetizing_shunt), Val(:siemens), units)
+get_magnetizing_shunt(value::ThreeWindingTransformer) = _units_arg_required(get_magnetizing_shunt, value, :magnetizing_shunt, Val(:siemens))
+get_magnetizing_shunt_unitful(value::ThreeWindingTransformer) = _units_arg_required(get_magnetizing_shunt_unitful, value, :magnetizing_shunt, Val(:siemens))
 InfrastructureSystems.display_units_arg(::typeof(get_magnetizing_shunt), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_magnetizing_shunt_unitful), ::Type{ThreeWindingTransformer}) = InfrastructureSystems.SU
 """Get [`ThreeWindingTransformer`](@ref) `shunt_location`."""
@@ -196,18 +210,32 @@ get_internal(value::ThreeWindingTransformer) = value.internal
 set_star_bus!(value::ThreeWindingTransformer, val) = value.star_bus = val
 """Set [`ThreeWindingTransformer`](@ref) `r_12`."""
 set_r_12!(value::ThreeWindingTransformer, val) = value.r_12 = set_value(value, Val(:r_12), val, Val(:ohm))
+set_r_12!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_r_12!, value, :r_12, Val(:ohm), val)
+set_r_12!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r_12!, value, :r_12, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `x_12`."""
 set_x_12!(value::ThreeWindingTransformer, val) = value.x_12 = set_value(value, Val(:x_12), val, Val(:ohm))
+set_x_12!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_x_12!, value, :x_12, Val(:ohm), val)
+set_x_12!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x_12!, value, :x_12, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `r_23`."""
 set_r_23!(value::ThreeWindingTransformer, val) = value.r_23 = set_value(value, Val(:r_23), val, Val(:ohm))
+set_r_23!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_r_23!, value, :r_23, Val(:ohm), val)
+set_r_23!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r_23!, value, :r_23, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `x_23`."""
 set_x_23!(value::ThreeWindingTransformer, val) = value.x_23 = set_value(value, Val(:x_23), val, Val(:ohm))
+set_x_23!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_x_23!, value, :x_23, Val(:ohm), val)
+set_x_23!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x_23!, value, :x_23, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `r_31`."""
 set_r_31!(value::ThreeWindingTransformer, val) = value.r_31 = set_value(value, Val(:r_31), val, Val(:ohm))
+set_r_31!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_r_31!, value, :r_31, Val(:ohm), val)
+set_r_31!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r_31!, value, :r_31, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `x_31`."""
 set_x_31!(value::ThreeWindingTransformer, val) = value.x_31 = set_value(value, Val(:x_31), val, Val(:ohm))
+set_x_31!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_x_31!, value, :x_31, Val(:ohm), val)
+set_x_31!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x_31!, value, :x_31, Val(:ohm), val)
 """Set [`ThreeWindingTransformer`](@ref) `magnetizing_shunt`."""
 set_magnetizing_shunt!(value::ThreeWindingTransformer, val) = value.magnetizing_shunt = set_value(value, Val(:magnetizing_shunt), val, Val(:siemens))
+set_magnetizing_shunt!(value::ThreeWindingTransformer, val::Real) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
+set_magnetizing_shunt!(value::ThreeWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
 """Set [`ThreeWindingTransformer`](@ref) `shunt_location`."""
 set_shunt_location!(value::ThreeWindingTransformer, val) = value.shunt_location = val
 """Set [`ThreeWindingTransformer`](@ref) `services`."""

--- a/src/models/generated/TransformerCircuit.jl
+++ b/src/models/generated/TransformerCircuit.jl
@@ -223,12 +223,10 @@ set_tap!(value::TransformerCircuit, val) = value.tap = val
 set_α!(value::TransformerCircuit, val) = value.α = val
 """Set [`TransformerCircuit`](@ref) `r`."""
 set_r!(value::TransformerCircuit, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
-set_r!(value::TransformerCircuit, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
-set_r!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::TransformerCircuit, val::_UntaggedNumber) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`TransformerCircuit`](@ref) `x`."""
 set_x!(value::TransformerCircuit, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
-set_x!(value::TransformerCircuit, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
-set_x!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::TransformerCircuit, val::_UntaggedNumber) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`TransformerCircuit`](@ref) `control_objective`."""
 set_control_objective!(value::TransformerCircuit, val) = value.control_objective = val
 """Set [`TransformerCircuit`](@ref) `regulated_bus_number`."""
@@ -241,24 +239,19 @@ set_controlled_quantity_limits!(value::TransformerCircuit, val) = value.controll
 set_number_of_tap_positions!(value::TransformerCircuit, val) = value.number_of_tap_positions = val
 """Set [`TransformerCircuit`](@ref) `rating`."""
 set_rating!(value::TransformerCircuit, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::TransformerCircuit, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::TransformerCircuit, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`TransformerCircuit`](@ref) `rating_b`."""
 set_rating_b!(value::TransformerCircuit, val) = value.rating_b = set_value(value, Val(:rating_b), val, Val(:mva))
-set_rating_b!(value::TransformerCircuit, val::Real) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
-set_rating_b!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
+set_rating_b!(value::TransformerCircuit, val::_UntaggedNumber) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
 """Set [`TransformerCircuit`](@ref) `rating_c`."""
 set_rating_c!(value::TransformerCircuit, val) = value.rating_c = set_value(value, Val(:rating_c), val, Val(:mva))
-set_rating_c!(value::TransformerCircuit, val::Real) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
-set_rating_c!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
+set_rating_c!(value::TransformerCircuit, val::_UntaggedNumber) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
 """Set [`TransformerCircuit`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TransformerCircuit, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::TransformerCircuit, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TransformerCircuit, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TransformerCircuit`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::TransformerCircuit, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
-set_reactive_power_flow!(value::TransformerCircuit, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
-set_reactive_power_flow!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::TransformerCircuit, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`TransformerCircuit`](@ref) `base_power`."""
 set_base_power!(value::TransformerCircuit, val) = value.base_power = val
 """Set [`TransformerCircuit`](@ref) `base_voltage_primary`."""

--- a/src/models/generated/TransformerCircuit.jl
+++ b/src/models/generated/TransformerCircuit.jl
@@ -142,12 +142,16 @@ get_α(value::TransformerCircuit) = value.α
 get_r(value::TransformerCircuit, units) = InfrastructureSystems._strip_units(get_value(value, Val(:r), Val(:ohm), units))
 """Get [`TransformerCircuit`](@ref) `r` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_r`](@ref)."""
 get_r_unitful(value::TransformerCircuit, units) = get_value(value, Val(:r), Val(:ohm), units)
+get_r(value::TransformerCircuit) = _units_arg_required(get_r, value, :r, Val(:ohm))
+get_r_unitful(value::TransformerCircuit) = _units_arg_required(get_r_unitful, value, :r, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_r), ::Type{TransformerCircuit}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_r_unitful), ::Type{TransformerCircuit}) = InfrastructureSystems.SU
 """Get [`TransformerCircuit`](@ref) `x` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_x_unitful`](@ref)."""
 get_x(value::TransformerCircuit, units) = InfrastructureSystems._strip_units(get_value(value, Val(:x), Val(:ohm), units))
 """Get [`TransformerCircuit`](@ref) `x` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_x`](@ref)."""
 get_x_unitful(value::TransformerCircuit, units) = get_value(value, Val(:x), Val(:ohm), units)
+get_x(value::TransformerCircuit) = _units_arg_required(get_x, value, :x, Val(:ohm))
+get_x_unitful(value::TransformerCircuit) = _units_arg_required(get_x_unitful, value, :x, Val(:ohm))
 InfrastructureSystems.display_units_arg(::typeof(get_x), ::Type{TransformerCircuit}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_x_unitful), ::Type{TransformerCircuit}) = InfrastructureSystems.SU
 """Get [`TransformerCircuit`](@ref) `control_objective`."""
@@ -164,30 +168,40 @@ get_number_of_tap_positions(value::TransformerCircuit) = value.number_of_tap_pos
 get_rating(value::TransformerCircuit, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`TransformerCircuit`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::TransformerCircuit, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::TransformerCircuit) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::TransformerCircuit) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{TransformerCircuit}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{TransformerCircuit}) = InfrastructureSystems.DU
 """Get [`TransformerCircuit`](@ref) `rating_b` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_b_unitful`](@ref)."""
 get_rating_b(value::TransformerCircuit, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_b), Val(:mva), units))
 """Get [`TransformerCircuit`](@ref) `rating_b` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_b`](@ref)."""
 get_rating_b_unitful(value::TransformerCircuit, units) = get_value(value, Val(:rating_b), Val(:mva), units)
+get_rating_b(value::TransformerCircuit) = _units_arg_required(get_rating_b, value, :rating_b, Val(:mva))
+get_rating_b_unitful(value::TransformerCircuit) = _units_arg_required(get_rating_b_unitful, value, :rating_b, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating_b), ::Type{TransformerCircuit}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_b_unitful), ::Type{TransformerCircuit}) = InfrastructureSystems.DU
 """Get [`TransformerCircuit`](@ref) `rating_c` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_c_unitful`](@ref)."""
 get_rating_c(value::TransformerCircuit, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_c), Val(:mva), units))
 """Get [`TransformerCircuit`](@ref) `rating_c` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_c`](@ref)."""
 get_rating_c_unitful(value::TransformerCircuit, units) = get_value(value, Val(:rating_c), Val(:mva), units)
+get_rating_c(value::TransformerCircuit) = _units_arg_required(get_rating_c, value, :rating_c, Val(:mva))
+get_rating_c_unitful(value::TransformerCircuit) = _units_arg_required(get_rating_c_unitful, value, :rating_c, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating_c), ::Type{TransformerCircuit}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_c_unitful), ::Type{TransformerCircuit}) = InfrastructureSystems.DU
 """Get [`TransformerCircuit`](@ref) `active_power_flow` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_flow_unitful`](@ref)."""
 get_active_power_flow(value::TransformerCircuit, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`TransformerCircuit`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::TransformerCircuit, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::TransformerCircuit) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::TransformerCircuit) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{TransformerCircuit}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{TransformerCircuit}) = InfrastructureSystems.SU
 """Get [`TransformerCircuit`](@ref) `reactive_power_flow` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_flow_unitful`](@ref)."""
 get_reactive_power_flow(value::TransformerCircuit, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_flow), Val(:mvar), units))
 """Get [`TransformerCircuit`](@ref) `reactive_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_flow`](@ref)."""
 get_reactive_power_flow_unitful(value::TransformerCircuit, units) = get_value(value, Val(:reactive_power_flow), Val(:mvar), units)
+get_reactive_power_flow(value::TransformerCircuit) = _units_arg_required(get_reactive_power_flow, value, :reactive_power_flow, Val(:mvar))
+get_reactive_power_flow_unitful(value::TransformerCircuit) = _units_arg_required(get_reactive_power_flow_unitful, value, :reactive_power_flow, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow), ::Type{TransformerCircuit}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_flow_unitful), ::Type{TransformerCircuit}) = InfrastructureSystems.SU
 """Get [`TransformerCircuit`](@ref) `base_power`."""
@@ -209,8 +223,12 @@ set_tap!(value::TransformerCircuit, val) = value.tap = val
 set_α!(value::TransformerCircuit, val) = value.α = val
 """Set [`TransformerCircuit`](@ref) `r`."""
 set_r!(value::TransformerCircuit, val) = value.r = set_value(value, Val(:r), val, Val(:ohm))
+set_r!(value::TransformerCircuit, val::Real) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
+set_r!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_r!, value, :r, Val(:ohm), val)
 """Set [`TransformerCircuit`](@ref) `x`."""
 set_x!(value::TransformerCircuit, val) = value.x = set_value(value, Val(:x), val, Val(:ohm))
+set_x!(value::TransformerCircuit, val::Real) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
+set_x!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_x!, value, :x, Val(:ohm), val)
 """Set [`TransformerCircuit`](@ref) `control_objective`."""
 set_control_objective!(value::TransformerCircuit, val) = value.control_objective = val
 """Set [`TransformerCircuit`](@ref) `regulated_bus_number`."""
@@ -223,14 +241,24 @@ set_controlled_quantity_limits!(value::TransformerCircuit, val) = value.controll
 set_number_of_tap_positions!(value::TransformerCircuit, val) = value.number_of_tap_positions = val
 """Set [`TransformerCircuit`](@ref) `rating`."""
 set_rating!(value::TransformerCircuit, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::TransformerCircuit, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`TransformerCircuit`](@ref) `rating_b`."""
 set_rating_b!(value::TransformerCircuit, val) = value.rating_b = set_value(value, Val(:rating_b), val, Val(:mva))
+set_rating_b!(value::TransformerCircuit, val::Real) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
+set_rating_b!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_b!, value, :rating_b, Val(:mva), val)
 """Set [`TransformerCircuit`](@ref) `rating_c`."""
 set_rating_c!(value::TransformerCircuit, val) = value.rating_c = set_value(value, Val(:rating_c), val, Val(:mva))
+set_rating_c!(value::TransformerCircuit, val::Real) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
+set_rating_c!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_c!, value, :rating_c, Val(:mva), val)
 """Set [`TransformerCircuit`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TransformerCircuit, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::TransformerCircuit, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TransformerCircuit`](@ref) `reactive_power_flow`."""
 set_reactive_power_flow!(value::TransformerCircuit, val) = value.reactive_power_flow = set_value(value, Val(:reactive_power_flow), val, Val(:mvar))
+set_reactive_power_flow!(value::TransformerCircuit, val::Real) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
+set_reactive_power_flow!(value::TransformerCircuit, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_flow!, value, :reactive_power_flow, Val(:mvar), val)
 """Set [`TransformerCircuit`](@ref) `base_power`."""
 set_base_power!(value::TransformerCircuit, val) = value.base_power = val
 """Set [`TransformerCircuit`](@ref) `base_voltage_primary`."""

--- a/src/models/generated/TransmissionInterface.jl
+++ b/src/models/generated/TransmissionInterface.jl
@@ -90,8 +90,8 @@ get_internal(value::TransmissionInterface) = value.internal
 set_available!(value::TransmissionInterface, val) = value.available = val
 """Set [`TransmissionInterface`](@ref) `active_power_flow_limits`."""
 set_active_power_flow_limits!(value::TransmissionInterface, val) = value.active_power_flow_limits = set_value(value, Val(:active_power_flow_limits), val, Val(:mw))
-set_active_power_flow_limits!(value::TransmissionInterface, val::Real) = _units_tag_required(set_active_power_flow_limits!, value, :active_power_flow_limits, Val(:mw), val)
-set_active_power_flow_limits!(value::TransmissionInterface, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow_limits!, value, :active_power_flow_limits, Val(:mw), val)
+set_active_power_flow_limits!(value::TransmissionInterface, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow_limits!, value, :active_power_flow_limits, Val(:mw), val)
+set_active_power_flow_limits!(value::TransmissionInterface, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_flow_limits!, value, :active_power_flow_limits, Val(:mw), val)
 """Set [`TransmissionInterface`](@ref) `violation_penalty`."""
 set_violation_penalty!(value::TransmissionInterface, val) = value.violation_penalty = val
 """Set [`TransmissionInterface`](@ref) `direction_mapping`."""

--- a/src/models/generated/TransmissionInterface.jl
+++ b/src/models/generated/TransmissionInterface.jl
@@ -73,6 +73,8 @@ get_available(value::TransmissionInterface) = value.available
 get_active_power_flow_limits(value::TransmissionInterface, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow_limits), Val(:mw), units))
 """Get [`TransmissionInterface`](@ref) `active_power_flow_limits` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow_limits`](@ref)."""
 get_active_power_flow_limits_unitful(value::TransmissionInterface, units) = get_value(value, Val(:active_power_flow_limits), Val(:mw), units)
+get_active_power_flow_limits(value::TransmissionInterface) = _units_arg_required(get_active_power_flow_limits, value, :active_power_flow_limits, Val(:mw))
+get_active_power_flow_limits_unitful(value::TransmissionInterface) = _units_arg_required(get_active_power_flow_limits_unitful, value, :active_power_flow_limits, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_limits), ::Type{TransmissionInterface}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_limits_unitful), ::Type{TransmissionInterface}) = InfrastructureSystems.SU
 """Get [`TransmissionInterface`](@ref) `violation_penalty`."""
@@ -88,6 +90,8 @@ get_internal(value::TransmissionInterface) = value.internal
 set_available!(value::TransmissionInterface, val) = value.available = val
 """Set [`TransmissionInterface`](@ref) `active_power_flow_limits`."""
 set_active_power_flow_limits!(value::TransmissionInterface, val) = value.active_power_flow_limits = set_value(value, Val(:active_power_flow_limits), val, Val(:mw))
+set_active_power_flow_limits!(value::TransmissionInterface, val::Real) = _units_tag_required(set_active_power_flow_limits!, value, :active_power_flow_limits, Val(:mw), val)
+set_active_power_flow_limits!(value::TransmissionInterface, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow_limits!, value, :active_power_flow_limits, Val(:mw), val)
 """Set [`TransmissionInterface`](@ref) `violation_penalty`."""
 set_violation_penalty!(value::TransmissionInterface, val) = value.violation_penalty = val
 """Set [`TransmissionInterface`](@ref) `direction_mapping`."""

--- a/src/models/generated/TwoTerminalGenericHVDCLine.jl
+++ b/src/models/generated/TwoTerminalGenericHVDCLine.jl
@@ -156,26 +156,25 @@ get_internal(value::TwoTerminalGenericHVDCLine) = value.internal
 set_available!(value::TwoTerminalGenericHVDCLine, val) = value.available = val
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TwoTerminalGenericHVDCLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TwoTerminalGenericHVDCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `arc`."""
 set_arc!(value::TwoTerminalGenericHVDCLine, val) = value.arc = val
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `active_power_limits_from`."""
 set_active_power_limits_from!(value::TwoTerminalGenericHVDCLine, val) = value.active_power_limits_from = set_value(value, Val(:active_power_limits_from), val, Val(:mw))
-set_active_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
-set_active_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `active_power_limits_to`."""
 set_active_power_limits_to!(value::TwoTerminalGenericHVDCLine, val) = value.active_power_limits_to = set_value(value, Val(:active_power_limits_to), val, Val(:mw))
-set_active_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
-set_active_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `reactive_power_limits_from`."""
 set_reactive_power_limits_from!(value::TwoTerminalGenericHVDCLine, val) = value.reactive_power_limits_from = set_value(value, Val(:reactive_power_limits_from), val, Val(:mvar))
-set_reactive_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
-set_reactive_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `reactive_power_limits_to`."""
 set_reactive_power_limits_to!(value::TwoTerminalGenericHVDCLine, val) = value.reactive_power_limits_to = set_value(value, Val(:reactive_power_limits_to), val, Val(:mvar))
-set_reactive_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
-set_reactive_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `loss`."""
 set_loss!(value::TwoTerminalGenericHVDCLine, val) = value.loss = val
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `services`."""

--- a/src/models/generated/TwoTerminalGenericHVDCLine.jl
+++ b/src/models/generated/TwoTerminalGenericHVDCLine.jl
@@ -103,6 +103,8 @@ get_available(value::TwoTerminalGenericHVDCLine) = value.available
 get_active_power_flow(value::TwoTerminalGenericHVDCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::TwoTerminalGenericHVDCLine, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `arc`."""
@@ -111,24 +113,32 @@ get_arc(value::TwoTerminalGenericHVDCLine) = value.arc
 get_active_power_limits_from(value::TwoTerminalGenericHVDCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_from), Val(:mw), units))
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `active_power_limits_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_from`](@ref)."""
 get_active_power_limits_from_unitful(value::TwoTerminalGenericHVDCLine, units) = get_value(value, Val(:active_power_limits_from), Val(:mw), units)
+get_active_power_limits_from(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_active_power_limits_from, value, :active_power_limits_from, Val(:mw))
+get_active_power_limits_from_unitful(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_active_power_limits_from_unitful, value, :active_power_limits_from, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_from), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_from_unitful), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `active_power_limits_to` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_to_unitful`](@ref)."""
 get_active_power_limits_to(value::TwoTerminalGenericHVDCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_to), Val(:mw), units))
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `active_power_limits_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_to`](@ref)."""
 get_active_power_limits_to_unitful(value::TwoTerminalGenericHVDCLine, units) = get_value(value, Val(:active_power_limits_to), Val(:mw), units)
+get_active_power_limits_to(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_active_power_limits_to, value, :active_power_limits_to, Val(:mw))
+get_active_power_limits_to_unitful(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_active_power_limits_to_unitful, value, :active_power_limits_to, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_to), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_to_unitful), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `reactive_power_limits_from` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_from_unitful`](@ref)."""
 get_reactive_power_limits_from(value::TwoTerminalGenericHVDCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits_from), Val(:mvar), units))
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `reactive_power_limits_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits_from`](@ref)."""
 get_reactive_power_limits_from_unitful(value::TwoTerminalGenericHVDCLine, units) = get_value(value, Val(:reactive_power_limits_from), Val(:mvar), units)
+get_reactive_power_limits_from(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_reactive_power_limits_from, value, :reactive_power_limits_from, Val(:mvar))
+get_reactive_power_limits_from_unitful(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_reactive_power_limits_from_unitful, value, :reactive_power_limits_from, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_from), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_from_unitful), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `reactive_power_limits_to` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_to_unitful`](@ref)."""
 get_reactive_power_limits_to(value::TwoTerminalGenericHVDCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits_to), Val(:mvar), units))
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `reactive_power_limits_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits_to`](@ref)."""
 get_reactive_power_limits_to_unitful(value::TwoTerminalGenericHVDCLine, units) = get_value(value, Val(:reactive_power_limits_to), Val(:mvar), units)
+get_reactive_power_limits_to(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_reactive_power_limits_to, value, :reactive_power_limits_to, Val(:mvar))
+get_reactive_power_limits_to_unitful(value::TwoTerminalGenericHVDCLine) = _units_arg_required(get_reactive_power_limits_to_unitful, value, :reactive_power_limits_to, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_to), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_to_unitful), ::Type{TwoTerminalGenericHVDCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalGenericHVDCLine`](@ref) `loss`."""
@@ -146,16 +156,26 @@ get_internal(value::TwoTerminalGenericHVDCLine) = value.internal
 set_available!(value::TwoTerminalGenericHVDCLine, val) = value.available = val
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TwoTerminalGenericHVDCLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `arc`."""
 set_arc!(value::TwoTerminalGenericHVDCLine, val) = value.arc = val
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `active_power_limits_from`."""
 set_active_power_limits_from!(value::TwoTerminalGenericHVDCLine, val) = value.active_power_limits_from = set_value(value, Val(:active_power_limits_from), val, Val(:mw))
+set_active_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `active_power_limits_to`."""
 set_active_power_limits_to!(value::TwoTerminalGenericHVDCLine, val) = value.active_power_limits_to = set_value(value, Val(:active_power_limits_to), val, Val(:mw))
+set_active_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `reactive_power_limits_from`."""
 set_reactive_power_limits_from!(value::TwoTerminalGenericHVDCLine, val) = value.reactive_power_limits_from = set_value(value, Val(:reactive_power_limits_from), val, Val(:mvar))
+set_reactive_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `reactive_power_limits_to`."""
 set_reactive_power_limits_to!(value::TwoTerminalGenericHVDCLine, val) = value.reactive_power_limits_to = set_value(value, Val(:reactive_power_limits_to), val, Val(:mvar))
+set_reactive_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::Real) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalGenericHVDCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `loss`."""
 set_loss!(value::TwoTerminalGenericHVDCLine, val) = value.loss = val
 """Set [`TwoTerminalGenericHVDCLine`](@ref) `services`."""

--- a/src/models/generated/TwoTerminalLCCLine.jl
+++ b/src/models/generated/TwoTerminalLCCLine.jl
@@ -361,8 +361,7 @@ set_available!(value::TwoTerminalLCCLine, val) = value.available = val
 set_arc!(value::TwoTerminalLCCLine, val) = value.arc = val
 """Set [`TwoTerminalLCCLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TwoTerminalLCCLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TwoTerminalLCCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TwoTerminalLCCLine`](@ref) `r`."""
 set_r!(value::TwoTerminalLCCLine, val) = value.r = val
 """Set [`TwoTerminalLCCLine`](@ref) `transfer_setpoint`."""
@@ -423,20 +422,20 @@ set_inverter_extinction_angle!(value::TwoTerminalLCCLine, val) = value.inverter_
 set_inverter_capacitor_reactance!(value::TwoTerminalLCCLine, val) = value.inverter_capacitor_reactance = val
 """Set [`TwoTerminalLCCLine`](@ref) `active_power_limits_from`."""
 set_active_power_limits_from!(value::TwoTerminalLCCLine, val) = value.active_power_limits_from = set_value(value, Val(:active_power_limits_from), val, Val(:mw))
-set_active_power_limits_from!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
-set_active_power_limits_from!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalLCCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalLCCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
 """Set [`TwoTerminalLCCLine`](@ref) `active_power_limits_to`."""
 set_active_power_limits_to!(value::TwoTerminalLCCLine, val) = value.active_power_limits_to = set_value(value, Val(:active_power_limits_to), val, Val(:mw))
-set_active_power_limits_to!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
-set_active_power_limits_to!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalLCCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalLCCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
 """Set [`TwoTerminalLCCLine`](@ref) `reactive_power_limits_from`."""
 set_reactive_power_limits_from!(value::TwoTerminalLCCLine, val) = value.reactive_power_limits_from = set_value(value, Val(:reactive_power_limits_from), val, Val(:mvar))
-set_reactive_power_limits_from!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
-set_reactive_power_limits_from!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalLCCLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalLCCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
 """Set [`TwoTerminalLCCLine`](@ref) `reactive_power_limits_to`."""
 set_reactive_power_limits_to!(value::TwoTerminalLCCLine, val) = value.reactive_power_limits_to = set_value(value, Val(:reactive_power_limits_to), val, Val(:mvar))
-set_reactive_power_limits_to!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
-set_reactive_power_limits_to!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalLCCLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalLCCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
 """Set [`TwoTerminalLCCLine`](@ref) `loss`."""
 set_loss!(value::TwoTerminalLCCLine, val) = value.loss = val
 """Set [`TwoTerminalLCCLine`](@ref) `services`."""

--- a/src/models/generated/TwoTerminalLCCLine.jl
+++ b/src/models/generated/TwoTerminalLCCLine.jl
@@ -250,6 +250,8 @@ get_arc(value::TwoTerminalLCCLine) = value.arc
 get_active_power_flow(value::TwoTerminalLCCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`TwoTerminalLCCLine`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::TwoTerminalLCCLine, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::TwoTerminalLCCLine) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::TwoTerminalLCCLine) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalLCCLine`](@ref) `r`."""
@@ -314,24 +316,32 @@ get_inverter_capacitor_reactance(value::TwoTerminalLCCLine) = value.inverter_cap
 get_active_power_limits_from(value::TwoTerminalLCCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_from), Val(:mw), units))
 """Get [`TwoTerminalLCCLine`](@ref) `active_power_limits_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_from`](@ref)."""
 get_active_power_limits_from_unitful(value::TwoTerminalLCCLine, units) = get_value(value, Val(:active_power_limits_from), Val(:mw), units)
+get_active_power_limits_from(value::TwoTerminalLCCLine) = _units_arg_required(get_active_power_limits_from, value, :active_power_limits_from, Val(:mw))
+get_active_power_limits_from_unitful(value::TwoTerminalLCCLine) = _units_arg_required(get_active_power_limits_from_unitful, value, :active_power_limits_from, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_from), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_from_unitful), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalLCCLine`](@ref) `active_power_limits_to` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_to_unitful`](@ref)."""
 get_active_power_limits_to(value::TwoTerminalLCCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_to), Val(:mw), units))
 """Get [`TwoTerminalLCCLine`](@ref) `active_power_limits_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_to`](@ref)."""
 get_active_power_limits_to_unitful(value::TwoTerminalLCCLine, units) = get_value(value, Val(:active_power_limits_to), Val(:mw), units)
+get_active_power_limits_to(value::TwoTerminalLCCLine) = _units_arg_required(get_active_power_limits_to, value, :active_power_limits_to, Val(:mw))
+get_active_power_limits_to_unitful(value::TwoTerminalLCCLine) = _units_arg_required(get_active_power_limits_to_unitful, value, :active_power_limits_to, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_to), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_to_unitful), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalLCCLine`](@ref) `reactive_power_limits_from` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_from_unitful`](@ref)."""
 get_reactive_power_limits_from(value::TwoTerminalLCCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits_from), Val(:mvar), units))
 """Get [`TwoTerminalLCCLine`](@ref) `reactive_power_limits_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits_from`](@ref)."""
 get_reactive_power_limits_from_unitful(value::TwoTerminalLCCLine, units) = get_value(value, Val(:reactive_power_limits_from), Val(:mvar), units)
+get_reactive_power_limits_from(value::TwoTerminalLCCLine) = _units_arg_required(get_reactive_power_limits_from, value, :reactive_power_limits_from, Val(:mvar))
+get_reactive_power_limits_from_unitful(value::TwoTerminalLCCLine) = _units_arg_required(get_reactive_power_limits_from_unitful, value, :reactive_power_limits_from, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_from), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_from_unitful), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalLCCLine`](@ref) `reactive_power_limits_to` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_to_unitful`](@ref)."""
 get_reactive_power_limits_to(value::TwoTerminalLCCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits_to), Val(:mvar), units))
 """Get [`TwoTerminalLCCLine`](@ref) `reactive_power_limits_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits_to`](@ref)."""
 get_reactive_power_limits_to_unitful(value::TwoTerminalLCCLine, units) = get_value(value, Val(:reactive_power_limits_to), Val(:mvar), units)
+get_reactive_power_limits_to(value::TwoTerminalLCCLine) = _units_arg_required(get_reactive_power_limits_to, value, :reactive_power_limits_to, Val(:mvar))
+get_reactive_power_limits_to_unitful(value::TwoTerminalLCCLine) = _units_arg_required(get_reactive_power_limits_to_unitful, value, :reactive_power_limits_to, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_to), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_to_unitful), ::Type{TwoTerminalLCCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalLCCLine`](@ref) `loss`."""
@@ -351,6 +361,8 @@ set_available!(value::TwoTerminalLCCLine, val) = value.available = val
 set_arc!(value::TwoTerminalLCCLine, val) = value.arc = val
 """Set [`TwoTerminalLCCLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TwoTerminalLCCLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TwoTerminalLCCLine`](@ref) `r`."""
 set_r!(value::TwoTerminalLCCLine, val) = value.r = val
 """Set [`TwoTerminalLCCLine`](@ref) `transfer_setpoint`."""
@@ -411,12 +423,20 @@ set_inverter_extinction_angle!(value::TwoTerminalLCCLine, val) = value.inverter_
 set_inverter_capacitor_reactance!(value::TwoTerminalLCCLine, val) = value.inverter_capacitor_reactance = val
 """Set [`TwoTerminalLCCLine`](@ref) `active_power_limits_from`."""
 set_active_power_limits_from!(value::TwoTerminalLCCLine, val) = value.active_power_limits_from = set_value(value, Val(:active_power_limits_from), val, Val(:mw))
+set_active_power_limits_from!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
 """Set [`TwoTerminalLCCLine`](@ref) `active_power_limits_to`."""
 set_active_power_limits_to!(value::TwoTerminalLCCLine, val) = value.active_power_limits_to = set_value(value, Val(:active_power_limits_to), val, Val(:mw))
+set_active_power_limits_to!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
 """Set [`TwoTerminalLCCLine`](@ref) `reactive_power_limits_from`."""
 set_reactive_power_limits_from!(value::TwoTerminalLCCLine, val) = value.reactive_power_limits_from = set_value(value, Val(:reactive_power_limits_from), val, Val(:mvar))
+set_reactive_power_limits_from!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
 """Set [`TwoTerminalLCCLine`](@ref) `reactive_power_limits_to`."""
 set_reactive_power_limits_to!(value::TwoTerminalLCCLine, val) = value.reactive_power_limits_to = set_value(value, Val(:reactive_power_limits_to), val, Val(:mvar))
+set_reactive_power_limits_to!(value::TwoTerminalLCCLine, val::Real) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalLCCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
 """Set [`TwoTerminalLCCLine`](@ref) `loss`."""
 set_loss!(value::TwoTerminalLCCLine, val) = value.loss = val
 """Set [`TwoTerminalLCCLine`](@ref) `services`."""

--- a/src/models/generated/TwoTerminalVSCLine.jl
+++ b/src/models/generated/TwoTerminalVSCLine.jl
@@ -260,24 +260,32 @@ get_arc(value::TwoTerminalVSCLine) = value.arc
 get_active_power_flow(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_flow), Val(:mw), units))
 """Get [`TwoTerminalVSCLine`](@ref) `active_power_flow` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_flow`](@ref)."""
 get_active_power_flow_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:active_power_flow), Val(:mw), units)
+get_active_power_flow(value::TwoTerminalVSCLine) = _units_arg_required(get_active_power_flow, value, :active_power_flow, Val(:mw))
+get_active_power_flow_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_active_power_flow_unitful, value, :active_power_flow, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_flow_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `rating` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_rating_unitful`](@ref)."""
 get_rating(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating), Val(:mva), units))
 """Get [`TwoTerminalVSCLine`](@ref) `rating` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating`](@ref)."""
 get_rating_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:rating), Val(:mva), units)
+get_rating(value::TwoTerminalVSCLine) = _units_arg_required(get_rating, value, :rating, Val(:mva))
+get_rating_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_rating_unitful, value, :rating, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.DU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.DU
 """Get [`TwoTerminalVSCLine`](@ref) `active_power_limits_from` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_from_unitful`](@ref)."""
 get_active_power_limits_from(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_from), Val(:mw), units))
 """Get [`TwoTerminalVSCLine`](@ref) `active_power_limits_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_from`](@ref)."""
 get_active_power_limits_from_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:active_power_limits_from), Val(:mw), units)
+get_active_power_limits_from(value::TwoTerminalVSCLine) = _units_arg_required(get_active_power_limits_from, value, :active_power_limits_from, Val(:mw))
+get_active_power_limits_from_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_active_power_limits_from_unitful, value, :active_power_limits_from, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_from), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_from_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `active_power_limits_to` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_active_power_limits_to_unitful`](@ref)."""
 get_active_power_limits_to(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:active_power_limits_to), Val(:mw), units))
 """Get [`TwoTerminalVSCLine`](@ref) `active_power_limits_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_active_power_limits_to`](@ref)."""
 get_active_power_limits_to_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:active_power_limits_to), Val(:mw), units)
+get_active_power_limits_to(value::TwoTerminalVSCLine) = _units_arg_required(get_active_power_limits_to, value, :active_power_limits_to, Val(:mw))
+get_active_power_limits_to_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_active_power_limits_to_unitful, value, :active_power_limits_to, Val(:mw))
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_to), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_active_power_limits_to_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `g`."""
@@ -288,6 +296,8 @@ get_dc_current(value::TwoTerminalVSCLine) = value.dc_current
 get_reactive_power_from(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_from), Val(:mvar), units))
 """Get [`TwoTerminalVSCLine`](@ref) `reactive_power_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_from`](@ref)."""
 get_reactive_power_from_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:reactive_power_from), Val(:mvar), units)
+get_reactive_power_from(value::TwoTerminalVSCLine) = _units_arg_required(get_reactive_power_from, value, :reactive_power_from, Val(:mvar))
+get_reactive_power_from_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_reactive_power_from_unitful, value, :reactive_power_from, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_from), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_from_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `dc_control_from`."""
@@ -308,12 +318,16 @@ get_max_dc_current_from(value::TwoTerminalVSCLine) = value.max_dc_current_from
 get_rating_from(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_from), Val(:mva), units))
 """Get [`TwoTerminalVSCLine`](@ref) `rating_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_from`](@ref)."""
 get_rating_from_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:rating_from), Val(:mva), units)
+get_rating_from(value::TwoTerminalVSCLine) = _units_arg_required(get_rating_from, value, :rating_from, Val(:mva))
+get_rating_from_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_rating_from_unitful, value, :rating_from, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating_from), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_from_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `reactive_power_limits_from` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_from_unitful`](@ref)."""
 get_reactive_power_limits_from(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits_from), Val(:mvar), units))
 """Get [`TwoTerminalVSCLine`](@ref) `reactive_power_limits_from` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits_from`](@ref)."""
 get_reactive_power_limits_from_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:reactive_power_limits_from), Val(:mvar), units)
+get_reactive_power_limits_from(value::TwoTerminalVSCLine) = _units_arg_required(get_reactive_power_limits_from, value, :reactive_power_limits_from, Val(:mvar))
+get_reactive_power_limits_from_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_reactive_power_limits_from_unitful, value, :reactive_power_limits_from, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_from), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_from_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `power_factor_weighting_fraction_from`."""
@@ -326,6 +340,8 @@ get_dc_voltage_droop_from(value::TwoTerminalVSCLine) = value.dc_voltage_droop_fr
 get_reactive_power_to(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_to), Val(:mvar), units))
 """Get [`TwoTerminalVSCLine`](@ref) `reactive_power_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_to`](@ref)."""
 get_reactive_power_to_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:reactive_power_to), Val(:mvar), units)
+get_reactive_power_to(value::TwoTerminalVSCLine) = _units_arg_required(get_reactive_power_to, value, :reactive_power_to, Val(:mvar))
+get_reactive_power_to_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_reactive_power_to_unitful, value, :reactive_power_to, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_to), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_to_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `dc_control_to`."""
@@ -346,12 +362,16 @@ get_max_dc_current_to(value::TwoTerminalVSCLine) = value.max_dc_current_to
 get_rating_to(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:rating_to), Val(:mva), units))
 """Get [`TwoTerminalVSCLine`](@ref) `rating_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_rating_to`](@ref)."""
 get_rating_to_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:rating_to), Val(:mva), units)
+get_rating_to(value::TwoTerminalVSCLine) = _units_arg_required(get_rating_to, value, :rating_to, Val(:mva))
+get_rating_to_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_rating_to_unitful, value, :rating_to, Val(:mva))
 InfrastructureSystems.display_units_arg(::typeof(get_rating_to), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_rating_to_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `reactive_power_limits_to` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`get_reactive_power_limits_to_unitful`](@ref)."""
 get_reactive_power_limits_to(value::TwoTerminalVSCLine, units) = InfrastructureSystems._strip_units(get_value(value, Val(:reactive_power_limits_to), Val(:mvar), units))
 """Get [`TwoTerminalVSCLine`](@ref) `reactive_power_limits_to` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_reactive_power_limits_to`](@ref)."""
 get_reactive_power_limits_to_unitful(value::TwoTerminalVSCLine, units) = get_value(value, Val(:reactive_power_limits_to), Val(:mvar), units)
+get_reactive_power_limits_to(value::TwoTerminalVSCLine) = _units_arg_required(get_reactive_power_limits_to, value, :reactive_power_limits_to, Val(:mvar))
+get_reactive_power_limits_to_unitful(value::TwoTerminalVSCLine) = _units_arg_required(get_reactive_power_limits_to_unitful, value, :reactive_power_limits_to, Val(:mvar))
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_to), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_reactive_power_limits_to_unitful), ::Type{TwoTerminalVSCLine}) = InfrastructureSystems.SU
 """Get [`TwoTerminalVSCLine`](@ref) `power_factor_weighting_fraction_to`."""
@@ -385,18 +405,28 @@ set_available!(value::TwoTerminalVSCLine, val) = value.available = val
 set_arc!(value::TwoTerminalVSCLine, val) = value.arc = val
 """Set [`TwoTerminalVSCLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TwoTerminalVSCLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
+set_active_power_flow!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TwoTerminalVSCLine`](@ref) `rating`."""
 set_rating!(value::TwoTerminalVSCLine, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
+set_rating!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`TwoTerminalVSCLine`](@ref) `active_power_limits_from`."""
 set_active_power_limits_from!(value::TwoTerminalVSCLine, val) = value.active_power_limits_from = set_value(value, Val(:active_power_limits_from), val, Val(:mw))
+set_active_power_limits_from!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
 """Set [`TwoTerminalVSCLine`](@ref) `active_power_limits_to`."""
 set_active_power_limits_to!(value::TwoTerminalVSCLine, val) = value.active_power_limits_to = set_value(value, Val(:active_power_limits_to), val, Val(:mw))
+set_active_power_limits_to!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
 """Set [`TwoTerminalVSCLine`](@ref) `g`."""
 set_g!(value::TwoTerminalVSCLine, val) = value.g = val
 """Set [`TwoTerminalVSCLine`](@ref) `dc_current`."""
 set_dc_current!(value::TwoTerminalVSCLine, val) = value.dc_current = val
 """Set [`TwoTerminalVSCLine`](@ref) `reactive_power_from`."""
 set_reactive_power_from!(value::TwoTerminalVSCLine, val) = value.reactive_power_from = set_value(value, Val(:reactive_power_from), val, Val(:mvar))
+set_reactive_power_from!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_reactive_power_from!, value, :reactive_power_from, Val(:mvar), val)
+set_reactive_power_from!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_from!, value, :reactive_power_from, Val(:mvar), val)
 """Set [`TwoTerminalVSCLine`](@ref) `dc_control_from`."""
 set_dc_control_from!(value::TwoTerminalVSCLine, val) = value.dc_control_from = val
 """Set [`TwoTerminalVSCLine`](@ref) `ac_control_from`."""
@@ -413,8 +443,12 @@ set_converter_loss_from!(value::TwoTerminalVSCLine, val) = value.converter_loss_
 set_max_dc_current_from!(value::TwoTerminalVSCLine, val) = value.max_dc_current_from = val
 """Set [`TwoTerminalVSCLine`](@ref) `rating_from`."""
 set_rating_from!(value::TwoTerminalVSCLine, val) = value.rating_from = set_value(value, Val(:rating_from), val, Val(:mva))
+set_rating_from!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_rating_from!, value, :rating_from, Val(:mva), val)
+set_rating_from!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_from!, value, :rating_from, Val(:mva), val)
 """Set [`TwoTerminalVSCLine`](@ref) `reactive_power_limits_from`."""
 set_reactive_power_limits_from!(value::TwoTerminalVSCLine, val) = value.reactive_power_limits_from = set_value(value, Val(:reactive_power_limits_from), val, Val(:mvar))
+set_reactive_power_limits_from!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
 """Set [`TwoTerminalVSCLine`](@ref) `power_factor_weighting_fraction_from`."""
 set_power_factor_weighting_fraction_from!(value::TwoTerminalVSCLine, val) = value.power_factor_weighting_fraction_from = val
 """Set [`TwoTerminalVSCLine`](@ref) `voltage_limits_from`."""
@@ -423,6 +457,8 @@ set_voltage_limits_from!(value::TwoTerminalVSCLine, val) = value.voltage_limits_
 set_dc_voltage_droop_from!(value::TwoTerminalVSCLine, val) = value.dc_voltage_droop_from = val
 """Set [`TwoTerminalVSCLine`](@ref) `reactive_power_to`."""
 set_reactive_power_to!(value::TwoTerminalVSCLine, val) = value.reactive_power_to = set_value(value, Val(:reactive_power_to), val, Val(:mvar))
+set_reactive_power_to!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_reactive_power_to!, value, :reactive_power_to, Val(:mvar), val)
+set_reactive_power_to!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_to!, value, :reactive_power_to, Val(:mvar), val)
 """Set [`TwoTerminalVSCLine`](@ref) `dc_control_to`."""
 set_dc_control_to!(value::TwoTerminalVSCLine, val) = value.dc_control_to = val
 """Set [`TwoTerminalVSCLine`](@ref) `ac_control_to`."""
@@ -439,8 +475,12 @@ set_converter_loss_to!(value::TwoTerminalVSCLine, val) = value.converter_loss_to
 set_max_dc_current_to!(value::TwoTerminalVSCLine, val) = value.max_dc_current_to = val
 """Set [`TwoTerminalVSCLine`](@ref) `rating_to`."""
 set_rating_to!(value::TwoTerminalVSCLine, val) = value.rating_to = set_value(value, Val(:rating_to), val, Val(:mva))
+set_rating_to!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_rating_to!, value, :rating_to, Val(:mva), val)
+set_rating_to!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_to!, value, :rating_to, Val(:mva), val)
 """Set [`TwoTerminalVSCLine`](@ref) `reactive_power_limits_to`."""
 set_reactive_power_limits_to!(value::TwoTerminalVSCLine, val) = value.reactive_power_limits_to = set_value(value, Val(:reactive_power_limits_to), val, Val(:mvar))
+set_reactive_power_limits_to!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
 """Set [`TwoTerminalVSCLine`](@ref) `power_factor_weighting_fraction_to`."""
 set_power_factor_weighting_fraction_to!(value::TwoTerminalVSCLine, val) = value.power_factor_weighting_fraction_to = val
 """Set [`TwoTerminalVSCLine`](@ref) `voltage_limits_to`."""

--- a/src/models/generated/TwoTerminalVSCLine.jl
+++ b/src/models/generated/TwoTerminalVSCLine.jl
@@ -405,28 +405,25 @@ set_available!(value::TwoTerminalVSCLine, val) = value.available = val
 set_arc!(value::TwoTerminalVSCLine, val) = value.arc = val
 """Set [`TwoTerminalVSCLine`](@ref) `active_power_flow`."""
 set_active_power_flow!(value::TwoTerminalVSCLine, val) = value.active_power_flow = set_value(value, Val(:active_power_flow), val, Val(:mw))
-set_active_power_flow!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
-set_active_power_flow!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
+set_active_power_flow!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_flow!, value, :active_power_flow, Val(:mw), val)
 """Set [`TwoTerminalVSCLine`](@ref) `rating`."""
 set_rating!(value::TwoTerminalVSCLine, val) = value.rating = set_value(value, Val(:rating), val, Val(:mva))
-set_rating!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
-set_rating!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
+set_rating!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_rating!, value, :rating, Val(:mva), val)
 """Set [`TwoTerminalVSCLine`](@ref) `active_power_limits_from`."""
 set_active_power_limits_from!(value::TwoTerminalVSCLine, val) = value.active_power_limits_from = set_value(value, Val(:active_power_limits_from), val, Val(:mw))
-set_active_power_limits_from!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
-set_active_power_limits_from!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
+set_active_power_limits_from!(value::TwoTerminalVSCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_from!, value, :active_power_limits_from, Val(:mw), val)
 """Set [`TwoTerminalVSCLine`](@ref) `active_power_limits_to`."""
 set_active_power_limits_to!(value::TwoTerminalVSCLine, val) = value.active_power_limits_to = set_value(value, Val(:active_power_limits_to), val, Val(:mw))
-set_active_power_limits_to!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
-set_active_power_limits_to!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
+set_active_power_limits_to!(value::TwoTerminalVSCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_active_power_limits_to!, value, :active_power_limits_to, Val(:mw), val)
 """Set [`TwoTerminalVSCLine`](@ref) `g`."""
 set_g!(value::TwoTerminalVSCLine, val) = value.g = val
 """Set [`TwoTerminalVSCLine`](@ref) `dc_current`."""
 set_dc_current!(value::TwoTerminalVSCLine, val) = value.dc_current = val
 """Set [`TwoTerminalVSCLine`](@ref) `reactive_power_from`."""
 set_reactive_power_from!(value::TwoTerminalVSCLine, val) = value.reactive_power_from = set_value(value, Val(:reactive_power_from), val, Val(:mvar))
-set_reactive_power_from!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_reactive_power_from!, value, :reactive_power_from, Val(:mvar), val)
-set_reactive_power_from!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_from!, value, :reactive_power_from, Val(:mvar), val)
+set_reactive_power_from!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_from!, value, :reactive_power_from, Val(:mvar), val)
 """Set [`TwoTerminalVSCLine`](@ref) `dc_control_from`."""
 set_dc_control_from!(value::TwoTerminalVSCLine, val) = value.dc_control_from = val
 """Set [`TwoTerminalVSCLine`](@ref) `ac_control_from`."""
@@ -443,12 +440,11 @@ set_converter_loss_from!(value::TwoTerminalVSCLine, val) = value.converter_loss_
 set_max_dc_current_from!(value::TwoTerminalVSCLine, val) = value.max_dc_current_from = val
 """Set [`TwoTerminalVSCLine`](@ref) `rating_from`."""
 set_rating_from!(value::TwoTerminalVSCLine, val) = value.rating_from = set_value(value, Val(:rating_from), val, Val(:mva))
-set_rating_from!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_rating_from!, value, :rating_from, Val(:mva), val)
-set_rating_from!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_from!, value, :rating_from, Val(:mva), val)
+set_rating_from!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_rating_from!, value, :rating_from, Val(:mva), val)
 """Set [`TwoTerminalVSCLine`](@ref) `reactive_power_limits_from`."""
 set_reactive_power_limits_from!(value::TwoTerminalVSCLine, val) = value.reactive_power_limits_from = set_value(value, Val(:reactive_power_limits_from), val, Val(:mvar))
-set_reactive_power_limits_from!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
-set_reactive_power_limits_from!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
+set_reactive_power_limits_from!(value::TwoTerminalVSCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits_from!, value, :reactive_power_limits_from, Val(:mvar), val)
 """Set [`TwoTerminalVSCLine`](@ref) `power_factor_weighting_fraction_from`."""
 set_power_factor_weighting_fraction_from!(value::TwoTerminalVSCLine, val) = value.power_factor_weighting_fraction_from = val
 """Set [`TwoTerminalVSCLine`](@ref) `voltage_limits_from`."""
@@ -457,8 +453,7 @@ set_voltage_limits_from!(value::TwoTerminalVSCLine, val) = value.voltage_limits_
 set_dc_voltage_droop_from!(value::TwoTerminalVSCLine, val) = value.dc_voltage_droop_from = val
 """Set [`TwoTerminalVSCLine`](@ref) `reactive_power_to`."""
 set_reactive_power_to!(value::TwoTerminalVSCLine, val) = value.reactive_power_to = set_value(value, Val(:reactive_power_to), val, Val(:mvar))
-set_reactive_power_to!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_reactive_power_to!, value, :reactive_power_to, Val(:mvar), val)
-set_reactive_power_to!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_to!, value, :reactive_power_to, Val(:mvar), val)
+set_reactive_power_to!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_to!, value, :reactive_power_to, Val(:mvar), val)
 """Set [`TwoTerminalVSCLine`](@ref) `dc_control_to`."""
 set_dc_control_to!(value::TwoTerminalVSCLine, val) = value.dc_control_to = val
 """Set [`TwoTerminalVSCLine`](@ref) `ac_control_to`."""
@@ -475,12 +470,11 @@ set_converter_loss_to!(value::TwoTerminalVSCLine, val) = value.converter_loss_to
 set_max_dc_current_to!(value::TwoTerminalVSCLine, val) = value.max_dc_current_to = val
 """Set [`TwoTerminalVSCLine`](@ref) `rating_to`."""
 set_rating_to!(value::TwoTerminalVSCLine, val) = value.rating_to = set_value(value, Val(:rating_to), val, Val(:mva))
-set_rating_to!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_rating_to!, value, :rating_to, Val(:mva), val)
-set_rating_to!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_rating_to!, value, :rating_to, Val(:mva), val)
+set_rating_to!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_rating_to!, value, :rating_to, Val(:mva), val)
 """Set [`TwoTerminalVSCLine`](@ref) `reactive_power_limits_to`."""
 set_reactive_power_limits_to!(value::TwoTerminalVSCLine, val) = value.reactive_power_limits_to = set_value(value, Val(:reactive_power_limits_to), val, Val(:mvar))
-set_reactive_power_limits_to!(value::TwoTerminalVSCLine, val::Real) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
-set_reactive_power_limits_to!(value::TwoTerminalVSCLine, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalVSCLine, val::_UntaggedNumber) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
+set_reactive_power_limits_to!(value::TwoTerminalVSCLine, val::NamedTuple{(:min, :max), <:Tuple{Vararg{_UntaggedNumber}}}) = _units_tag_required(set_reactive_power_limits_to!, value, :reactive_power_limits_to, Val(:mvar), val)
 """Set [`TwoTerminalVSCLine`](@ref) `power_factor_weighting_fraction_to`."""
 set_power_factor_weighting_fraction_to!(value::TwoTerminalVSCLine, val) = value.power_factor_weighting_fraction_to = val
 """Set [`TwoTerminalVSCLine`](@ref) `voltage_limits_to`."""

--- a/src/models/generated/TwoWindingTransformer.jl
+++ b/src/models/generated/TwoWindingTransformer.jl
@@ -73,6 +73,8 @@ get_circuit(value::TwoWindingTransformer) = value.circuit
 get_magnetizing_shunt(value::TwoWindingTransformer, units) = InfrastructureSystems._strip_units(get_value(value, Val(:magnetizing_shunt), Val(:siemens), units))
 """Get [`TwoWindingTransformer`](@ref) `magnetizing_shunt` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`get_magnetizing_shunt`](@ref)."""
 get_magnetizing_shunt_unitful(value::TwoWindingTransformer, units) = get_value(value, Val(:magnetizing_shunt), Val(:siemens), units)
+get_magnetizing_shunt(value::TwoWindingTransformer) = _units_arg_required(get_magnetizing_shunt, value, :magnetizing_shunt, Val(:siemens))
+get_magnetizing_shunt_unitful(value::TwoWindingTransformer) = _units_arg_required(get_magnetizing_shunt_unitful, value, :magnetizing_shunt, Val(:siemens))
 InfrastructureSystems.display_units_arg(::typeof(get_magnetizing_shunt), ::Type{TwoWindingTransformer}) = InfrastructureSystems.SU
 InfrastructureSystems.display_units_arg(::typeof(get_magnetizing_shunt_unitful), ::Type{TwoWindingTransformer}) = InfrastructureSystems.SU
 """Get [`TwoWindingTransformer`](@ref) `shunt_location`."""
@@ -86,6 +88,8 @@ get_internal(value::TwoWindingTransformer) = value.internal
 
 """Set [`TwoWindingTransformer`](@ref) `magnetizing_shunt`."""
 set_magnetizing_shunt!(value::TwoWindingTransformer, val) = value.magnetizing_shunt = set_value(value, Val(:magnetizing_shunt), val, Val(:siemens))
+set_magnetizing_shunt!(value::TwoWindingTransformer, val::Real) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
+set_magnetizing_shunt!(value::TwoWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
 """Set [`TwoWindingTransformer`](@ref) `shunt_location`."""
 set_shunt_location!(value::TwoWindingTransformer, val) = value.shunt_location = val
 """Set [`TwoWindingTransformer`](@ref) `services`."""

--- a/src/models/generated/TwoWindingTransformer.jl
+++ b/src/models/generated/TwoWindingTransformer.jl
@@ -88,8 +88,7 @@ get_internal(value::TwoWindingTransformer) = value.internal
 
 """Set [`TwoWindingTransformer`](@ref) `magnetizing_shunt`."""
 set_magnetizing_shunt!(value::TwoWindingTransformer, val) = value.magnetizing_shunt = set_value(value, Val(:magnetizing_shunt), val, Val(:siemens))
-set_magnetizing_shunt!(value::TwoWindingTransformer, val::Real) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
-set_magnetizing_shunt!(value::TwoWindingTransformer, val::NamedTuple{<:Any, <:Tuple{Vararg{Real}}}) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
+set_magnetizing_shunt!(value::TwoWindingTransformer, val::_UntaggedNumber) = _units_tag_required(set_magnetizing_shunt!, value, :magnetizing_shunt, Val(:siemens), val)
 """Set [`TwoWindingTransformer`](@ref) `shunt_location`."""
 set_shunt_location!(value::TwoWindingTransformer, val) = value.shunt_location = val
 """Set [`TwoWindingTransformer`](@ref) `services`."""

--- a/src/units/types.jl
+++ b/src/units/types.jl
@@ -23,6 +23,14 @@ Accepted target-unit argument for unit-aware getters/setters: a Unitful unit
 """
 const UnitArg = Union{Unitful.Units, IS.AbstractUnitSystem}
 
+"""
+A number carrying no units: what a unit-aware setter must reject. Both quantity
+wrappers are `Number`s but neither is a `Real` (nor a `Complex`), so this alias
+selects exactly the untagged values. Convertible fields are `Float64` or
+`Complex{Float64}`, so both are covered.
+"""
+const _UntaggedNumber = Union{Real, Complex{<:Real}}
+
 # One public strip generic for both quantity kinds: Unitful's `ustrip` works on
 # `RelativeQuantity` too (IS deliberately does not define its own `ustrip`).
 Unitful.ustrip(q::IS.RelativeQuantity) = IS._strip_units(q)

--- a/test/test_base_power.jl
+++ b/test/test_base_power.jl
@@ -210,6 +210,27 @@ end
     end
     @test occursin("`val * OHMS`", msg_x)
 
+    # The compound fallback exists only where a NamedTuple is a valid value: a
+    # scalar field must not advertise one, or the error would tell the caller to
+    # tag the elements of a value the field can never hold.
+    minmax_t = NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    updown_t = NamedTuple{(:up, :down), Tuple{Float64, Float64}}
+    # `hasmethod` would be true either way -- the generic `set_X!(value, val)`
+    # takes anything -- so ask which method a NamedTuple actually selects.
+    selected(f, t) = which(f, Tuple{ThermalStandard, t}).sig.parameters[3]
+    @test selected(set_active_power!, minmax_t) === Any
+    @test selected(set_rating!, minmax_t) === Any
+    @test selected(set_active_power_limits!, minmax_t) <: NamedTuple
+    @test selected(set_ramp_limits!, updown_t) <: NamedTuple
+    # ...and it is keyed to that field's own element names.
+    @test selected(set_active_power_limits!, updown_t) === Any
+
+    # A `Complex` field is untagged in the same way a real one is.
+    @test_throws ArgumentError set_magnetizing_shunt!(
+        TwoWindingTransformer(nothing),
+        0.1 + 0.2im,
+    )
+
     # Tagged values still round-trip through every accepted form.
     set_active_power!(gen, 0.6 * DU)
     @test get_active_power(gen, DU) ≈ 0.6

--- a/test/test_base_power.jl
+++ b/test/test_base_power.jl
@@ -242,6 +242,77 @@ end
     @test get_active_power_limits(gen, DU) == (min = 0.0, max = 1.0)
 end
 
+# The error messages name a natural unit per conversion category. That name is only
+# useful if it is a symbol the caller actually has and the accessors actually take,
+# so each case here reads the unit out of the message itself and round-trips it.
+@testset "Suggested natural units are what the accessors accept" begin
+    sys, gen = _sys_with_thermal(; system_base = 100.0, device_base = 250.0)
+    bus1 = get_component(ACBus, sys, "b1")
+    bus2 = ACBus(;
+        number = 2, name = "b2", available = true,
+        bustype = ACBusTypes.PV, angle = 0.0, magnitude = 1.0,
+        voltage_limits = (min = 0.9, max = 1.1), base_voltage = 138.0,
+    )
+    add_component!(sys, bus2)
+    line = Line(;
+        name = "l1", available = true, active_power_flow = 0.0,
+        reactive_power_flow = 0.0, arc = Arc(; from = bus1, to = bus2),
+        r = 0.01, x = 0.1, b = (from = 0.001, to = 0.001),
+        rating = 2.0, angle_limits = (min = -1.0, max = 1.0),
+    )
+    add_component!(sys, line)
+
+    # One field per conversion category: active, reactive and apparent power,
+    # impedance, admittance. Voltage and current have no convertible fields --
+    # `base_voltage` is stored natural and read with a plain one-argument getter --
+    # so no message ever suggests a unit for them.
+    cases = (
+        (:mw, get_active_power, set_active_power!, gen),
+        (:mvar, get_reactive_power, set_reactive_power!, gen),
+        (:mva, get_rating, set_rating!, gen),
+        (:ohm, get_x, set_x!, line),
+        (:siemens, get_b, set_b!, line),
+    )
+    for (token, getter, setter, comp) in cases
+        get_msg = try
+            getter(comp)
+        catch e
+            sprint(showerror, e)
+        end
+        suggested = match(r"the natural unit `([^`]+)`", get_msg)
+        @test suggested !== nothing
+        name = Symbol(suggested.captures[1])
+
+        # The suggestion must be a name the caller has from `using PowerSystems`.
+        @test name in names(PowerSystems)
+        units = getfield(PowerSystems, name)
+
+        # The getter takes exactly what its message suggested...
+        before = getter(comp, units)
+        @test _unwrap_units(before) == before
+
+        # ...and the setter takes `val * <that same unit>`, as its own message says.
+        set_msg = try
+            setter(comp, 1.0)
+        catch e
+            sprint(showerror, e)
+        end
+        @test occursin("`val * $name`", set_msg)
+        setter(comp, before isa NamedTuple ? map(x -> x * units, before) : before * units)
+        @test getter(comp, units) == before
+    end
+
+    # The suggested names are the `u"..."` literals, not separate constants, and a
+    # unit named as a string is not accepted by either form.
+    @test MW === Unitful.@u_str("MW")
+    @test MVAr === Unitful.@u_str("MVAr")
+    @test MVA === Unitful.@u_str("MVA")
+    @test OHMS === Unitful.@u_str("Ω")
+    @test SIEMENS === Unitful.@u_str("S")
+    @test get_active_power(gen, Unitful.@u_str("MW")) == get_active_power(gen, MW)
+    @test_throws MethodError get_active_power(gen, "MW")
+end
+
 # Regression guard for the explicit-units performance contract (PR #1695):
 # the internal per-unit conversions must compile away so that a literal unit
 # argument yields a type-stable, allocation-free `Float64`, and `ustrip` of the

--- a/test/test_base_power.jl
+++ b/test/test_base_power.jl
@@ -122,6 +122,105 @@ end
     @test get_ramp_limits_unitful(gen, NU) === nothing
 end
 
+@testset "Generated getters: omitting the units argument explains what to pass" begin
+    sys, gen = _sys_with_thermal(; system_base = 100.0, device_base = 250.0)
+
+    for f in (get_active_power, get_active_power_unitful, get_rating, get_rating_unitful)
+        @test_throws ArgumentError f(gen)
+    end
+
+    msg = try
+        get_active_power(gen)
+    catch e
+        sprint(showerror, e)
+    end
+    # The message must name the getter, the field, the relative markers and the
+    # field's natural unit; a bare MethodError names none of them.
+    @test occursin("get_active_power", msg)
+    @test occursin("active_power", msg)
+    @test occursin("ThermalStandard", msg)
+    for u in ("`DU`", "`SU`", "`NU`", "`MW`")
+        @test occursin(u, msg)
+    end
+    @test occursin("get_active_power_unitful(component, units)", msg)
+
+    # The `_unitful` companion points back at the bare getter, not at itself.
+    msg_u = try
+        get_active_power_unitful(gen)
+    catch e
+        sprint(showerror, e)
+    end
+    @test occursin("get_active_power(component, units)", msg_u)
+    @test !occursin("_unitful_unitful", msg_u)
+
+    # Impedance fields advertise their own natural unit.
+    msg_x = try
+        get_x(Line(nothing))
+    catch e
+        sprint(showerror, e)
+    end
+    @test occursin("`OHMS`", msg_x)
+end
+
+@testset "Generated setters: untagged values explain what to pass" begin
+    sys, gen = _sys_with_thermal(; system_base = 100.0, device_base = 250.0)
+
+    # A bare float, a bare integer and an all-untagged compound are all rejected.
+    @test_throws ArgumentError set_active_power!(gen, 0.5)
+    @test_throws ArgumentError set_active_power!(gen, 1)
+    @test_throws ArgumentError set_active_power_limits!(gen, (min = 0.0, max = 1.0))
+
+    msg = try
+        set_active_power!(gen, 0.5)
+    catch e
+        sprint(showerror, e)
+    end
+    @test occursin("set_active_power!", msg)
+    @test occursin("active_power", msg)
+    @test occursin("ThermalStandard", msg)
+    for tag in ("`val * DU`", "`val * SU`", "`val * MW`")
+        @test occursin(tag, msg)
+    end
+    # `NU` is a getter target only; there is no `val * NU`.
+    @test !occursin("val * NU", msg)
+
+    # A compound field spells out the per-element form.
+    msg_c = try
+        set_active_power_limits!(gen, (min = 0.0, max = 1.0))
+    catch e
+        sprint(showerror, e)
+    end
+    @test occursin("set_active_power_limits!", msg_c)
+    @test occursin("min = 0.0 * DU", msg_c)
+
+    # A partially tagged compound is caught one level down and still names the field.
+    msg_p = try
+        set_active_power_limits!(gen, (min = 0.0 * DU, max = 1.0))
+    catch e
+        sprint(showerror, e)
+    end
+    @test occursin("active_power_limits", msg_p)
+    @test occursin("`val * DU`", msg_p)
+
+    # Impedance setters advertise their own natural unit.
+    msg_x = try
+        set_x!(Line(nothing), 0.1)
+    catch e
+        sprint(showerror, e)
+    end
+    @test occursin("`val * OHMS`", msg_x)
+
+    # Tagged values still round-trip through every accepted form.
+    set_active_power!(gen, 0.6 * DU)
+    @test get_active_power(gen, DU) ≈ 0.6
+    set_active_power!(gen, 0.3 * SU)
+    @test get_active_power(gen, SU) ≈ 0.3
+    set_active_power!(gen, 60.0 * MW)
+    @test get_active_power(gen, MW) ≈ 60.0
+    set_active_power_limits!(gen, (min = 0.0 * DU, max = 1.0 * DU))
+    @test get_active_power_limits(gen, DU) == (min = 0.0, max = 1.0)
+end
+
 # Regression guard for the explicit-units performance contract (PR #1695):
 # the internal per-unit conversions must compile away so that a literal unit
 # argument yields a type-stable, allocation-free `Float64`, and `ustrip` of the

--- a/test/test_generated_unit_accessors.jl
+++ b/test/test_generated_unit_accessors.jl
@@ -1,0 +1,80 @@
+"""
+Blanket coverage for the generated explicit-units accessors.
+
+Every convertible field emits the same three or four methods from one template, so
+a hand-written test per field would test the template 247 times over. Instead this
+walks the descriptor -- the same source the generator reads -- and exercises each
+generated method on a demo (`T(nothing)`) instance of its own struct. A field the
+descriptor marks convertible but whose accessor was never emitted, or emitted with
+the wrong arity, fails here rather than in whatever downstream code first calls it.
+
+The fallbacks are exercised rather than the working accessors: they need no bases,
+so a detached demo component is enough to reach every one of them.
+"""
+
+const DESCRIPTOR_FIELDS = JSON.parsefile(
+    joinpath(@__DIR__, "..", "src", "descriptors", "power_system_structs.json"),
+)["auto_generated_structs"]
+
+"""Demo instance of a generated struct, or `nothing` when the descriptor gives it no
+null values (`T(nothing)` is only emitted for structs that have them)."""
+function _demo_component(item)
+    name = Symbol(item["struct_name"])
+    isdefined(PowerSystems, name) || return nothing
+    T = getfield(PowerSystems, name)
+    T isa Type || return nothing
+    hasmethod(T, Tuple{Nothing}) || return nothing
+    return try
+        T(nothing)
+    catch
+        nothing
+    end
+end
+
+@testset "Generated accessors: every convertible field reports its missing units" begin
+    checked_structs = 0
+    checked_fields = 0
+    unreachable = String[]
+    for item in DESCRIPTOR_FIELDS
+        convertible = filter(f -> get(f, "needs_conversion", false), item["fields"])
+        isempty(convertible) && continue
+        comp = _demo_component(item)
+        if isnothing(comp)
+            push!(unreachable, item["struct_name"])
+            continue
+        end
+        checked_structs += 1
+        for field in convertible
+            name = field["name"]
+            checked_fields += 1
+            # `exclude_getter`/`exclude_setter` mean the accessor is hand-written
+            # with its own signature; the generator emits no fallback for it.
+            if !get(field, "exclude_getter", false)
+                getter = getfield(PowerSystems, Symbol("get_", name))
+                unitful = getfield(PowerSystems, Symbol("get_", name, "_unitful"))
+                @test_throws ArgumentError getter(comp)
+                @test_throws ArgumentError unitful(comp)
+            end
+            if !get(field, "exclude_setter", false)
+                setter = getfield(PowerSystems, Symbol("set_", name, "!"))
+                @test_throws ArgumentError setter(comp, 1.0)
+            end
+        end
+    end
+    # Every struct carrying convertible fields is reachable through `T(nothing)`,
+    # so the walk covers all of them; the floors catch a renamed descriptor key
+    # silently reducing this file to zero assertions. Both numbers only grow as
+    # convertible fields are added (35 structs / 191 fields at the time of writing).
+    @test isempty(unreachable)
+    @test checked_structs >= 35
+    @test checked_fields >= 191
+
+    # Spot-check that the coverage above is reaching the informative message and
+    # not some unrelated `ArgumentError`.
+    msg = try
+        get_active_power(ThermalStandard(nothing))
+    catch e
+        sprint(showerror, e)
+    end
+    @test occursin("requires an explicit units argument", msg)
+end


### PR DESCRIPTION
## Problem

With explicit units, `get_active_power(gen)` is an error — but the error Julia reports is a bare `MethodError` listing the two-argument signatures, which never says what a valid unit argument *is*. Setters were only slightly better: a bare float hit a generic `"setter requires explicit units"` that named neither the setter nor the field, and a bare **integer** fell through to a `MethodError` entirely.

## What this does

The accessor templates in `src/generate_structs.jl` now emit fallback methods for every convertible field, alongside the working accessors:

- a one-argument getter, and its `_unitful` companion;
- a setter taking an untagged `Real`;
- a setter taking a compound value whose elements are all untagged.

They route to `_units_arg_required` / `_units_tag_required` in `src/models/components.jl`, which name the accessor, the owning type, the field, and the units that would have worked. Both share one set of message builders (`_natural_unit_example`, `_field_description`, `_units_menu`, `_tag_menu`), so the getter and setter messages stay in step and each field advertises its own natural unit (`MW`, `MVAr`, `MVA`, `OHMS`, `SIEMENS`).

```
ArgumentError: `get_active_power` requires an explicit units argument:
`get_active_power(component, units)`. `ThermalStandard`'s `active_power` is a per-unit
quantity with no default unit system, so the units must be named at the call site: `DU`
(per unit on the device base), `SU` (per unit on the system base), `NU` or the natural
unit `MW`. For the unit-bearing value instead of a bare number, use
`get_active_power_unitful(component, units)`.

ArgumentError: `set_active_power_limits!` requires a units-tagged value:
`set_active_power_limits!(component, val * units)`. … A compound field takes one tagged
value per element, e.g. `(min = 0.0 * DU, max = 1.0 * DU)`.
```

The setter menu deliberately omits `NU`: it is a getter target only, and `val * NU` is not even constructible.

Dispatch is safe because `Unitful.Quantity` and `IS.RelativeQuantity` are `Number` but not `Real`, so tagged values still reach the working accessor. `TwoWindingTransformer`'s hand-written `get_r`/`get_x`/`set_r!`/`set_x!` forwarding gained matching arities so they reach the circuit's generated fallback rather than a `MethodError`.

## Two fixes that fell out of it

- `set_value`'s bare-number rejection matched `::Float64`, so `set_active_power!(gen, 1)` produced a raw `MethodError`. It now matches `::Real`, and its message names the field.
- `_to_device_base` discarded the field (`set_value(c, nothing, val, cu)`), so a bare element inside a compound could not report which field it belonged to; the field is now threaded through. No behavior change today — every compound field uses the default base provider — but the SU branch's `_conversion_base(c, field)` now gets the real field, which is the correct value if a compound field ever needs a field-specific one.

## Testing

- Full suite: 14852/14852 pass on this branch.
- New testsets in `test/test_base_power.jl` cover, for getters and setters: the error type, the message naming the accessor/field/type/unit menu/natural unit, the `_unitful` companion pointing back at the bare getter (not `..._unitful_unitful`), bare float, bare integer, all-untagged compound, partially tagged compound (caught one level down, still names the field), and round-trips through every accepted tagged form.
- Docs were **not** built: `julia --project=docs -e 'Pkg.instantiate()'` fails in this checkout with `Did not find subdirectory PowerTimeSeriesOpenAPIModels.jl` while resolving PowerOpenAPIModels, unrelated to this change. No docstrings were added or altered.

## One thing to know before the next regeneration

The generator re-emits three `from_openapi(po, refs)` two-arg methods (TradingHub, VirtualParticipant, PointToPointBid) that are hand-written in `src/openapi/import_handwritten.jl`; leaving them in breaks precompilation with *"Method overwriting is not permitted"*. They had already been deleted from the committed generated files, so I stripped them out again to keep this diff to the units change — but the generator/committed-file divergence is pre-existing and will bite the next person who regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JSuicq3FsLGV29kFyoHpr